### PR TITLE
Specify phpunit v7 in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
 default:
-	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
@@ -22,18 +22,18 @@ help: ## Prints this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## install development dependencies
-	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 
 	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 install-test: ## install test dependency: phpunit.phar 
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 
 install-style: ## install style checker dependency: phpcs.phar
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpcs.phar
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 test-assignment: bin/phpunit.phar ## run single test using ASSIGNMENTS: test-assignment ASSIGNMENT=wordy


### PR DESCRIPTION
The latest phpunit (v8) has breaking changes that require us to update some test files. It also drops support for PHP 7.1