### PR TITLE
Convert traditional array syntax to short

### DIFF
--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -6,51 +6,51 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 {
     public function testSingleCoinChange()
     {
-        $this->assertEquals(array(25), findFewestCoins(array(1, 5, 10, 25, 100), 25));
+        $this->assertEquals([25], findFewestCoins([1, 5, 10, 25, 100], 25));
     }
 
     public function testChange()
     {
-        $this->assertEquals(array(5, 10), findFewestCoins(array(1, 5, 10, 25, 100), 15));
+        $this->assertEquals([5, 10], findFewestCoins([1, 5, 10, 25, 100], 15));
     }
 
     public function testChangeWithLilliputianCoins()
     {
-        $this->assertEquals(array(4, 4, 15), findFewestCoins(array(1, 4, 15, 20, 50), 23));
+        $this->assertEquals([4, 4, 15], findFewestCoins([1, 4, 15, 20, 50], 23));
     }
 
     public function testChangeWithLowerElboniaCoins()
     {
-        $this->assertEquals(array(21, 21, 21), findFewestCoins(array(1, 5, 10, 21, 25), 63));
+        $this->assertEquals([21, 21, 21], findFewestCoins([1, 5, 10, 21, 25], 63));
     }
 
     public function testWithLargeTargetValue()
     {
         $this->assertEquals(
-            array(2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100),
-            findFewestCoins(array(1, 2, 5, 10, 20, 50, 100), 999)
+            [2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100],
+            findFewestCoins([1, 2, 5, 10, 20, 50, 100], 999)
         );
     }
 
     public function testPossibleChangeWithoutUnitCoinsAvailable()
     {
         $this->assertEquals(
-            array(2, 2, 2, 5, 10),
-            findFewestCoins(array(2, 5, 10, 20, 50), 21)
+            [2, 2, 2, 5, 10],
+            findFewestCoins([2, 5, 10, 20, 50], 21)
         );
     }
 
     public function testAnotherPossibleChangeWithoutUnitCoinsAvailable()
     {
         $this->assertEquals(
-            array(4, 4, 4, 5, 5, 5),
-            findFewestCoins(array(4, 5), 27)
+            [4, 4, 4, 5, 5, 5],
+            findFewestCoins([4, 5], 27)
         );
     }
 
     public function testNoCoinsForZero()
     {
-        $this->assertEquals(array(), findFewestCoins(array(1, 5, 10, 21, 25), 0));
+        $this->assertEquals([], findFewestCoins([1, 5, 10, 21, 25], 0));
     }
 
     public function testForChangeSmallerThanAvailableCoins()
@@ -58,7 +58,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No coins small enough to make change');
 
-        findFewestCoins(array(5, 10), 3);
+        findFewestCoins([5, 10], 3);
     }
 
     public function testErrorIfNoCombinationCanAddUpToTarget()
@@ -66,7 +66,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No combination can add up to target');
 
-        findFewestCoins(array(5, 10), 94);
+        findFewestCoins([5, 10], 94);
     }
 
     public function testChangeValueLessThanZero()
@@ -74,6 +74,6 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot make change for negative value');
 
-        findFewestCoins(array(1, 2, 5), -5);
+        findFewestCoins([1, 2, 5], -5);
     }
 }

--- a/exercises/connect/connect_test.php
+++ b/exercises/connect/connect_test.php
@@ -16,13 +16,13 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     public function testEmptyBoardHasNoWinner()
     {
-        $lines = array(
+        $lines = [
             ". . . . .",
             " . . . . .",
             "  . . . . .",
             "   . . . . .",
             "    . . . . ."
-        );
+        ];
         $this->assertEquals(null, resultFor($this->makeBoard($lines)));
     }
 
@@ -31,7 +31,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testOneByOneBoardBlack()
     {
-        $lines = array("X");
+        $lines = ["X"];
         $this->assertEquals("black", resultFor($this->makeBoard($lines)));
     }
 
@@ -40,7 +40,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testOneByOneBoardWhite()
     {
-        $lines = array("O");
+        $lines = ["O"];
         $this->assertEquals("white", resultFor($this->makeBoard($lines)));
     }
 
@@ -50,13 +50,13 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testConvultedPath()
     {
-        $lines = array(
+        $lines = [
             ". X X . .",
             " X . X . X",
             "  . X . X .",
             "   . X X . .",
             "    O O O O O"
-        );
+        ];
         $this->assertEquals("black", resultFor($this->makeBoard($lines)));
     }
 
@@ -65,13 +65,13 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testRectangleWhiteWins()
     {
-        $lines = array(
+        $lines = [
             ". O . .",
             " O X X X",
             "  O O O .",
             "   X X O X",
             "    . O X ."
-        );
+        ];
         $this->assertEquals("white", resultFor($this->makeBoard($lines)));
     }
 
@@ -80,13 +80,13 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testRectangleBlackWins()
     {
-        $lines = array(
+        $lines = [
             ". O . .",
             " O X X X",
             "  O X O .",
             "   X X O X",
             "    . O X ."
-        );
+        ];
         $this->assertEquals("black", resultFor($this->makeBoard($lines)));
     }
 
@@ -96,7 +96,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testSpiralBlackWins()
     {
-        $lines = array(
+        $lines = [
             "OXXXXXXXX",
             "OXOOOOOOO",
             "OXOXXXXXO",
@@ -106,7 +106,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
             "OXXXXXOXO",
             "OOOOOOOXO",
             "XXXXXXXXO"
-        );
+        ];
         $this->assertEquals("black", resultFor($this->makeBoard($lines)));
     }
 
@@ -116,7 +116,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testSpiralNobodyWins()
     {
-        $lines = array(
+        $lines = [
             "OXXXXXXXX",
             "OXOOOOOOO",
             "OXOXXXXXO",
@@ -126,7 +126,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
             "OXXXXXOXO",
             "OOOOOOOXO",
             "XXXXXXXXO"
-        );
+        ];
         $this->assertEquals(null, resultFor($this->makeBoard($lines)));
     }
 
@@ -136,13 +136,13 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      */
     public function testIllegalDiagonalNobodyWins()
     {
-        $lines = array(
+        $lines = [
             "X O . .",
             " O X X X",
             "  O X O .",
             "   . O X .",
             "    X X O O"
-        );
+        ];
 
         $this->assertEquals(null, resultFor($this->makeBoard($lines)));
     }

--- a/exercises/connect/example.php
+++ b/exercises/connect/example.php
@@ -25,7 +25,7 @@ class Board
         $this->width = strlen($lines[0]);
 
         $this->fields = array_map(function ($line) {
-            $row = array();
+            $row = [];
             for ($i = 0; $i < strlen($line); $i++) {
                 switch ($line[$i]) {
                     case "O":
@@ -54,14 +54,14 @@ class Board
 
     public function neighbours($c)
     {
-        $coords = array(
-            array($c[0] + 1, $c[1]),
-            array($c[0] - 1, $c[1]),
-            array($c[0],   $c[1] + 1),
-            array($c[0],   $c[1] - 1),
-            array($c[0] - 1, $c[1] + 1),
-            array($c[0] + 1, $c[1] - 1)
-        );
+        $coords = [
+            [$c[0] + 1, $c[1]],
+            [$c[0] - 1, $c[1]],
+            [$c[0],   $c[1] + 1],
+            [$c[0],   $c[1] - 1],
+            [$c[0] - 1, $c[1] + 1],
+            [$c[0] + 1, $c[1] - 1]
+        ];
         $validCoord = function ($c) {
             return $c[0] >= 0 && $c[0] < $this->width && $c[1] >= 0 && $c[1] < $this->height;
         };
@@ -79,18 +79,18 @@ class Board
 
     public function whiteStartCoords()
     {
-        $coords = array();
+        $coords = [];
         for ($i = 0; $i < $this->width; $i++) {
-            array_push($coords, array($i, 0));
+            array_push($coords, [$i, 0]);
         }
         return $coords;
     }
 
     public function blackStartCoords()
     {
-        $coords = array();
+        $coords = [];
         for ($i = 0; $i < $this->height; $i++) {
-            array_push($coords, array(0, $i));
+            array_push($coords, [0, $i]);
         }
         return $coords;
     }

--- a/exercises/flatten-array/example.php
+++ b/exercises/flatten-array/example.php
@@ -2,7 +2,7 @@
 
 function flatten($array = [])
 {
-    $return = array();
+    $return = [];
     array_walk_recursive($array, function ($x) use (&$return) {
         return !is_null($x) ? $return[] = $x : [];
     });


### PR DESCRIPTION
As of PHP 5.4 short array syntax is supported and nowadays widely used in the community.