### PR TITLE
Replace usage of deprecated $canonicalize phpunit parameter

### DIFF
--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -7,6 +7,8 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider provideListOfAllergen
+     *
+     * @param Allergen $allergen
      */
     public function testNoAllergiesMeansNotAllergicToAnything($allergen)
     {
@@ -17,6 +19,8 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider provideListOfAllergen
+     *
+     * @param Allergen $allergicTo
      */
     public function testAllergiesToOneAllergen($allergicTo)
     {
@@ -26,7 +30,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         $otherAllergen = array_filter(Allergen::allergenList(), function ($allergen) use ($allergicTo) {
             return $allergen != $allergicTo;
         });
-        $self = $this;
+        $self          = $this;
         array_map(function ($allergen) use ($allergies, $self) {
             $self->assertFalse($allergies->isAllergicTo($allergen));
         }, $otherAllergen);
@@ -77,7 +81,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ], $allergies->getList());
     }
 
-    public function testIsAllergicToEgssAndShellfish()
+    public function testIsAllergicToEggsAndShellfish()
     {
         $allergies = new Allergies(5);
 

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -58,40 +58,40 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
     {
         $allergies = new Allergies(248);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::CATS),
             new Allergen(Allergen::CHOCOLATE),
             new Allergen(Allergen::POLLEN),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIsAllergicToEggsAndPeanuts()
     {
         $allergies = new Allergies(3);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::PEANUTS),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIsAllergicToEgssAndShellfish()
     {
         $allergies = new Allergies(5);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::SHELLFISH),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     public function testIgnoreNonAllergenScorePart()
     {
         $allergies = new Allergies(509);
 
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::CATS),
             new Allergen(Allergen::CHOCOLATE),
             new Allergen(Allergen::EGGS),
@@ -99,7 +99,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
             new Allergen(Allergen::SHELLFISH),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList(), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+        ], $allergies->getList());
     }
 
     /**

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -30,9 +30,9 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         $otherAllergen = array_filter(Allergen::allergenList(), function ($allergen) use ($allergicTo) {
             return $allergen != $allergicTo;
         });
-        $self          = $this;
-        array_map(function ($allergen) use ($allergies, $self) {
-            $self->assertFalse($allergies->isAllergicTo($allergen));
+
+        array_map(function ($allergen) use ($allergies) {
+            $this->assertFalse($allergies->isAllergicTo($allergen));
         }, $otherAllergen);
     }
 

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -31,13 +31,9 @@ class GradeSchoolTest extends TestCase
 
         $students = $this->school->grade(2) ;
         $this->assertCount(3, $students);
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             ['Claire', 'Marc', 'Virginie'],
-            $students,
-            $message = '',
-            $delta = 0.0,
-            $maxDepth = 10,
-            $canonicalize = true
+            $students
         );
     }
 

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -23,7 +23,7 @@ class GradeSchoolTest extends TestCase
         $this->assertContains('Claire', $this->school->grade(2));
     }
 
-    public function testAddStudentsinSameGrade()
+    public function testAddStudentsInSameGrade()
     {
         $this->school->add("Marc", 2);
         $this->school->add("Virginie", 2);

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -29,12 +29,16 @@ nucleotides are different from their equivalent in the other string.
 
 The Hamming distance between these two DNA strands is 7.
 
-# Implementation notes
+## Implementation notes
 
 The Hamming distance is only defined for sequences of equal length. This means
 that based on the definition, each language could deal with getting sequences
 of equal length differently.
 
+## Restrictions
+
+Don't solve this with the `gmp_hamdist` function!
+Solve this one yourself using other basic tools instead.
 
 ## Running the tests
 


### PR DESCRIPTION
More deprecated things.

In other news, I found the [PHPUnit issue on github](https://github.com/sebastianbergmann/phpunit/issues/3341) 😃 