### PR TITLE
Generate missing exercise READMEs

### DIFF
--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -1,0 +1,48 @@
+# Collatz Conjecture
+
+The Collatz Conjecture or 3x+1 problem can be summarized as follows:
+
+Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is
+odd, multiply n by 3 and add 1 to get 3n + 1. Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will
+always reach 1 eventually.
+
+Given a number n, return the number of steps required to reach 1.
+
+## Examples
+
+Starting with n = 12, the steps would be as follows:
+
+0. 12
+1. 6
+2. 3
+3. 10
+4. 5
+5. 16
+6. 8
+7. 4
+8. 2
+9. 1
+
+Resulting in 9 steps. So for input n = 12, the return value would be 9.
+
+## Making the Test Suite Pass
+
+1. Get [PHPUnit].
+
+        % wget --no-check-certificate https://phar.phpunit.de/phpunit.phar
+        % chmod +x phpunit.phar
+
+2. Execute the tests for an assignment.
+
+        % phpunit.phar wordy/wordy_test.php
+
+[PHPUnit]: http://phpunit.de
+
+
+## Source
+
+An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,0 +1,91 @@
+# Crypto Square
+
+Implement the classic method for composing secret messages called a square code.
+
+Given an English text, output the encoded version of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
+from the English text and the message is downcased.
+
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
+
+For example, the sentence
+
+> If man was meant to stay on the ground, god would have given us roots.
+
+is normalized to:
+
+> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
+
+```text
+ifmanwas
+meanttos
+tayonthe
+groundgo
+dwouldha
+vegivenu
+sroots
+```
+
+The coded message is obtained by reading down the columns going left to
+right.
+
+The message above is coded as:
+
+```text
+imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+```
+
+Output the encoded text in chunks.  Phrases that fill perfect rectangles
+`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
+Phrases that do not fill perfect rectangles will have `n` empty spaces.
+Those spaces should be distributed evenly, added to the end of the last
+`n` chunks.
+
+```text
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
+```
+
+Notice that were we to stack these, we could visually decode the
+cyphertext back in to the original message:
+
+```text
+imtgdvs
+fearwer
+mayoogo
+anouuio
+ntnnlvt
+wttddes
+aohghn
+sseoau
+```
+
+## Making the Test Suite Pass
+
+1. Get [PHPUnit].
+
+        % wget --no-check-certificate https://phar.phpunit.de/phpunit.phar
+        % chmod +x phpunit.phar
+
+2. Execute the tests for an assignment.
+
+        % phpunit.phar wordy/wordy_test.php
+
+[PHPUnit]: http://phpunit.de
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -1,0 +1,32 @@
+# Flatten Array
+
+Take a nested list and return a single flattened list with all values except nil/null.
+
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+
+For Example
+
+input: [1,[2,3,null,4],[null],5]
+
+output: [1,2,3,4,5]
+
+## Making the Test Suite Pass
+
+1. Get [PHPUnit].
+
+        % wget --no-check-certificate https://phar.phpunit.de/phpunit.phar
+        % chmod +x phpunit.phar
+
+2. Execute the tests for an assignment.
+
+        % phpunit.phar wordy/wordy_test.php
+
+[PHPUnit]: http://phpunit.de
+
+
+## Source
+
+Interview Question [https://reference.wolfram.com/language/ref/Flatten.html](https://reference.wolfram.com/language/ref/Flatten.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -1,0 +1,80 @@
+# Transpose
+
+Given an input text output it transposed.
+
+Roughly explained, the transpose of a matrix:
+
+```text
+ABC
+DEF
+```
+
+is given by:
+
+```text
+AD
+BE
+CF
+```
+
+Rows become columns and columns become rows. See <https://en.wikipedia.org/wiki/Transpose>.
+
+If the input has rows of different lengths, this is to be solved as follows:
+
+- Pad to the left with spaces.
+- Don't pad to the right.
+
+Therefore, transposing this matrix:
+
+```text
+ABC
+DE
+```
+
+results in:
+
+```text
+AD
+BE
+C
+```
+
+And transposing:
+
+```text
+AB
+DEF
+```
+
+results in:
+
+```text
+AD
+BE
+ F
+```
+
+In general, all characters from the input should also be present in the transposed output.
+That means that if a column in the input text contains only spaces on its bottom-most row(s),
+the corresponding output row should contain the spaces in its right-most column(s).
+
+## Making the Test Suite Pass
+
+1. Get [PHPUnit].
+
+        % wget --no-check-certificate https://phar.phpunit.de/phpunit.phar
+        % chmod +x phpunit.phar
+
+2. Execute the tests for an assignment.
+
+        % phpunit.phar wordy/wordy_test.php
+
+[PHPUnit]: http://phpunit.de
+
+
+## Source
+
+Reddit r/dailyprogrammer challenge #270 [Easy]. [https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text](https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
The following exercises were missing READMEs:

- collatz-conjecture
- crypto-square
- flatten-array
- transpose

In preparation for [v2](https://github.com/exercism/v2-feedback/blob/master/README.md) we're updating Configlet—our Exercism track linter—to require that we generate the exercise README. This is because in v2 we will not be generating READMEs on the fly, but deliver the README as defined in the directory for each implementation.

I'm going to go ahead and merge this as soon as the build passes, as this is janitorial work rather than a language-specific change.

See https://github.com/exercism/configlet/issues/116 for more details.