### PR TITLE
Pangram: Test for missing letter but 26 characters

### DIFF
--- a/exercises/pangram/pangram_test.php
+++ b/exercises/pangram/pangram_test.php
@@ -48,4 +48,9 @@ class PangramTest extends PHPUnit\Framework\TestCase
     {
         $this->assertTrue(isPangram('Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.'));
     }
+  
+    public function testMissingLetterReplacedWithUpperCaseCharacter()
+    {
+        $this->assertFalse(isPangram("Tthe quick brown fo jumps over the lazy dog"));
+    }
 }


### PR DESCRIPTION
I have found solutions to this exercise, that return `true` for the string `Tthe quick brown fo jumps over the lazy dog` ("x" is missing). One example for this would be the following code:
```php
<?php
function isPangram($str) {
	preg_match_all("/[A-z]/", $str, $matches);

	return count(array_unique($matches[0])) >= 26;
}
```
My proposed fix will add a test for this case.