### PR TITLE
Replace usage of deprecated `$delta` parameter of `assertEquals()` with `assertEqualsWithDelta()` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .DS_Store
 tmp
 *.phar
+.phpunit.result.cache
 bin/configlet
 bin/configlet.exe

--- a/config.json
+++ b/config.json
@@ -648,7 +648,7 @@
     },
     {
       "slug": "palindrome-products",
-      "uuid": "abd68340-91b9-48c1-8567-79822bb2165c",
+      "uuid": "3201ddeb-9046-4801-a31a-28c292686e1e",
       "core": false,
       "unlocked_by": null,
       "difficulty": 6,
@@ -672,7 +672,7 @@
     },
     {
       "slug": "affine-cipher",
-      "uuid": "d1267415-aff5-411d-b267-49a4a2c8fda2",
+      "uuid": "4ef04018-7745-47ac-8b01-2d3d27055f4e",
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,
@@ -684,7 +684,7 @@
     },
     {
       "slug": "diamond",
-      "uuid": "a7bc6837-59e4-46a1-89a2-a5aa44f5e66e",
+      "uuid": "64a8f560-0991-4897-812e-7c57a2617fde",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     {
       "slug": "hello-world",
       "uuid": "56116aa6-e3d1-4122-a394-a7e0f6ab6fea",
-      "core": false,
+      "core": true,
       "auto_approve": true,
       "unlocked_by": null,
       "difficulty": 1,
@@ -18,7 +18,7 @@
     {
       "slug": "hamming",
       "uuid": "48de430b-0d88-4af0-ab48-d00b840312bb",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -29,7 +29,7 @@
     {
       "slug": "gigasecond",
       "uuid": "81aa4bc9-4936-46c2-bb2f-433246a86c5d",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -39,7 +39,7 @@
     {
       "slug": "bob",
       "uuid": "ae91650f-fe06-466a-a40a-6a24f5926fbe",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -48,14 +48,111 @@
       ]
     },
     {
+      "slug": "rna-transcription",
+      "uuid": "81d96250-f2e4-4228-a8e9-254b6b8784ac",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "luhn",
+      "uuid": "1b034dc9-be9a-4434-bc78-57742f63107e",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": []
+    },
+    {
+      "slug": "isogram",
+      "uuid": "435f0ec1-f53c-4fe4-b92b-43a582c2fa82",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "robot-name",
+      "uuid": "b24d5f98-8d62-4177-b0ae-306bbf0f918b",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "classes",
+        "randomness",
+        "strings"
+      ]
+    },
+    {
+      "slug": "difference-of-squares",
+      "uuid": "238d86fe-6e29-43b0-9e27-a54caa773618",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "integers",
+        "math"
+      ]
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "2d2974e2-2d5e-41d9-8dc3-951967631b37",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": [
+        "arrays"
+      ]
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "cc6c3b27-b719-454c-a743-7bc73bd47cf1",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "oop"
+      ]
+    },
+    {
       "slug": "run-length-encoding",
       "uuid": "0a453685-55c2-47e2-88b2-e26d1d8fbde9",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
-      "difficulty": 1,
+      "difficulty": 5,
       "topics": [
         "algorithms",
         "strings",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "largest-series-product",
+      "uuid": "4fbeb249-dc1d-4282-8455-d1c06a7cb420",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 5,
+      "topics": [
+        "integers",
+        "math",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "0ad53d66-cbdc-4d9a-a083-d24af216d3d9",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "filtering",
         "text_formatting"
       ]
     },
@@ -67,63 +164,6 @@
       "difficulty": 4,
       "topics": [
         "strings"
-      ]
-    },
-    {
-      "slug": "rna-transcription",
-      "uuid": "81d96250-f2e4-4228-a8e9-254b6b8784ac",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "raindrops",
-      "uuid": "0ad53d66-cbdc-4d9a-a083-d24af216d3d9",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 6,
-      "topics": [
-        "filtering",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "isogram",
-      "uuid": "435f0ec1-f53c-4fe4-b92b-43a582c2fa82",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "filtering",
-        "strings"
-      ]
-    },
-    {
-      "slug": "difference-of-squares",
-      "uuid": "238d86fe-6e29-43b0-9e27-a54caa773618",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "integers",
-        "math"
-      ]
-    },
-    {
-      "slug": "largest-series-product",
-      "uuid": "4fbeb249-dc1d-4282-8455-d1c06a7cb420",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 5,
-      "topics": [
-        "integers",
-        "math",
-        "strings",
-        "transforming"
       ]
     },
     {
@@ -157,18 +197,6 @@
       "topics": [
         "strings",
         "transforming"
-      ]
-    },
-    {
-      "slug": "robot-name",
-      "uuid": "b24d5f98-8d62-4177-b0ae-306bbf0f918b",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "classes",
-        "randomness",
-        "strings"
       ]
     },
     {
@@ -444,16 +472,6 @@
       ]
     },
     {
-      "slug": "robot-simulator",
-      "uuid": "cc6c3b27-b719-454c-a743-7bc73bd47cf1",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "oop"
-      ]
-    },
-    {
       "slug": "ocr-numbers",
       "uuid": "a7a269a5-e99c-4fcf-b331-9a130e94f9e4",
       "core": false,
@@ -496,24 +514,6 @@
         "integers",
         "strings"
       ]
-    },
-    {
-      "slug": "grade-school",
-      "uuid": "2d2974e2-2d5e-41d9-8dc3-951967631b37",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 6,
-      "topics": [
-        "arrays"
-      ]
-    },
-    {
-      "slug": "luhn",
-      "uuid": "1b034dc9-be9a-4434-bc78-57742f63107e",
-      "core": false,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": []
     },
     {
       "slug": "perfect-numbers",

--- a/config.json
+++ b/config.json
@@ -693,6 +693,16 @@
         "loops",
         "strings"
       ]
+    },
+    {
+      "slug": "two-fer",
+      "uuid": "fae78f5f-316b-44b7-aade-f61b3be990a7",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "strings"
+      ]
     }
   ]
 }

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -58,40 +58,40 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
     {
         $allergies = new Allergies(248);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::CATS),
             new Allergen(Allergen::CHOCOLATE),
             new Allergen(Allergen::POLLEN),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIsAllergicToEggsAndPeanuts()
     {
         $allergies = new Allergies(3);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::PEANUTS),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
-    public function testIsAllergicToEgssAndShellfish()
+    public function testIsAllergicToEggsAndShellfish()
     {
         $allergies = new Allergies(5);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::SHELLFISH),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIgnoreNonAllergenScorePart()
     {
         $allergies = new Allergies(509);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::CATS),
             new Allergen(Allergen::CHOCOLATE),
             new Allergen(Allergen::EGGS),
@@ -99,7 +99,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
             new Allergen(Allergen::SHELLFISH),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     /**

--- a/exercises/bob/bob_test.php
+++ b/exercises/bob/bob_test.php
@@ -9,7 +9,7 @@ class BobTest extends PHPUnit\Framework\TestCase
      */
     private $bob;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->bob = new Bob;
     }

--- a/exercises/bowling/bowling_test.php
+++ b/exercises/bowling/bowling_test.php
@@ -11,7 +11,7 @@ class GameTest extends PHPUnit\Framework\TestCase
     /** @var Game */
     private $game;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->game = new Game();
     }

--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -55,20 +55,25 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     public function testForChangeSmallerThanAvailableCoins()
     {
-        $this->expectException('InvalidArgumentException', 'No coins small enough to make change');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No coins small enough to make change');
+
         findFewestCoins(array(5, 10), 3);
     }
 
     public function testErrorIfNoCombinationCanAddUpToTarget()
     {
-        $this->expectException('InvalidArgumentException', 'No combination can add up to target');
-        findFewestCoins(array(5, 10), 94);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No combination can add up to target');
 
+        findFewestCoins(array(5, 10), 94);
     }
 
     public function testChangeValueLessThanZero()
     {
-        $this->expectException('InvalidArgumentException', 'Cannot make change for negative value');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot make change for negative value');
+
         findFewestCoins(array(1, 2, 5), -5);
     }
 }

--- a/exercises/change/example.php
+++ b/exercises/change/example.php
@@ -8,7 +8,7 @@ function findFewestCoins(array $coins, int $total_change): array
         return []; # no coins
     }
     if ($total_change < 0) {
-        throw new InvalidArgumentException("Cannot find negative change values");
+        throw new InvalidArgumentException("Cannot make change for negative value");
     }
     if (min($coins) > $total_change) {
         throw new InvalidArgumentException('No coins small enough to make change');

--- a/exercises/collatz-conjecture/collatz-conjecture_test.php
+++ b/exercises/collatz-conjecture/collatz-conjecture_test.php
@@ -27,13 +27,17 @@ class CollatzConjecture extends PHPUnit\Framework\TestCase
 
     public function testZeroIsAnError()
     {
-        $this->expectException('InvalidArgumentException', 'Only positive numbers are allowed');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only positive numbers are allowed');
+
         steps(0);
     }
 
     public function testNegativeValueIsAnError()
     {
-        $this->expectException('InvalidArgumentException', 'Only positive numbers are allowed');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only positive numbers are allowed');
+
         steps(-1);
     }
 }

--- a/exercises/grade-school/example.php
+++ b/exercises/grade-school/example.php
@@ -2,34 +2,26 @@
 
 class School
 {
-    private $database = array() ;
+    private $students = [];
 
-    public function numberOfStudents()
+    public function add($name, $grade)
     {
-        return (count($this->database, COUNT_RECURSIVE) - count($this->database)) ;
-    }
-
-    public function add($student, $grade)
-    {
-        $this->database[$grade][] = $student ;
+        $this->students[$grade][] = $name;
     }
 
     public function grade($grade)
     {
-        return (array_key_exists($grade, $this->database) ? $this->database[$grade] : array()) ;
+        return (array_key_exists($grade, $this->students) ? $this->students[$grade] : []);
     }
 
     public function studentsByGradeAlphabetical()
     {
-        $tmp = $this->database ;
-        ksort($tmp) ;
+        ksort($this->students);
 
-        foreach ($tmp as $grade => $students) {
-            asort($students) ;
-            foreach ($students as $student) {
-                $res [ $grade ][] = $student ;
-            }
-        }
-        return $res ;
+        return array_map(function ($grade) {
+            sort($grade);
+
+            return $grade;
+        }, $this->students);
     }
 }

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -60,6 +60,7 @@ class GradeSchoolTest extends TestCase
             5 => ['Claire', 'Marc', 'Virginie']
         ];
         $schoolStudents = $this->school->studentsByGradeAlphabetical();
-        $this->assertEquals($sortedStudents, $schoolStudents);
+
+        $this->assertTrue($sortedStudents === $schoolStudents);
     }
 }

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -5,11 +5,11 @@ use PHPUnit\Framework\TestCase;
 
 class GradeSchoolTest extends TestCase
 {
-    protected $school ;
+    protected $school;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->school = new School() ;
+        $this->school = new School();
     }
 
     public function testNoStudent()
@@ -29,15 +29,11 @@ class GradeSchoolTest extends TestCase
         $this->school->add("Virginie", 2);
         $this->school->add("Claire", 2);
 
-        $students = $this->school->grade(2) ;
+        $students = $this->school->grade(2);
         $this->assertCount(3, $students);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             ['Claire', 'Marc', 'Virginie'],
-            $students,
-            $message = '',
-            $delta = 0.0,
-            $maxDepth = 10,
-            $canonicalize = true
+            $students
         );
     }
 
@@ -68,7 +64,7 @@ class GradeSchoolTest extends TestCase
             4 => ['Mehdi'],
             5 => ['Claire', 'Marc', 'Virginie']
         ];
-        $schoolStudents = $this->school->studentsByGradeAlphabetical() ;
-        $this->assertEquals($sortedStudents, $schoolStudents) ;
+        $schoolStudents = $this->school->studentsByGradeAlphabetical();
+        $this->assertEquals($sortedStudents, $schoolStudents);
     }
 }

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -12,11 +12,6 @@ class GradeSchoolTest extends TestCase
         $this->school = new School();
     }
 
-    public function testNoStudent()
-    {
-        $this->assertEquals(0, $this->school->numberOfStudents());
-    }
-
     public function testAddStudent()
     {
         $this->school->add("Claire", 2);

--- a/exercises/grains/grains_test.php
+++ b/exercises/grains/grains_test.php
@@ -51,27 +51,24 @@ class GrainsTest extends PHPUnit\Framework\TestCase
         $this->assertSame('9223372036854775808', square(64));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsZero()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         square(0);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsNegative()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         square(-1);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsGreaterThan64()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         square(65);
     }
 

--- a/exercises/hamming/hamming.php
+++ b/exercises/hamming/hamming.php
@@ -1,11 +1,13 @@
 <?php
 
-//
-// This is only a SKELETON file for the "Hamming" exercise. It's been provided as a
-// convenience to get you started writing code faster.
-//
+/*
+This is only a SKELETON file for the "Hamming" exercise. It's been provided as a
+convenience to get you started writing code faster.
 
-function distance($a, $b)
+Remove this comment before submitting your exercise.
+*/
+
+function distance(string $strandA, string $strandB): int
 {
     //
     // YOUR CODE GOES HERE

--- a/exercises/largest-series-product/largest-series-product_test.php
+++ b/exercises/largest-series-product/largest-series-product_test.php
@@ -83,11 +83,10 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(0, $series->largestProduct(3));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsSpanLongerThanStringLength()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series(123);
         $series->largestProduct(4);
     }
@@ -123,29 +122,26 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(1, $series->largestProduct(0));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsEmptyStringAndNonzeroSpan()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series("");
         $series->largestProduct(1);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsInvalidCharacterInDigits()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series("1234a5");
         $series->largestProduct(2);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsNegativeSpan()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $series = new Series("12345");
         $series->largestProduct(-1);
     }

--- a/exercises/ocr-numbers/ocr-numbers_test.php
+++ b/exercises/ocr-numbers/ocr-numbers_test.php
@@ -47,10 +47,11 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * Input with a number of lines that is not a multiple of four raises an error
-     * @expectedException InvalidArgumentException
      */
     public function testErrorWrongNumberOfLines()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $input = [
             " _ ",
             "| |",
@@ -61,10 +62,11 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * Input with a number of columns that is not a multiple of three raises an error
-     * @expectedException InvalidArgumentException
      */
     public function testErrorWrongNumberOfColumns()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $input = [
             "    ",
             "   |",

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -6,7 +6,8 @@ The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
-insensitive. Input will not contain non-ASCII symbols.
+insensitive. Input may contain non-ASCII symbols, but it is only necessary to 
+check whether each letter in the English alphabet is present.
 
 
 ## Running the tests

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -16,19 +16,17 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('4561237890', $number->number());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWithLettersInPlaceOfNumbers()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('123-abc-1234');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWhen9Digits()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('123456789');
     }
 
@@ -44,27 +42,24 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('1234567890', $number->number());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWhen11Digits()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('21234567890');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWhen12DigitsAndFirstIs1()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('112345678901');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWhen10DigitsWithExtraLetters()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $number = new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
     }
 

--- a/exercises/queen-attack/queen-attack_test.php
+++ b/exercises/queen-attack/queen-attack_test.php
@@ -14,45 +14,45 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
 
     /**
      * Test the queen is placed on a positive rank.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The rank and file numbers must be positive.
      */
     public function testQueenHasPositiveRank()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The rank and file numbers must be positive.');
+
         placeQueen(-2, 2);
     }
 
     /**
      * Test the queen has a rank on the board.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The position must be on a standard size chess board.
      */
     public function testQueenHasRankOnBoard()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The position must be on a standard size chess board.');
+
         placeQueen(8, 4);
     }
 
     /**
      * Test the queen is placed on a positive file.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The rank and file numbers must be positive.
      */
     public function testQueenHasPositiveFile()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The rank and file numbers must be positive.');
+
         placeQueen(2, -2);
     }
 
     /**
      * Test the queen has a file on the board.
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The position must be on a standard size chess board.
      */
     public function testQueenHasFileOnBoard()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The position must be on a standard size chess board.');
+
         placeQueen(4, 8);
     }
 

--- a/exercises/robot-name/robot-name_test.php
+++ b/exercises/robot-name/robot-name_test.php
@@ -7,7 +7,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
     /** @var Robot $robot */
     protected $robot = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->robot = new Robot();
     }
@@ -45,7 +45,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
 
         $this->assertRegExp('/\w{2}\d{3}/', $name2);
     }
-  
+
     public function testNameArentRecycled()
     {
         $names = [];

--- a/exercises/robot-simulator/robot-simulator_test.php
+++ b/exercises/robot-simulator/robot-simulator_test.php
@@ -137,12 +137,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
     }
 
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMalformedInstructions()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
         $robot->instructions('LARX');
     }

--- a/exercises/space-age/space-age_test.php
+++ b/exercises/space-age/space-age_test.php
@@ -15,48 +15,48 @@ class SpaceAgeTester extends PHPUnit\Framework\TestCase
     public function testAgeOnEarth()
     {
         $age = new SpaceAge(1000000000);
-        $this->assertEquals(31.69, $age->earth(), '', self::DELTA);
+        $this->assertEqualsWithDelta(31.69, $age->earth(), self::DELTA);
     }
 
     public function testAgeOnMercury()
     {
         $age = new SpaceAge(2134835688);
-        $this->assertEquals(280.88, $age->mercury(), '', self::DELTA);
+        $this->assertEqualsWithDelta(280.88, $age->mercury(), self::DELTA);
     }
 
     public function testAgeOnVenus()
     {
         $age = new SpaceAge(189839836);
-        $this->assertEquals(9.78, $age->venus(), '', self::DELTA);
+        $this->assertEqualsWithDelta(9.78, $age->venus(), self::DELTA);
     }
 
     public function testAgeOnMars()
     {
         $age = new SpaceAge(2329871239);
-        $this->assertEquals(39.25, $age->mars(), '', self::DELTA);
+        $this->assertEqualsWithDelta(39.25, $age->mars(), self::DELTA);
     }
 
     public function testAgeOnJupiter()
     {
         $age = new SpaceAge(901876382);
-        $this->assertEquals(2.41, $age->jupiter(), '', self::DELTA);
+        $this->assertEqualsWithDelta(2.41, $age->jupiter(), self::DELTA);
     }
 
     public function testAgeOnSaturn()
     {
         $age = new SpaceAge(3000000000);
-        $this->assertEquals(3.23, $age->saturn(), '', self::DELTA);
+        $this->assertEqualsWithDelta(3.23, $age->saturn(), self::DELTA);
     }
 
     public function testAgeOnUranus()
     {
         $age = new SpaceAge(3210123456);
-        $this->assertEquals(1.21, $age->uranus(), '', self::DELTA);
+        $this->assertEqualsWithDelta(1.21, $age->uranus(), self::DELTA);
     }
 
     public function testAgeOnNeptune()
     {
         $age = new SpaceAge(8210123456);
-        $this->assertEquals(1.58, $age->neptune(), '', self::DELTA);
+        $this->assertEqualsWithDelta(1.58, $age->neptune(), self::DELTA);
     }
 }

--- a/exercises/triangle/triangle_test.php
+++ b/exercises/triangle/triangle_test.php
@@ -92,35 +92,31 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testTrianglesWithNoSizeAreIllegal()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(0, 0, 0))->kind();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testTrianglesViolatingTriangleInequalityAreIllegal()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(1, 1, 3))->kind();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testTrianglesViolatingTriangleInequalityAreIllegal2()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(7, 3, 2))->kind();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testTrianglesViolatingTriangleInequalityAreIllegal3()
     {
+        $this->expectException(\Exception::class);
+
         (new Triangle(1, 3, 1))->kind();
     }
 }

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -1,0 +1,52 @@
+# Two Fer
+
+`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+
+Given a name, return a string with the message:
+
+```text
+One for X, one for me.
+```
+
+Where X is the given name.
+
+However, if the name is missing, return the string:
+
+```text
+One for you, one for me.
+```
+
+Here are some examples:
+
+|Name    | String to return
+|:------:|:-----------------:
+|Alice   | One for Alice, one for me.
+|Bob     | One for Bob, one for me.
+|        | One for you, one for me.
+|Zaphod  | One for Zaphod, one for me.
+
+## Running the tests
+
+1. Go to the root of your PHP exercise directory, which is `<EXERCISM_WORKSPACE>/php`.
+   To find the Exercism workspace run
+
+        % exercism debug | grep Workspace
+
+1. Get [PHPUnit] if you don't have it already.
+
+        % wget --no-check-certificate https://phar.phpunit.de/phpunit.phar
+        % chmod +x phpunit.phar
+
+2. Execute the tests:
+
+        % ./phpunit.phar two-fer/two-fer_test.php
+
+[PHPUnit]: http://phpunit.de
+
+
+## Source
+
+[https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-fer/example.php
+++ b/exercises/two-fer/example.php
@@ -1,0 +1,6 @@
+<?php
+
+function twoFer(string $name = 'you'): string
+{
+    return "One for $name, one for me.";
+}

--- a/exercises/two-fer/two-fer_test.php
+++ b/exercises/two-fer/two-fer_test.php
@@ -1,0 +1,21 @@
+<?php
+
+require "two-fer.php";
+
+class TwoFerTest extends PHPUnit\Framework\TestCase
+{
+    public function testNoNameGiven()
+    {
+        $this->assertEquals('One for you, one for me.', twoFer());
+    }
+
+    public function testANameGiven()
+    {
+        $this->assertEquals('One for Alice, one for me.', twoFer('Alice'));
+    }
+
+    public function testAnotherNameGiven()
+    {
+        $this->assertEquals('One for Bob, one for me.', twoFer('Bob'));
+    }
+}


### PR DESCRIPTION
This closes #233 

`allergies` also has the delta parameter, but doesn't seem to actually *use* it? Either way, `PHPUnit` doesn't give deprecation warnings - I've not however done that exercise (I'm doing it right now), so I'll update this PR if it does start warning me :)