### PR TITLE
Add test to stop non-numerics passing when casting is used

### DIFF
--- a/exercises/luhn/luhn_test.php
+++ b/exercises/luhn/luhn_test.php
@@ -68,4 +68,9 @@ class LuhnValidatorTest extends PHPUnit\Framework\TestCase
     {
         $this->assertTrue(isValid("091"));
     }
+
+    public function testThatStringContainingSymbolsWhichCouldBeZeroIsInvalid()
+    {
+        $this->assertFalse(isValid(" ABCDEF"));
+    }
 }


### PR DESCRIPTION
Several solutions have come across that pass only because they
cast each individual character to an integer. This commit adds
a test for an input that is matches the five zeros input, except
the characters are non-numeric. This should be invalid, but
solutions that cast character to int will allow this one which is
not correct.