### PR TITLE
Assert Invalid Trinary *is* 0

### DIFF
--- a/trinary/trinary_test.php
+++ b/trinary/trinary_test.php
@@ -55,6 +55,6 @@ class TrinaryTest extends \PHPUnit_Framework_TestCase
     public function testInvalidTrinaryIsDecimal0()
     {
         $trinary = new Trinary('carrot');
-        $this->assertEquals(0, $trinary->toDecimal());
+        $this->assertSame(0, $trinary->toDecimal());
     }
 }


### PR DESCRIPTION
http://exercism.io/submissions/60932f0152a3aeb60057bc0d

Related to the above nitpicking, I noticed the Trinary test was asserting that invalid trinary was equivalent to 0, not that it was 0.
