### PR TITLE
fix PHPUnit8 compatibility issues (#230)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .DS_Store
 tmp
 *.phar
+.phpunit.result.cache
 bin/configlet
 bin/configlet.exe

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -77,7 +77,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ], $allergies->getList());
     }
 
-    public function testIsAllergicToEgssAndShellfish()
+    public function testIsAllergicToEggsAndShellfish()
     {
         $allergies = new Allergies(5);
 

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -58,40 +58,40 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
     {
         $allergies = new Allergies(248);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::CATS),
             new Allergen(Allergen::CHOCOLATE),
             new Allergen(Allergen::POLLEN),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIsAllergicToEggsAndPeanuts()
     {
         $allergies = new Allergies(3);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::PEANUTS),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIsAllergicToEgssAndShellfish()
     {
         $allergies = new Allergies(5);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::SHELLFISH),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIgnoreNonAllergenScorePart()
     {
         $allergies = new Allergies(509);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::CATS),
             new Allergen(Allergen::CHOCOLATE),
             new Allergen(Allergen::EGGS),
@@ -99,7 +99,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
             new Allergen(Allergen::SHELLFISH),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     /**

--- a/exercises/bob/bob_test.php
+++ b/exercises/bob/bob_test.php
@@ -9,7 +9,7 @@ class BobTest extends PHPUnit\Framework\TestCase
      */
     private $bob;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->bob = new Bob;
     }

--- a/exercises/bowling/bowling_test.php
+++ b/exercises/bowling/bowling_test.php
@@ -11,7 +11,7 @@ class GameTest extends PHPUnit\Framework\TestCase
     /** @var Game */
     private $game;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->game = new Game();
     }

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -7,7 +7,7 @@ class GradeSchoolTest extends TestCase
 {
     protected $school ;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->school = new School() ;
     }
@@ -31,13 +31,9 @@ class GradeSchoolTest extends TestCase
 
         $students = $this->school->grade(2) ;
         $this->assertCount(3, $students);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             ['Claire', 'Marc', 'Virginie'],
-            $students,
-            $message = '',
-            $delta = 0.0,
-            $maxDepth = 10,
-            $canonicalize = true
+            $students
         );
     }
 

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -5,11 +5,11 @@ use PHPUnit\Framework\TestCase;
 
 class GradeSchoolTest extends TestCase
 {
-    protected $school ;
+    protected $school;
 
     protected function setUp(): void
     {
-        $this->school = new School() ;
+        $this->school = new School();
     }
 
     public function testNoStudent()
@@ -29,7 +29,7 @@ class GradeSchoolTest extends TestCase
         $this->school->add("Virginie", 2);
         $this->school->add("Claire", 2);
 
-        $students = $this->school->grade(2) ;
+        $students = $this->school->grade(2);
         $this->assertCount(3, $students);
         $this->assertEqualsCanonicalizing(
             ['Claire', 'Marc', 'Virginie'],
@@ -64,7 +64,7 @@ class GradeSchoolTest extends TestCase
             4 => ['Mehdi'],
             5 => ['Claire', 'Marc', 'Virginie']
         ];
-        $schoolStudents = $this->school->studentsByGradeAlphabetical() ;
-        $this->assertEquals($sortedStudents, $schoolStudents) ;
+        $schoolStudents = $this->school->studentsByGradeAlphabetical();
+        $this->assertEquals($sortedStudents, $schoolStudents);
     }
 }

--- a/exercises/robot-name/robot-name_test.php
+++ b/exercises/robot-name/robot-name_test.php
@@ -7,7 +7,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
     /** @var Robot $robot */
     protected $robot = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->robot = new Robot();
     }
@@ -45,7 +45,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
 
         $this->assertRegExp('/\w{2}\d{3}/', $name2);
     }
-  
+
     public function testNameArentRecycled()
     {
         $names = [];


### PR DESCRIPTION
PHPUnit 8 needs void return types for setUp, tearDown, etc. but only setUp is used in the exercises.

There is one small compatibility problem left for PHPUnit 8 that I don't know how to fix, but I guess that's fine for now:
When executing /php/exercises/grade-school/grade-school_test.php you get this warning:
```
PHPUnit 8.0.4 by Sebastian Bergmann and contributors.

..W...                                                              6 / 6 (100%)

Time: 167 ms, Memory: 10.00MB

There was 1 warning:

1) GradeSchoolTest::testAddStudentsinSameGrade
The optional $canonicalize parameter of assertEquals() is deprecated and will be removed in PHPUnit 9. Refactor your test to use assertEqualsCanonicalizing() instead.

WARNINGS!
Tests: 6, Assertions: 10, Warnings: 1.
[Finished in 0.3s]
```

Refactoring to assertEqualsCanonicalizing() is not possible because in PHPUnit7 that method doesn't exist.