### PR TITLE
Upgrade PHP version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: php
 php:
-- 7.0
+- 7.1
 script:
 - make install
 - make style-check

--- a/exercises/meetup/example.php
+++ b/exercises/meetup/example.php
@@ -1,7 +1,5 @@
 <?php
 
-use DateTime;
-
 function meetup_day($year, $month, $which, $weekday)
 {
     $monthName = (DateTime::createFromFormat("!m", $month))->format('F');

--- a/exercises/meetup/meetup_test.php
+++ b/exercises/meetup/meetup_test.php
@@ -2,8 +2,6 @@
 
 require "meetup.php";
 
-use DateTime;
-
 class MeetupTest extends PHPUnit\Framework\TestCase
 {
     public function testMonteenthOfMay2013()

--- a/exercises/series/example.php
+++ b/exercises/series/example.php
@@ -1,7 +1,5 @@
 <?php
 
-use Exception;
-
 function slices($series, $size)
 {
     if ($size > strlen($series) || $size < 1) {

--- a/exercises/series/series_test.php
+++ b/exercises/series/series_test.php
@@ -1,6 +1,5 @@
 <?php
 require "series.php";
-use Exception;
 
 class SieveTest extends PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
The build on Travis is failing because the phptest.phar that gets downloaded is incompatible with the version of PHP that we've specified in the `.travis.yml` file.

```
PHPUnit 7.0.0 by Sebastian Bergmann and contributors.
This version of PHPUnit is supported on PHP 7.1 and PHP 7.2.
You are using PHP 7.0.25 (/home/travis/.phpenv/versions/7.0.25/bin/php).
make[1]: *** [test-assignment] Error 1
```