### PR TITLE
Improve Gigasecond exercise example

### DIFF
--- a/exercises/gigasecond/example.php
+++ b/exercises/gigasecond/example.php
@@ -3,6 +3,5 @@
 function from(DateTimeImmutable $from)
 {
     $interval = new DateInterval('PT1000000000S');
-    $date = clone $from;
-    return $date->add($interval);
+    return $from->add($interval);
 }

--- a/exercises/gigasecond/example.php
+++ b/exercises/gigasecond/example.php
@@ -1,6 +1,6 @@
 <?php
 
-function from(DateTimeImmutable $from)
+function from(DateTimeImmutable $from) : DateTimeImmutable
 {
     $interval = new DateInterval('PT1000000000S');
     return $from->add($interval);


### PR DESCRIPTION
This PR improves the example of the Gigasecond example.

- Remove unnecessary clone of `DateTimeImmutable` object
- Declare return type