### PR TITLE
Gigasecond: Converted to Function, Handled No Default Timezone

### DIFF
--- a/gigasecond/example.php
+++ b/gigasecond/example.php
@@ -1,11 +1,7 @@
 <?php
 
-class Gigasecond
+function from(\DateTime $from)
 {
-    public static function from(\DateTime $from)
-    {
-        $interval = new DateInterval("PT1000000000S");
-
-        return $from->add($interval);
-    }
+    $interval = new DateInterval("PT1000000000S");
+    return $from->add($interval);
 }

--- a/gigasecond/gigasecond_test.php
+++ b/gigasecond/gigasecond_test.php
@@ -4,23 +4,34 @@ require "gigasecond.php";
 
 class GigasecondTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function date_setup($date)
+    {
+        $UTC = new DateTimeZone("UTC");
+        $date = new DateTime($date, $UTC);
+        return $date;
+    }
+
     public function test1()
     {
-        $gs = Gigasecond::from(new DateTime("2011-04-25"));
+        $date = GigasecondTest::date_setup("2011-04-25");
+        $gs = from($date);
 
         $this->assertSame($gs->format("Y-m-d"), "2043-01-01");
     }
 
     public function test2()
     {
-        $gs = GigaSecond::from(new DateTime("1977-06-13"));
+        $date = GigasecondTest::date_setup("1977-06-13");
+        $gs = from($date);
 
         $this->assertSame($gs->format("Y-m-d"), "2009-02-19");
     }
 
     public function test3()
     {
-        $gs = Gigasecond::from(new DateTime("1959-7-19"));
+        $date = GigasecondTest::date_setup("1959-7-19");
+        $gs = from($date);
 
         $this->assertSame($gs->format("Y-m-d"), "1991-03-27");
     }
@@ -28,10 +39,8 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
     public function testYourself()
     {
         $this->markTestSkipped();
-
-        $your_birthday = new DateTime("your_birthday");
-
-        $gs = Gigasecond::from(new DateTime($your_birthday));
+        $your_birthday = GigasecondTest::date_setup("your_birthday");
+        $gs = from($your_birthday);
 
         $this->assertSame($gs->format("Y-m-d"), "2009-01-31");
     }


### PR DESCRIPTION
With the old test cases an error would be thrown if the user didn't have a default timezone set in their php.ini file. I wrote a setup for the test cases that creates dates with the UTC timezone. This change allows the test cases to run regardless of if a php.ini file is set.
