### PR TITLE
Replace usage of deprecated $delta phpunit parameter

### DIFF
--- a/exercises/space-age/space-age_test.php
+++ b/exercises/space-age/space-age_test.php
@@ -15,48 +15,48 @@ class SpaceAgeTester extends PHPUnit\Framework\TestCase
     public function testAgeOnEarth()
     {
         $age = new SpaceAge(1000000000);
-        $this->assertEquals(31.69, $age->earth(), '', self::DELTA);
+        $this->assertEqualsWithDelta(31.69, $age->earth(), self::DELTA);
     }
 
     public function testAgeOnMercury()
     {
         $age = new SpaceAge(2134835688);
-        $this->assertEquals(280.88, $age->mercury(), '', self::DELTA);
+        $this->assertEqualsWithDelta(280.88, $age->mercury(), self::DELTA);
     }
 
     public function testAgeOnVenus()
     {
         $age = new SpaceAge(189839836);
-        $this->assertEquals(9.78, $age->venus(), '', self::DELTA);
+        $this->assertEqualsWithDelta(9.78, $age->venus(), self::DELTA);
     }
 
     public function testAgeOnMars()
     {
         $age = new SpaceAge(2329871239);
-        $this->assertEquals(39.25, $age->mars(), '', self::DELTA);
+        $this->assertEqualsWithDelta(39.25, $age->mars(), self::DELTA);
     }
 
     public function testAgeOnJupiter()
     {
         $age = new SpaceAge(901876382);
-        $this->assertEquals(2.41, $age->jupiter(), '', self::DELTA);
+        $this->assertEqualsWithDelta(2.41, $age->jupiter(), self::DELTA);
     }
 
     public function testAgeOnSaturn()
     {
         $age = new SpaceAge(3000000000);
-        $this->assertEquals(3.23, $age->saturn(), '', self::DELTA);
+        $this->assertEqualsWithDelta(3.23, $age->saturn(), self::DELTA);
     }
 
     public function testAgeOnUranus()
     {
         $age = new SpaceAge(3210123456);
-        $this->assertEquals(1.21, $age->uranus(), '', self::DELTA);
+        $this->assertEqualsWithDelta(1.21, $age->uranus(), self::DELTA);
     }
 
     public function testAgeOnNeptune()
     {
         $age = new SpaceAge(8210123456);
-        $this->assertEquals(1.58, $age->neptune(), '', self::DELTA);
+        $this->assertEqualsWithDelta(1.58, $age->neptune(), self::DELTA);
     }
 }


### PR DESCRIPTION
This closes #233 

`allergies` also has the delta parameter, but doesn't seem to actually *use* it? Either way, `PHPUnit` doesn't give deprecation warnings - I've not however done that exercise (I'm doing it right now), so I'll update this PR if it does start warning me :)

----

I managed to mess up the rebase, causing #237 to be closed 😖 