### PR TITLE
Use the new PSR12 standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,22 @@ FILEEXT := "php"
 EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
+PHPCSVERSION := "3.4.2"
+
 default:
 	wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
-	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
+	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/$(PHPCSVERSION)/phpcs.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 help: ## Prints this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $, $}'
 
 install: ## install development dependencies
 	wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 
-	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
+	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/$(PHPCSVERSION)/phpcs.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 install-test: ## install test dependency: phpunit.phar 

--- a/exercises/accumulate/accumulate_test.php
+++ b/exercises/accumulate/accumulate_test.php
@@ -59,7 +59,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
             $expected,
             accumulate($chars, function ($char) use ($digits) {
                 return accumulate($digits, function ($digit) use ($char) {
-                    return $char.$digit;
+                    return $char . $digit;
                 });
             })
         );

--- a/exercises/acronym/example.php
+++ b/exercises/acronym/example.php
@@ -15,6 +15,6 @@ function acronym($phrase)
     }
 
     return array_reduce($words[0], function ($acronym, $word) {
-        return $acronym.mb_strtoupper(mb_substr($word, 0, 1));
+        return $acronym . mb_strtoupper(mb_substr($word, 0, 1));
     });
 }

--- a/phpcs-php.xml
+++ b/phpcs-php.xml
@@ -2,8 +2,8 @@
 <ruleset name="xPHP">
   <description>Coding standard for xPHP</description>
 
-  <!-- Include all sniffs in the PSR2 standard except... -->
-  <rule ref="PSR2">
+  <!-- Include all sniffs in the PSR12 standard except... -->
+  <rule ref="PSR12">
     <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
     <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses"/>
     <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>


### PR DESCRIPTION
> PSR-2 was accepted in 2012 and since then a number of changes have been made to PHP which has implications for coding style guidelines. Whilst PSR-2 is very comprehensive of PHP functionality that existed at the time of writing, new functionality is very open to interpretation. This PSR, therefore, seeks to clarify the content of PSR-2 in a more modern context with new functionality available, and make the errata to PSR-2 binding.