### PR TITLE
Hamming: Conform to Definition

### DIFF
--- a/hamming/hamming_test.php
+++ b/hamming/hamming_test.php
@@ -2,7 +2,7 @@
 
 require "hamming.php";
 
-class HammingComparatorTest extends PHPUnit_Framework_TestCase
+class HammingComparatorTest extends \PHPUnit_Framework_TestCase
 {
     public function testNoDifferenceBetweenIdenticalStrands()
     {


### PR DESCRIPTION
Removed test cases that do not conform to definition of hamming distance.

This file now has the same test cases as hamming in xpython

See issue #24
