### PR TITLE
Add "number of students" test to grade-school

### DIFF
--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -57,6 +57,17 @@ class GradeSchoolTest extends TestCase
         $this->assertEmpty($this->school->grade(1));
     }
 
+    public function testNumberOfStudents()
+    {
+        $this->school->add("Marc", 1);
+        $this->school->add("Virginie", 2);
+        $this->school->add("Claire", 3);
+        $this->school->add("Mehdi", 3);
+        $this->school->add("Jane", 3);
+
+        $this->assertEquals(5, $this->school->numberOfStudents());
+    }
+
     public function testSortSchool()
     {
         $this->school->add("Marc", 5);


### PR DESCRIPTION
Adds a missing test for the `numberOfStudents()` method which was called from the existing tests, but only to check whether there are no students listed before any are added. The new test adds five students to different grades and then checks the method returns `5`.

This requirement should possibly also be added to the README as currently it's only discoverable through the tests. Alternatively the existing test `testNoStudent()` could be removed to remove this requirement.



