### PR TITLE
Fix tests and example of phone number

### DIFF
--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -19,27 +19,17 @@ class PhoneNumber
         return substr($this->number, 0, 3);
     }
 
-    protected function prefix() : string
-    {
-        return substr($this->number, 3, 3);
-    }
-
-    protected function lineNumber() : string
-    {
-        return substr($this->number, 6, 4);
-    }
-
     public function prettyPrint(): string
     {
         return '(' . $this->areaCode() . ') ' . $this->prefix() . '-' . $this->lineNumber();
     }
 
-    protected function clean($number) : string
+    private function clean($number) : string
     {
         return $this->validate(preg_replace('/[^0-9a-z]+/i', '', $number));
     }
 
-    protected function validate($number) : string
+    private function validate($number) : string
     {
         if ($number !== preg_replace('/[^0-9]+/', '', $number)) {
             throw new InvalidArgumentException('Given number contains invalid characters.');
@@ -54,5 +44,15 @@ class PhoneNumber
         }
 
         return $number;
+    }
+
+    private function prefix() : string
+    {
+        return substr($this->number, 3, 3);
+    }
+
+    private function lineNumber() : string
+    {
+        return substr($this->number, 6, 4);
     }
 }

--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -2,55 +2,57 @@
 
 class PhoneNumber
 {
+    private $number;
+
     public function __construct($number)
     {
         $this->number = $this->clean($number);
     }
-  
+
     public function number()
     {
         return $this->number;
     }
-  
+
     public function areaCode()
     {
         return substr($this->number, 0, 3);
     }
-  
+
     protected function prefix()
     {
         return substr($this->number, 3, 3);
     }
-  
+
     protected function lineNumber()
     {
         return substr($this->number, 6, 4);
     }
-  
+
     public function prettyPrint()
     {
         return '(' . $this->areaCode() . ') ' . $this->prefix() . '-' . $this->lineNumber();
     }
-  
+
     protected function clean($number)
     {
         return $this->validate(preg_replace('/[^0-9a-z]+/i', '', $number));
     }
-  
+
     protected function validate($number)
     {
         if ($number != preg_replace('/[^0-9]+/', '', $number)) {
             throw new InvalidArgumentException();
         }
-  
+
         if (strlen($number) == 11) {
             $number = preg_replace('/^1/', '', $number);
         }
-  
+
         if (strlen($number) != 10) {
             throw new InvalidArgumentException();
         }
-  
+
         return $number;
     }
 }

--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -4,42 +4,42 @@ class PhoneNumber
 {
     private $number;
 
-    public function __construct($number)
+    public function __construct(string $number)
     {
         $this->number = $this->clean($number);
     }
 
-    public function number()
+    public function number() : string
     {
         return $this->number;
     }
 
-    public function areaCode()
+    public function areaCode() : string
     {
         return substr($this->number, 0, 3);
     }
 
-    protected function prefix()
+    protected function prefix() : string
     {
         return substr($this->number, 3, 3);
     }
 
-    protected function lineNumber()
+    protected function lineNumber() : string
     {
         return substr($this->number, 6, 4);
     }
 
-    public function prettyPrint()
+    public function prettyPrint(): string
     {
         return '(' . $this->areaCode() . ') ' . $this->prefix() . '-' . $this->lineNumber();
     }
 
-    protected function clean($number)
+    protected function clean($number) : string
     {
         return $this->validate(preg_replace('/[^0-9a-z]+/i', '', $number));
     }
 
-    protected function validate($number)
+    protected function validate($number) : string
     {
         if ($number !== preg_replace('/[^0-9]+/', '', $number)) {
             throw new InvalidArgumentException('Given number contains invalid characters.');

--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -42,7 +42,7 @@ class PhoneNumber
     protected function validate($number)
     {
         if ($number !== preg_replace('/[^0-9]+/', '', $number)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException('Given number contains invalid characters.');
         }
 
         if (strlen($number) === 11) {
@@ -50,7 +50,7 @@ class PhoneNumber
         }
 
         if (strlen($number) !== 10) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException('Given number has an invalid length.');
         }
 
         return $number;

--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -35,6 +35,13 @@ class PhoneNumber
             throw new InvalidArgumentException('Given number contains invalid characters.');
         }
 
+        $result = preg_match('/\(?[2-9][0-9]{2}\)?[-. ]?[2-9][0-9]{2}[-. ]?[0-9]{4}/', $number);
+        if (1 !== $result) {
+            throw new InvalidArgumentException(
+                'Given number has an invalid format.' . PHP_EOL . $number . PHP_EOL . $result
+            );
+        }
+
         if (strlen($number) === 11) {
             $number = preg_replace('/^1/', '', $number);
         }

--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -19,27 +19,32 @@ class PhoneNumber
         return substr($this->number, 0, 3);
     }
 
-    public function prettyPrint(): string
+    public function prettyPrint() : string
     {
         return '(' . $this->areaCode() . ') ' . $this->prefix() . '-' . $this->lineNumber();
     }
 
-    private function clean($number) : string
+    private function clean(string $number) : string
     {
-        return $this->validate(preg_replace('/[^0-9a-z]+/i', '', $number));
+        return $this->validate(preg_replace('/[^0-9a-z@:!]+/i', '', $number));
     }
 
-    private function validate($number) : string
+    private function validate(string $number) : string
     {
-        if ($number !== preg_replace('/[^0-9]+/', '', $number)) {
-            throw new InvalidArgumentException('Given number contains invalid characters.');
+        if (strlen($number) === 11 && $number[0] !== '1') {
+            throw new InvalidArgumentException('11 digits must start with 1');
         }
 
-        $result = preg_match('/\(?[2-9][0-9]{2}\)?[-. ]?[2-9][0-9]{2}[-. ]?[0-9]{4}/', $number);
-        if (1 !== $result) {
-            throw new InvalidArgumentException(
-                'Given number has an invalid format.' . PHP_EOL . $number . PHP_EOL . $result
-            );
+        if (strlen($number) > 11) {
+            throw new InvalidArgumentException('more than 11 digits');
+        }
+
+        if (0 !== preg_match('/[A-z]/', $number)) {
+            throw new InvalidArgumentException('letters not permitted');
+        }
+
+        if (0 !== preg_match('/[@:!]/', $number)) {
+            throw new InvalidArgumentException('punctuations not permitted');
         }
 
         if (strlen($number) === 11) {
@@ -47,7 +52,23 @@ class PhoneNumber
         }
 
         if (strlen($number) !== 10) {
-            throw new InvalidArgumentException('Given number has an invalid length.');
+            throw new InvalidArgumentException('incorrect number of digits');
+        }
+
+        if ($number[0] === '0') {
+            throw new InvalidArgumentException('area code cannot start with zero');
+        }
+
+        if ($number[0] === '1') {
+            throw new InvalidArgumentException('area code cannot start with one');
+        }
+
+        if ($number[3] === '0') {
+            throw new InvalidArgumentException('exchange code cannot start with zero');
+        }
+
+        if ($number[3] === '1') {
+            throw new InvalidArgumentException('exchange code cannot start with one');
         }
 
         return $number;

--- a/exercises/phone-number/example.php
+++ b/exercises/phone-number/example.php
@@ -41,15 +41,15 @@ class PhoneNumber
 
     protected function validate($number)
     {
-        if ($number != preg_replace('/[^0-9]+/', '', $number)) {
+        if ($number !== preg_replace('/[^0-9]+/', '', $number)) {
             throw new InvalidArgumentException();
         }
 
-        if (strlen($number) == 11) {
+        if (strlen($number) === 11) {
             $number = preg_replace('/^1/', '', $number);
         }
 
-        if (strlen($number) != 10) {
+        if (strlen($number) !== 10) {
             throw new InvalidArgumentException();
         }
 

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -4,41 +4,22 @@ require "phone-number.php";
 
 class PhoneNumberTest extends PHPUnit\Framework\TestCase
 {
-    public function testValidNumberWithAreaCodeAndBracketsAndDashes(): void
+    public function testCleansTheNumber(): void
     {
-        $number = new PhoneNumber('+1 (613)-995-0253');
-        $this->assertEquals('6139950253', $number->number());
+        $number = new PhoneNumber('(223) 456-7890');
+        $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testValidNumberWithAreaCode(): void
+    public function testCleansTheNumberWithDots(): void
     {
-        $number = new PhoneNumber('1 613 995 0253');
-        $this->assertEquals('6139950253', $number->number());
+        $number = new PhoneNumber('223.456.7890');
+        $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testValidNumberWithBracketsAndDashes(): void
+    public function testCleansTheNumberWithMultipleSpaces(): void
     {
-        $number = new PhoneNumber('(613)-995-0253');
-        $this->assertEquals('6139950253', $number->number());
-    }
-
-    public function testValidNumberWithDashes(): void
-    {
-        $number = new PhoneNumber('613-995-0253');
-        $this->assertEquals('6139950253', $number->number());
-    }
-
-    public function testValidNumberWithDots(): void
-    {
-        $number = new PhoneNumber('613.995.0253');
-        $this->assertEquals('6139950253', $number->number());
-    }
-
-    public function testInvalidWithLettersInPlaceOfNumbers(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new PhoneNumber('299-abc-6789');
+        $number = new PhoneNumber('223 456   7890   ');
+        $this->assertEquals('2234567890', $number->number());
     }
 
     public function testInvalidWhen9Digits(): void
@@ -48,88 +29,99 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('123456789');
     }
 
-    public function testValidWhen11DigitsAndFirstIs1(): void
-    {
-        $number = new PhoneNumber('19876543210');
-        $this->assertEquals('9876543210', $number->number());
-    }
-
-    public function testValidWhen10DigitsAndAreaCodeStartsWith2(): void
-    {
-        $number = new PhoneNumber('2345678901');
-        $this->assertEquals('2345678901', $number->number());
-    }
-
-    public function testInvalidWhen11Digits(): void
+    public function testInvalidWhen11DigitsDoesNotStartWithA1(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('22992999999');
+        new PhoneNumber('22234567890');
     }
 
-    public function testInvalidWhen12DigitsAndFirstIs1(): void
+    public function testValidWhen11DigitsAndStartingWith1(): void
+    {
+        $number = new PhoneNumber('12234567890');
+        $this->assertEquals('2234567890', $number->number());
+    }
+
+    public function testValidWhen11DigitsAndStartingWith1EvenWithPunctuation(): void
+    {
+        $number = new PhoneNumber('+1 (223) 456-7890');
+        $this->assertEquals('2234567890', $number->number());
+    }
+
+    public function testInvalidWhenMoreThan11Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('112345678901');
+        new PhoneNumber('321234567890');
     }
 
-    public function testInvalidWhen10DigitsWithExtraLetters(): void
+    public function testInvalidWithLetters(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
+        new PhoneNumber('123-abc-7890');
     }
 
-    public function testValidAreaCodeOf10Digits(): void
-    {
-        $number = new PhoneNumber('2345678901');
-        $this->assertEquals('234', $number->areaCode());
-    }
-
-    public function testValidAreaCodeOf11Digits(): void
-    {
-        $number = new PhoneNumber('12345678901');
-        $this->assertEquals('234', $number->areaCode());
-    }
-
-    public function testInvalidAreaCodeStartingWith0(): void
+    public function testInvalidWithPunctuation(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('0992999999');
+        new PhoneNumber('123-@:!-7890');
     }
 
-    public function testInvalidAreaCodeStartingWith1(): void
+    public function testInvalidIfAreaCodeStartsWith0(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('1992999999');
+        new PhoneNumber('(023) 456-7890');
     }
 
-    public function testInvalidPrefixStartingWith0(): void
+    public function testInvalidIfAreaCodeStartsWith1(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('2990999999');
+        new PhoneNumber('(123) 456-7890');
     }
 
-    public function testInvalidPrefixStartingWith1(): void
+    public function testInvalidIfExchangeCodeStartsWith0(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('2991999999');
+        new PhoneNumber('(223) 056-7890');
     }
 
-    public function testPrettyPrintWith10Digits(): void
+    public function testInvalidIfExchangeCodeStartsWith1(): void
     {
-        $number = new PhoneNumber('5552345678');
-        $this->assertEquals('(555) 234-5678', $number->prettyPrint());
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('(223) 156-7890');
     }
 
-    public function testPrettyPrintWith11Digits(): void
+    public function testInvalidIfAreaCodeStartsWith0OnValid11DigitNumber(): void
     {
-        $number = new PhoneNumber('12345678901');
-        $this->assertEquals('(234) 567-8901', $number->prettyPrint());
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('1 (023) 456-7890');
+    }
+
+    public function testInvalidIfAreaCodeStartsWith1OnValid11DigitNumber(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('1 (123) 456-7890');
+    }
+
+    public function testInvalidIfExchangeCodeStartsWith0OnValid11DigitNumber(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('1 (223) 056-7890');
+    }
+
+    public function testInvalidIfExchangeCodeStartsWith1OnValid11DigitNumber(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('1 (223) 156-7890');
     }
 }

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -20,14 +20,14 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $number = new PhoneNumber('123-abc-1234');
+        new PhoneNumber('123-abc-1234');
     }
 
     public function testInvalidWhen9Digits()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $number = new PhoneNumber('123456789');
+        new PhoneNumber('123456789');
     }
 
     public function testValidWhen11DigitsAndFirstIs1()
@@ -46,21 +46,21 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $number = new PhoneNumber('21234567890');
+        new PhoneNumber('21234567890');
     }
 
     public function testInvalidWhen12DigitsAndFirstIs1()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $number = new PhoneNumber('112345678901');
+        new PhoneNumber('112345678901');
     }
 
     public function testInvalidWhen10DigitsWithExtraLetters()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $number = new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
+        new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
     }
 
     public function testAreaCode()

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -4,23 +4,41 @@ require "phone-number.php";
 
 class PhoneNumberTest extends PHPUnit\Framework\TestCase
 {
-    public function testCleansNumber(): void
+    public function testValidNumberWithAreaCodeAndBracketsAndDashes(): void
     {
-        $number = new PhoneNumber('(123) 456-7890');
-        $this->assertEquals('1234567890', $number->number());
+        $number = new PhoneNumber('+1 (613)-995-0253');
+        $this->assertEquals('6139950253', $number->number());
     }
 
-    public function testCleansNumberWithDots(): void
+    public function testValidNumberWithAreaCode(): void
     {
-        $number = new PhoneNumber('456.123.7890');
-        $this->assertEquals('4561237890', $number->number());
+        $number = new PhoneNumber('1 613 995 0253');
+        $this->assertEquals('6139950253', $number->number());
+    }
+
+    public function testValidNumberWithBracketsAndDashes(): void
+    {
+        $number = new PhoneNumber('(613)-995-0253');
+        $this->assertEquals('6139950253', $number->number());
+    }
+
+    public function testValidNumberWithDashes(): void
+    {
+        $number = new PhoneNumber('613-995-0253');
+        $this->assertEquals('6139950253', $number->number());
+    }
+
+    public function testValidNumberWithDots(): void
+    {
+        $number = new PhoneNumber('613.995.0253');
+        $this->assertEquals('6139950253', $number->number());
     }
 
     public function testInvalidWithLettersInPlaceOfNumbers(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('123-abc-1234');
+        new PhoneNumber('299-abc-6789');
     }
 
     public function testInvalidWhen9Digits(): void
@@ -36,17 +54,17 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('9876543210', $number->number());
     }
 
-    public function testValidWhen10DigitsAndAreaCodeStartsWith1(): void
+    public function testValidWhen10DigitsAndAreaCodeStartsWith2(): void
     {
-        $number = new PhoneNumber('1234567890');
-        $this->assertEquals('1234567890', $number->number());
+        $number = new PhoneNumber('2345678901');
+        $this->assertEquals('2345678901', $number->number());
     }
 
     public function testInvalidWhen11Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PhoneNumber('21234567890');
+        new PhoneNumber('22992999999');
     }
 
     public function testInvalidWhen12DigitsAndFirstIs1(): void
@@ -63,21 +81,55 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
     }
 
-    public function testAreaCode(): void
+    public function testValidAreaCodeOf10Digits(): void
     {
-        $number = new PhoneNumber('1234567890');
-        $this->assertEquals('123', $number->areaCode());
+        $number = new PhoneNumber('2345678901');
+        $this->assertEquals('234', $number->areaCode());
     }
 
-    public function testPrettyPrint(): void
+    public function testValidAreaCodeOf11Digits(): void
     {
-        $number = new PhoneNumber('5551234567');
-        $this->assertEquals('(555) 123-4567', $number->prettyPrint());
+        $number = new PhoneNumber('12345678901');
+        $this->assertEquals('234', $number->areaCode());
     }
 
-    public function testPrettyPrintWithFullUsPhoneNumber(): void
+    public function testInvalidAreaCodeStartingWith0(): void
     {
-        $number = new PhoneNumber('11234567890');
-        $this->assertEquals('(123) 456-7890', $number->prettyPrint());
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('0992999999');
+    }
+
+    public function testInvalidAreaCodeStartingWith1(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('1992999999');
+    }
+
+    public function testInvalidPrefixStartingWith0(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('2990999999');
+    }
+
+    public function testInvalidPrefixStartingWith1(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new PhoneNumber('2991999999');
+    }
+
+    public function testPrettyPrintWith10Digits(): void
+    {
+        $number = new PhoneNumber('5552345678');
+        $this->assertEquals('(555) 234-5678', $number->prettyPrint());
+    }
+
+    public function testPrettyPrintWith11Digits(): void
+    {
+        $number = new PhoneNumber('12345678901');
+        $this->assertEquals('(234) 567-8901', $number->prettyPrint());
     }
 }

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -25,6 +25,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidWhen9Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('incorrect number of digits');
 
         new PhoneNumber('123456789');
     }
@@ -32,6 +33,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidWhen11DigitsDoesNotStartWithA1(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('11 digits must start with 1');
 
         new PhoneNumber('22234567890');
     }
@@ -51,6 +53,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidWhenMoreThan11Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('more than 11 digits');
 
         new PhoneNumber('321234567890');
     }
@@ -58,6 +61,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidWithLetters(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('letters not permitted');
 
         new PhoneNumber('123-abc-7890');
     }
@@ -65,6 +69,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidWithPunctuation(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('punctuations not permitted');
 
         new PhoneNumber('123-@:!-7890');
     }
@@ -72,6 +77,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfAreaCodeStartsWith0(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('area code cannot start with zero');
 
         new PhoneNumber('(023) 456-7890');
     }
@@ -79,6 +85,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfAreaCodeStartsWith1(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('area code cannot start with one');
 
         new PhoneNumber('(123) 456-7890');
     }
@@ -86,6 +93,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfExchangeCodeStartsWith0(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange code cannot start with zero');
 
         new PhoneNumber('(223) 056-7890');
     }
@@ -93,6 +101,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfExchangeCodeStartsWith1(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange code cannot start with one');
 
         new PhoneNumber('(223) 156-7890');
     }
@@ -100,6 +109,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfAreaCodeStartsWith0OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('area code cannot start with zero');
 
         new PhoneNumber('1 (023) 456-7890');
     }
@@ -107,6 +117,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfAreaCodeStartsWith1OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('area code cannot start with one');
 
         new PhoneNumber('1 (123) 456-7890');
     }
@@ -114,6 +125,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfExchangeCodeStartsWith0OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange code cannot start with zero');
 
         new PhoneNumber('1 (223) 056-7890');
     }
@@ -121,6 +133,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
     public function testInvalidIfExchangeCodeStartsWith1OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange code cannot start with one');
 
         new PhoneNumber('1 (223) 156-7890');
     }

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -4,78 +4,78 @@ require "phone-number.php";
 
 class PhoneNumberTest extends PHPUnit\Framework\TestCase
 {
-    public function testCleansNumber()
+    public function testCleansNumber(): void
     {
         $number = new PhoneNumber('(123) 456-7890');
         $this->assertEquals('1234567890', $number->number());
     }
 
-    public function testCleansNumberWithDots()
+    public function testCleansNumberWithDots(): void
     {
         $number = new PhoneNumber('456.123.7890');
         $this->assertEquals('4561237890', $number->number());
     }
 
-    public function testInvalidWithLettersInPlaceOfNumbers()
+    public function testInvalidWithLettersInPlaceOfNumbers(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new PhoneNumber('123-abc-1234');
     }
 
-    public function testInvalidWhen9Digits()
+    public function testInvalidWhen9Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new PhoneNumber('123456789');
     }
 
-    public function testValidWhen11DigitsAndFirstIs1()
+    public function testValidWhen11DigitsAndFirstIs1(): void
     {
         $number = new PhoneNumber('19876543210');
         $this->assertEquals('9876543210', $number->number());
     }
 
-    public function testValidWhen10DigitsAndAreaCodeStartsWith1()
+    public function testValidWhen10DigitsAndAreaCodeStartsWith1(): void
     {
         $number = new PhoneNumber('1234567890');
         $this->assertEquals('1234567890', $number->number());
     }
 
-    public function testInvalidWhen11Digits()
+    public function testInvalidWhen11Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new PhoneNumber('21234567890');
     }
 
-    public function testInvalidWhen12DigitsAndFirstIs1()
+    public function testInvalidWhen12DigitsAndFirstIs1(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new PhoneNumber('112345678901');
     }
 
-    public function testInvalidWhen10DigitsWithExtraLetters()
+    public function testInvalidWhen10DigitsWithExtraLetters(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new PhoneNumber('1a2a3a4a5a6a7a8a9a0a');
     }
 
-    public function testAreaCode()
+    public function testAreaCode(): void
     {
         $number = new PhoneNumber('1234567890');
         $this->assertEquals('123', $number->areaCode());
     }
 
-    public function testPrettyPrint()
+    public function testPrettyPrint(): void
     {
         $number = new PhoneNumber('5551234567');
         $this->assertEquals('(555) 123-4567', $number->prettyPrint());
     }
 
-    public function testPrettyPrintWithFullUsPhoneNumber()
+    public function testPrettyPrintWithFullUsPhoneNumber(): void
     {
         $number = new PhoneNumber('11234567890');
         $this->assertEquals('(123) 456-7890', $number->prettyPrint());


### PR DESCRIPTION
This PR resolves issues discussed in #260:

Adding tests for
- example inputs in readme
- validating first numbers of area code and prefix (allowing 2 through 9)

Resolve conflicts in existing tests due to added validation of area code and prefix.