### PR TITLE
Replace usage of deprecated phpunit expected exception tag

### DIFF
--- a/exercises/grains/grains_test.php
+++ b/exercises/grains/grains_test.php
@@ -51,9 +51,6 @@ class GrainsTest extends PHPUnit\Framework\TestCase
         $this->assertSame('9223372036854775808', square(64));
     }
 
-    /**
-     *
-     */
     public function testRejectsZero()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -61,9 +58,6 @@ class GrainsTest extends PHPUnit\Framework\TestCase
         square(0);
     }
 
-    /**
-     *
-     */
     public function testRejectsNegative()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -71,9 +65,6 @@ class GrainsTest extends PHPUnit\Framework\TestCase
         square(-1);
     }
 
-    /**
-     *
-     */
     public function testRejectsGreaterThan64()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/grains/grains_test.php
+++ b/exercises/grains/grains_test.php
@@ -52,26 +52,32 @@ class GrainsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsZero()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         square(0);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsNegative()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         square(-1);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsGreaterThan64()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         square(65);
     }
 

--- a/exercises/largest-series-product/largest-series-product_test.php
+++ b/exercises/largest-series-product/largest-series-product_test.php
@@ -83,9 +83,6 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(0, $series->largestProduct(3));
     }
 
-    /**
-     *
-     */
     public function testRejectsSpanLongerThanStringLength()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -125,9 +122,6 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(1, $series->largestProduct(0));
     }
 
-    /**
-     *
-     */
     public function testRejectsEmptyStringAndNonzeroSpan()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -136,9 +130,6 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $series->largestProduct(1);
     }
 
-    /**
-     *
-     */
     public function testRejectsInvalidCharacterInDigits()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -147,9 +138,6 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $series->largestProduct(2);
     }
 
-    /**
-     *
-     */
     public function testRejectsNegativeSpan()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/largest-series-product/largest-series-product_test.php
+++ b/exercises/largest-series-product/largest-series-product_test.php
@@ -84,10 +84,12 @@ class SeriesTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsSpanLongerThanStringLength()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series(123);
         $series->largestProduct(4);
     }
@@ -124,28 +126,34 @@ class SeriesTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsEmptyStringAndNonzeroSpan()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series("");
         $series->largestProduct(1);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsInvalidCharacterInDigits()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series("1234a5");
         $series->largestProduct(2);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testRejectsNegativeSpan()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series("12345");
         $series->largestProduct(-1);
     }

--- a/exercises/ocr-numbers/ocr-numbers_test.php
+++ b/exercises/ocr-numbers/ocr-numbers_test.php
@@ -47,10 +47,11 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * Input with a number of lines that is not a multiple of four raises an error
-     * @expectedException InvalidArgumentException
      */
     public function testErrorWrongNumberOfLines()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $input = [
             " _ ",
             "| |",
@@ -61,10 +62,11 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * Input with a number of columns that is not a multiple of three raises an error
-     * @expectedException InvalidArgumentException
      */
     public function testErrorWrongNumberOfColumns()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $input = [
             "    ",
             "   |",

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -17,18 +17,22 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testInvalidWithLettersInPlaceOfNumbers()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('123-abc-1234');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testInvalidWhen9Digits()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('123456789');
     }
 
@@ -45,26 +49,32 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testInvalidWhen11Digits()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('21234567890');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testInvalidWhen12DigitsAndFirstIs1()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('112345678901');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testInvalidWhen10DigitsWithExtraLetters()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
     }
 

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -16,9 +16,6 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('4561237890', $number->number());
     }
 
-    /**
-     *
-     */
     public function testInvalidWithLettersInPlaceOfNumbers()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -26,9 +23,6 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $number = new PhoneNumber('123-abc-1234');
     }
 
-    /**
-     *
-     */
     public function testInvalidWhen9Digits()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -48,9 +42,6 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('1234567890', $number->number());
     }
 
-    /**
-     *
-     */
     public function testInvalidWhen11Digits()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -58,9 +49,6 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $number = new PhoneNumber('21234567890');
     }
 
-    /**
-     *
-     */
     public function testInvalidWhen12DigitsAndFirstIs1()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -68,9 +56,6 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $number = new PhoneNumber('112345678901');
     }
 
-    /**
-     *
-     */
     public function testInvalidWhen10DigitsWithExtraLetters()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/queen-attack/queen-attack_test.php
+++ b/exercises/queen-attack/queen-attack_test.php
@@ -14,45 +14,45 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
 
     /**
      * Test the queen is placed on a positive rank.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The rank and file numbers must be positive.
      */
     public function testQueenHasPositiveRank()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The rank and file numbers must be positive.');
+
         placeQueen(-2, 2);
     }
 
     /**
      * Test the queen has a rank on the board.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The position must be on a standard size chess board.
      */
     public function testQueenHasRankOnBoard()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The position must be on a standard size chess board.');
+
         placeQueen(8, 4);
     }
 
     /**
      * Test the queen is placed on a positive file.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The rank and file numbers must be positive.
      */
     public function testQueenHasPositiveFile()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The rank and file numbers must be positive.');
+
         placeQueen(2, -2);
     }
 
     /**
      * Test the queen has a file on the board.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The position must be on a standard size chess board.
      */
     public function testQueenHasFileOnBoard()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The position must be on a standard size chess board.');
+
         placeQueen(4, 8);
     }
 

--- a/exercises/robot-simulator/robot-simulator_test.php
+++ b/exercises/robot-simulator/robot-simulator_test.php
@@ -137,10 +137,6 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
     }
 
-
-    /**
-     *
-     */
     public function testMalformedInstructions()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/robot-simulator/robot-simulator_test.php
+++ b/exercises/robot-simulator/robot-simulator_test.php
@@ -139,10 +139,12 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
 
     /**
-     * @expectedException InvalidArgumentException
+     *
      */
     public function testMalformedInstructions()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
         $robot->instructions('LARX');
     }

--- a/exercises/triangle/triangle_test.php
+++ b/exercises/triangle/triangle_test.php
@@ -92,9 +92,6 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     *
-     */
     public function testTrianglesWithNoSizeAreIllegal()
     {
         $this->expectException(\Exception::class);
@@ -102,9 +99,6 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         (new Triangle(0, 0, 0))->kind();
     }
 
-    /**
-     *
-     */
     public function testTrianglesViolatingTriangleInequalityAreIllegal()
     {
         $this->expectException(\Exception::class);
@@ -112,9 +106,6 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         (new Triangle(1, 1, 3))->kind();
     }
 
-    /**
-     *
-     */
     public function testTrianglesViolatingTriangleInequalityAreIllegal2()
     {
         $this->expectException(\Exception::class);
@@ -122,9 +113,6 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         (new Triangle(7, 3, 2))->kind();
     }
 
-    /**
-     *
-     */
     public function testTrianglesViolatingTriangleInequalityAreIllegal3()
     {
         $this->expectException(\Exception::class);

--- a/exercises/triangle/triangle_test.php
+++ b/exercises/triangle/triangle_test.php
@@ -93,34 +93,42 @@ class TriangleTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Exception
+     *
      */
     public function testTrianglesWithNoSizeAreIllegal()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(0, 0, 0))->kind();
     }
 
     /**
-     * @expectedException \Exception
+     *
      */
     public function testTrianglesViolatingTriangleInequalityAreIllegal()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(1, 1, 3))->kind();
     }
 
     /**
-     * @expectedException \Exception
+     *
      */
     public function testTrianglesViolatingTriangleInequalityAreIllegal2()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(7, 3, 2))->kind();
     }
 
     /**
-     * @expectedException \Exception
+     *
      */
     public function testTrianglesViolatingTriangleInequalityAreIllegal3()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(1, 3, 1))->kind();
     }
 }


### PR DESCRIPTION
This closes #232.

While doing this I noticed usage of `expectException` like this:

`$this->expectException('InvalidArgumentException', 'Only positive numbers are allowed');`

Personally, I think it'd be better to use `InvalidArgumentException::class`, but more importantly this doesn't actually test the exception message; PHPUnit just ignores the second parameter, checking only the exceptions *type*.

To achieve the desired behaviour, `expectExceptionMessage` should be used. 

I'll open up a new issue for this :)