### PR TITLE
 adding "whitout unit coins" tests

### DIFF
--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -55,4 +55,23 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         $this->expectException('InvalidArgumentException', 'Cannot make change for negative value');
         findFewestCoins(array(1, 2, 5), -5);
     }
+  
+    # bonus point if it pass these tests
+    public function testPossibleChangeWithoutUnitCoinsAvailable()
+    {
+        $this->markTestSkipped();
+        $this->assertEquals(
+            array(2, 2, 2, 5, 10),
+            findFewestCoins(array(2, 5, 10, 20, 50), 21)
+        );
+    }
+
+    public function testAnotherPossibleChangeWithoutUnitCoinsAvailable()
+    {
+        $this->markTestSkipped();
+        $this->assertEquals(
+            array(4, 4, 4, 5, 5, 5),
+            findFewestCoins(array(4, 5), 27)
+        );
+    }
 }

--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -36,27 +36,6 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testForChangeSmallerThanAvailableCoins()
-    {
-        $this->markTestSkipped();
-        $this->expectException('InvalidArgumentException', 'No coins small enough to make change');
-        findFewestCoins(array(5, 10), 3);
-    }
-
-    public function testNoCoinsForZero()
-    {
-        $this->markTestSkipped();
-        $this->assertEquals(array(), findFewestCoins(array(1, 2, 5), 0));
-    }
-
-    public function testChangeValueLessThanZero()
-    {
-        $this->markTestSkipped();
-        $this->expectException('InvalidArgumentException', 'Cannot make change for negative value');
-        findFewestCoins(array(1, 2, 5), -5);
-    }
-  
-    # bonus point if it pass these tests
     public function testPossibleChangeWithoutUnitCoinsAvailable()
     {
         $this->markTestSkipped();
@@ -73,5 +52,33 @@ class ChangeTest extends PHPUnit\Framework\TestCase
             array(4, 4, 4, 5, 5, 5),
             findFewestCoins(array(4, 5), 27)
         );
+    }
+
+    public function testNoCoinsForZero()
+    {
+        $this->markTestSkipped();
+        $this->assertEquals(array(), findFewestCoins(array(1, 5, 10, 21, 25), 0));
+    }
+
+    public function testForChangeSmallerThanAvailableCoins()
+    {
+        $this->markTestSkipped();
+        $this->expectException('InvalidArgumentException', 'No coins small enough to make change');
+        findFewestCoins(array(5, 10), 3);
+    }
+
+    public function testErrorIfNoCombinationCanAddUpToTarget()
+    {
+        $this->markTestSkipped();
+        $this->expectException('InvalidArgumentException', 'No combination can add up to target');
+        findFewestCoins(array(5, 10), 94);
+
+    }
+
+    public function testChangeValueLessThanZero()
+    {
+        $this->markTestSkipped();
+        $this->expectException('InvalidArgumentException', 'Cannot make change for negative value');
+        findFewestCoins(array(1, 2, 5), -5);
     }
 }

--- a/exercises/change/example.php
+++ b/exercises/change/example.php
@@ -1,44 +1,53 @@
 <?php
 
-function findFewestCoins($coins, $targetValue)
+// adapted from the python example
+function findFewestCoins(array $coins, int $total_change): array
 {
-    if ($targetValue == 0) {
-        return array(); // no coins
+    // Some checks
+    if ($total_change == 0) {
+        return []; # no coins
     }
-    if ($targetValue < 0) {
-        throw new InvalidArgumentException('Cannot make change for negative value');
+    if ($total_change < 0) {
+        throw new InvalidArgumentException("Cannot find negative change values");
     }
-    if (min($coins) > $targetValue) {
+    if (min($coins) > $total_change) {
         throw new InvalidArgumentException('No coins small enough to make change');
     }
 
-    $minCoins = [];
+    // init values
+    $min_coins_required = array_fill(0, $total_change + 1, INF);
+    $last_coin = array_fill(0, $total_change + 1, 0);
 
-    // populate the minCoins array with the minimum number of coins
-    // needed to make each step, from 0 up to our target value
-    foreach (range(0, $targetValue) as $step) {
-        // if the step is one of our coins, then just use that coin
-        if (in_array($step, $coins)) {
-            $minCoins[$step] = array($step);
-        } else {
-            foreach ($coins as $coin) {
-                // ignore if the coin value is bigger than our step.
-                if ($coin > $step) {
-                    continue;
-                }
+    $min_coins_required[0] = 0;
+    $last_coin[0] = -1;
 
-                // lookup the minimum number of coins to make the step, minus the value of the current coin
-                $lastCoins = $minCoins[$step - $coin];
-
-                // if there is no minCoins currently set for this step, or if the number of coins
-                // is greater than the number of coins it takes to make the last step, plus one new coin...
-                if (!isset($minCoins[$step]) || count($minCoins[$step]) > 1 + count($lastCoins)) {
-                    // set to the current coin, with the coins needed to make the last step
-                    $minCoins[$step] = array_merge(array($coin), $lastCoins);
+    foreach (range(1, $total_change) as $change) {
+        $final_result = $min_coins_required[$change];
+        foreach ($coins as $coin) {
+            if ($coin <= $change) {
+                $result = $min_coins_required[$change - $coin] + 1;
+                if ($result < $final_result) {
+                    $final_result = $result;
+                    $last_coin[$change] = $change - $coin;
                 }
             }
         }
+        $min_coins_required[$change] = $final_result;
     }
 
-    return $minCoins[$targetValue];
+    // no combination found
+    if ($min_coins_required[$total_change] == INF) {
+        throw new InvalidArgumentException("No combination can add up to target");
+    }
+
+    // init values
+    $last_coin_value = $total_change;
+    $array = [];
+    // if conbination found then build the coins array
+    while ($last_coin[$last_coin_value] != -1) {
+        array_push($array, $last_coin_value - $last_coin[$last_coin_value]);
+        $last_coin_value = $last_coin[$last_coin_value];
+    }
+
+    return $array;
 }


### PR DESCRIPTION
I came to this issue trying to resolve the python version of this exercise. My litteral translation to python of my php implementation was not able to pass these.

For the record, the only php solution i found that can pass these additionnal test is the DiscoParadise's one :
https://exercism.io/tracks/php/exercises/change/solutions/bb24e48efb4847c1be51543bc4742336