### PR TITLE
Remove testNoStudents() and clean up Grade School example

### DIFF
--- a/exercises/grade-school/example.php
+++ b/exercises/grade-school/example.php
@@ -2,29 +2,26 @@
 
 class School
 {
-    private $database = array() ;
+    private $students = [];
 
-    public function add($student, $grade)
+    public function add($name, $grade)
     {
-        $this->database[$grade][] = $student ;
+        $this->students[$grade][] = $name;
     }
 
     public function grade($grade)
     {
-        return (array_key_exists($grade, $this->database) ? $this->database[$grade] : array()) ;
+        return (array_key_exists($grade, $this->students) ? $this->students[$grade] : []);
     }
 
     public function studentsByGradeAlphabetical()
     {
-        $tmp = $this->database ;
-        ksort($tmp) ;
+        ksort($this->students);
 
-        foreach ($tmp as $grade => $students) {
-            asort($students) ;
-            foreach ($students as $student) {
-                $res [ $grade ][] = $student ;
-            }
-        }
-        return $res ;
+        return array_map(function ($grade) {
+            sort($grade);
+
+            return $grade;
+        }, $this->students);
     }
 }

--- a/exercises/grade-school/example.php
+++ b/exercises/grade-school/example.php
@@ -4,11 +4,6 @@ class School
 {
     private $database = array() ;
 
-    public function numberOfStudents()
-    {
-        return (count($this->database, COUNT_RECURSIVE) - count($this->database)) ;
-    }
-
     public function add($student, $grade)
     {
         $this->database[$grade][] = $student ;

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -12,11 +12,6 @@ class GradeSchoolTest extends TestCase
         $this->school = new School();
     }
 
-    public function testNoStudent()
-    {
-        $this->assertEquals(0, $this->school->numberOfStudents());
-    }
-
     public function testAddStudent()
     {
         $this->school->add("Claire", 2);


### PR DESCRIPTION
This PR removes the testNoStudents() method from Grade School. Additionally, the second commit cleans up the Grade School example, which had some weird formatting (spaces before semi-colons and around array accessors) and makes the sorting method clearer.

Let me know if this PR would be preferred without the example change, I just thought I'd do it while making the test change.