### PR TITLE
No check certificate to fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ EXAMPLE := "Example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)Test.$(FILEEXT)"
 
 phpunit.phar:
-	@wget http://phar.phpunit.de/phpunit.phar
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar
 
 # single test
 test-assignment: phpunit.phar


### PR DESCRIPTION
```
--2014-07-12 18:11:06--  http://phar.phpunit.de/phpunit.phar
Resolving phar.phpunit.de (phar.phpunit.de)... 188.94.27.25
Connecting to phar.phpunit.de (phar.phpunit.de)|188.94.27.25|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://phar.phpunit.de/phpunit.phar [following]
--2014-07-12 18:11:06--  https://phar.phpunit.de/phpunit.phar
Connecting to phar.phpunit.de (phar.phpunit.de)|188.94.27.25|:443... connected.
ERROR: no certificate subject alternative name matches
    requested host name `phar.phpunit.de'.
To connect to phar.phpunit.de insecurely, use `--no-check-certificate'.
make[1]: *** [phpunit.phar] Error 5
make: *** [test] Error 1
```
