### PR TITLE
Declaration of supported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: php
 php:
-- 7.1
 - 7.2
 - 7.3
 script:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
 default:
-	wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
+	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
@@ -22,18 +22,18 @@ help: ## Prints this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## install development dependencies
-	wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
+	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 
 	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
-install-test: ## install test dependency: phpunit.phar 
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpunit.phar
+install-test: ## install test dependency: phpunit.phar
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 
 install-style: ## install style checker dependency: phpcs.phar
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit-7.phar -O bin/phpcs.phar
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 test-assignment: bin/phpunit.phar ## run single test using ASSIGNMENTS: test-assignment ASSIGNMENT=wordy

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,28 +1,60 @@
-PHP can be downloaded and built from source, available at [php.net/downloads.php](http://php.net/downloads.php)
+### Which version to chose?
 
-Alternatively there are many pre-compiled versions available for [different operating systems](http://php.net/manual/en/install.php):
+We encourage to use a stable PHP release with active support. Currently this is **PHP 7.2 and 7.3**. Details on current releases and their timelines can be found at [php.net/supported-versions](https://www.php.net/supported-versions.php).
 
-**Windows users**: There are pre-built stacks including [WAMP](http://www.wampserver.com/en/) - (windows, Apache, MySQL, PHP) and [XAMPP](https://www.apachefriends.org/index.html)
+### Install PHP
 
-**OS X users**: Normally comes with PHP installed, but there are other pre-built options available, including [MAMP](http://www.mamp.info/en/).
+PHP can be downloaded and built from source, available at [php.net/downloads.php](http://php.net/downloads.php) or[windows.php.net/download](https://windows.php.net/download).
 
-**Linux users**: Different distributions have different methods. You should be able to
+> Note: A web server such as nginx or Apache HTTP server is not required to complete the exercises.
 
-````$ yum install php````
+#### Linux
+
+Different distributions have different methods. You should be able to
+
+```bash
+$ yum install php
+```
 
 or
 
-````$ apt-get install php````
+```bash
+$ apt-get install php
+```
 
 depending on your repository manager.
 
+For further instructions, read the manual on [Installation on Unix systems](https://www.php.net/manual/en/install.unix.php).
 
-### Install PHPUnit:
+#### macOS
 
-To globally install PHPUnit testing framework, you can add it to your global composer file, which you can then add to your environment PATH.
+Normally macOS comes with PHP installed. There are other pre-built options available, including [MAMP](http://www.mamp.info/en/) an [php-osx.liip.ch](https://php-osx.liip.ch/).
 
-To do this call
+For further instructions, read the manual on [Installation on macOS](https://www.php.net/manual/en/install.macosx.php).
 
-````$ composer global require phpunit/phpunit````
+#### Windows
 
-If you are not using Composer package manager you can download the phpunit.phar file and add that to your PATH, or project directory as explained here: [PHPUnit](https://phpunit.de/manual/current/en/installation.html)
+Official PHP binaries for Windows can be downloaded from [windows.php.net/download](https://windows.php.net/download).
+
+There are pre-built stacks including [WAMP](http://www.wampserver.com/en/) - (Windows, Apache, MySQL, PHP) and [XAMPP](https://www.apachefriends.org/de/index.html).
+
+For further instructions, read the manual on [Installation on Windows systems](https://www.php.net/manual/en/install.windows.php).
+
+#### Other
+
+If you want to use a different OS, see instruction on [php.net/manual/en/install](https://www.php.net/manual/en/install.php).
+
+
+### Install PHPUnit
+
+#### Via Composer
+
+PHPUnit can be installed globally via [Composer](https://getcomposer.org), using the following command.
+
+```bash
+$ composer global require phpunit/phpunit
+```
+
+#### Manual installation
+
+If you are not using Composer package manager, follow the official [Installing PHPUnit instructions](https://phpunit.de/manual/6.5/en/installation.html).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit>
     <testsuites>
-        <testsuite>
+        <testsuite name="unit">
             <directory>./</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
This PR

- provides changes discussed in #266,
- adds a new paragraph to the installation doc on which PHP versions are supported (stable release with active support),
- updates installation instructions in general and
- updates travis.yml to drop support of PHP 7.1 (!).

The intention of this change is to provide a great learning experience for the students, making usage of current language features. I am open to any feedback that helps accomplish that goal.

Although I am sure, I have seen a contribution guide in the past, I could not find any instructions on how to format the doc files. Please let me know, if changes are required.