### PR TITLE
Correct mention of non-ASCII symbols in Pangram

### DIFF
--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -6,7 +6,8 @@ The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
-insensitive. Input will not contain non-ASCII symbols.
+insensitive. Input may contain non-ASCII symbols, but it is only necessary to 
+check whether each letter in the English alphabet is present.
 
 
 ## Running the tests


### PR DESCRIPTION
The README for the Pangram problem states that the input will not contain non-ASCII symbols, however the test `testPangramWithNonAsciiCharacters()` does, as the name suggests, include non-ASCII characters. This updates the README to be consistent with the tests.