### PR TITLE
Hamming: Conform to Definition

### DIFF
--- a/hamming/hamming_test.php
+++ b/hamming/hamming_test.php
@@ -29,16 +29,6 @@ class HammingComparatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, HammingComparator::distance('GGACG', 'GGTCG'));
     }
 
-    public function testIgnoresExtraLengthOnFirstStrandWhenLonger()
-    {
-        $this->assertEquals(1, HammingComparator::distance('AGAGACTTA', 'AAA'));
-    }
-
-    public function testIgnoresExtraLengthOnOtherStrandWhenLonger()
-    {
-        $this->assertEquals(2, HammingComparator::distance('AGG', 'AAAACTGACCCACCCCAGG'));
-    }
-
     public function testLargeHammingDistance()
     {
         $this->assertEquals(4, HammingComparator::distance('GATACA', 'GCATAA'));


### PR DESCRIPTION
Removed test cases that do not conform to definition of hamming distance.

This file now has the same test cases as hamming in xpython

See issue #24
