### PR TITLE
Declare return types (take two)

### DIFF
--- a/exercises/accumulate/accumulate_test.php
+++ b/exercises/accumulate/accumulate_test.php
@@ -7,7 +7,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
         require 'accumulate.php';
     }
 
-    public function testAccumulateEmpty()
+    public function testAccumulateEmpty() : void
     {
         $accumulator = function ($value) {
             return $value ** 2;
@@ -16,7 +16,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
         $this->assertEquals([], accumulate([], $accumulator));
     }
 
-    public function testAccumulateSquares()
+    public function testAccumulateSquares() : void
     {
         $accumulator = function ($value) {
             return $value ** 2;
@@ -25,7 +25,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
         $this->assertEquals([1, 4, 9], accumulate([1, 2, 3], $accumulator));
     }
 
-    public function testAccumulateUpperCases()
+    public function testAccumulateUpperCases() : void
     {
         $accumulator = function ($string) {
             return mb_strtoupper($string);
@@ -34,7 +34,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(['HELLO', 'WORLD!'], accumulate(['Hello', 'World!'], $accumulator));
     }
 
-    public function testAccumulateReversedStrings()
+    public function testAccumulateReversedStrings() : void
     {
         $accumulator = function ($string) {
             return strrev($string);
@@ -43,7 +43,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(['Hello', 'World!'], accumulate(['olleH', '!dlroW'], $accumulator));
     }
 
-    public function testAccumulateConstants()
+    public function testAccumulateConstants() : void
     {
         $accumulator = function () {
             return 1;
@@ -52,7 +52,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
         $this->assertEquals([1, 1], accumulate(['Hello', 'World!'], $accumulator));
     }
 
-    public function testAccumulateWithinAccumulate()
+    public function testAccumulateWithinAccumulate() : void
     {
         $chars = ['a', 'b', 'c'];
         $digits = [1, 2, 3];
@@ -70,22 +70,22 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
 
     // Additional points for making the following tests pass
 
-    public function testAccumulateUsingBuiltInFunction()
+    public function testAccumulateUsingBuiltInFunction() : void
     {
         $this->assertEquals(['Hello', 'World!'], accumulate([" Hello\t", "\t World!\n "], 'trim'));
     }
 
-    public function testAccumulateUsingStaticMethod()
+    public function testAccumulateUsingStaticMethod() : void
     {
         $this->assertEquals([5, 6], accumulate(['Hello', 'World!'], 'Str::len'));
     }
 
-    public function testAccumulateUsingInvoke()
+    public function testAccumulateUsingInvoke() : void
     {
         $this->assertEquals([['f', 'o', 'o']], accumulate(['foo'], new StrSpliter()));
     }
 
-    public function testAccumulateUsingObjectAndArrayNotation()
+    public function testAccumulateUsingObjectAndArrayNotation() : void
     {
         $this->assertEquals([true, false, false], accumulate(['Yes', 0, []], [new Is(), 'truthy']));
     }
@@ -93,7 +93,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
 
 class Str
 {
-    public static function len($string)
+    public static function len($string) : int
     {
         return strlen($string);
     }
@@ -109,7 +109,7 @@ class StrSpliter
 
 class Is
 {
-    public function truthy($value)
+    public function truthy($value) : bool
     {
         return $value ? true : false;
     }

--- a/exercises/accumulate/accumulate_test.php
+++ b/exercises/accumulate/accumulate_test.php
@@ -4,7 +4,7 @@ class AccumulateTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'accumulate.php';
+        require_once 'accumulate.php';
     }
 
     public function testAccumulateEmpty() : void

--- a/exercises/acronym/acronym_test.php
+++ b/exercises/acronym/acronym_test.php
@@ -7,39 +7,39 @@ class AcronymTest extends PHPUnit\Framework\TestCase
         require 'acronym.php';
     }
 
-    public function testBasicTitleCase()
+    public function testBasicTitleCase() : void
     {
         $this->assertEquals('PNG', acronym('Portable Network Graphics'));
     }
 
-    public function testLowerCaseWord()
+    public function testLowerCaseWord() : void
     {
         $this->assertEquals('ROR', acronym('Ruby on Rails'));
     }
 
-    public function testCamelCase()
+    public function testCamelCase() : void
     {
         $this->assertEquals('HTML', acronym('HyperText Markup Language'));
     }
 
-    public function testAllCapsWords()
+    public function testAllCapsWords() : void
     {
         $this->assertEquals('PHP', acronym('PHP: Hypertext Preprocessor'));
     }
 
-    public function testHyphenated()
+    public function testHyphenated() : void
     {
         $this->assertEquals('CMOS', acronym('Complementary metal-oxide semiconductor'));
     }
 
     // Additional points for making the following tests pass
 
-    public function testOneWordIsNotAbbreviated()
+    public function testOneWordIsNotAbbreviated() : void
     {
         $this->assertEmpty(acronym('Word'));
     }
 
-    public function testUnicode()
+    public function testUnicode() : void
     {
         $phrase = 'Специализированная процессорная часть';
         $this->assertEquals('СПЧ', acronym($phrase));

--- a/exercises/acronym/acronym_test.php
+++ b/exercises/acronym/acronym_test.php
@@ -4,7 +4,7 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'acronym.php';
+        require_once 'acronym.php';
     }
 
     public function testBasicTitleCase() : void

--- a/exercises/affine-cipher/affine-cipher_test.php
+++ b/exercises/affine-cipher/affine-cipher_test.php
@@ -10,7 +10,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'affine-cipher.php';
+        require_once 'affine-cipher.php';
     }
 
     /**

--- a/exercises/affine-cipher/affine-cipher_test.php
+++ b/exercises/affine-cipher/affine-cipher_test.php
@@ -17,32 +17,32 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
      * Tests for encoding English to ciphertext with keys.
      */
 
-    public function testEncodeYes()
+    public function testEncodeYes() : void
     {
         $this->assertEquals('xbt', encode('yes', 5, 7));
     }
 
-    public function testEncodeNo()
+    public function testEncodeNo() : void
     {
         $this->assertEquals('fu', encode('no', 15, 18));
     }
 
-    public function testEncodeOMG()
+    public function testEncodeOMG() : void
     {
         $this->assertEquals('lvz', encode('OMG', 21, 3));
     }
 
-    public function testEncodeOMGWithSpaces()
+    public function testEncodeOMGWithSpaces() : void
     {
         $this->assertEquals('hjp', encode('O M G', 25, 47));
     }
 
-    public function testEncodemindblowingly()
+    public function testEncodemindblowingly() : void
     {
         $this->assertEquals('rzcwa gnxzc dgt', encode('mindblowingly', 11, 15));
     }
 
-    public function testEncodenumbers()
+    public function testEncodenumbers() : void
     {
         $this->assertEquals(
             'jqgjc rw123 jqgjc rw',
@@ -50,12 +50,12 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testEncodeDeepThought()
+    public function testEncodeDeepThought() : void
     {
         $this->assertEquals('iynia fdqfb ifje', encode('Truth is fiction.', 5, 17));
     }
 
-    public function testEncodeAllTheLetters()
+    public function testEncodeAllTheLetters() : void
     {
         $this->assertEquals(
             'swxtj npvyk lruol iejdc blaxk swxmh qzglf',
@@ -63,7 +63,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testEncodeWithANotCoprimeToM()
+    public function testEncodeWithANotCoprimeToM() : void
     {
         $this->expectException(Exception::class);
         encode('This is a test', 6, 17);
@@ -73,12 +73,12 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
      * Test decoding from ciphertext to English with keys
      */
 
-    public function testDecodeExercism()
+    public function testDecodeExercism() : void
     {
         $this->assertEquals('exercism', decode('tytgn fjr', 3, 7));
     }
 
-    public function testDecodeASentence()
+    public function testDecodeASentence() : void
     {
         $this->assertEquals(
             decode("qdwju nqcro muwhn odqun oppmd aunwd o", 19, 16),
@@ -86,7 +86,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeNumbers()
+    public function testDecodeNumbers() : void
     {
         $this->assertEquals(
             decode("odpoz ub123 odpoz ub", 25, 7),
@@ -94,7 +94,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeAllTheLetters()
+    public function testDecodeAllTheLetters() : void
     {
         $this->assertEquals(
             decode("swxtj npvyk lruol iejdc blaxk swxmh qzglf", 17, 33),
@@ -102,7 +102,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeWithNoSpacesInInput()
+    public function testDecodeWithNoSpacesInInput() : void
     {
         $this->assertEquals(
             decode("swxtjnpvyklruoliejdcblaxkswxmhqzglf", 17, 33),
@@ -110,7 +110,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeWithTooManySpaces()
+    public function testDecodeWithTooManySpaces() : void
     {
         $this->assertEquals(
             decode("vszzm    cly   yd cg    qdp", 15, 16),
@@ -118,7 +118,7 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeWithANotCoprimeToM()
+    public function testDecodeWithANotCoprimeToM() : void
     {
         $this->expectException(Exception::class);
         decode("Test", 13, 5);

--- a/exercises/affine-cipher/example.php
+++ b/exercises/affine-cipher/example.php
@@ -1,6 +1,5 @@
 <?php
 
-
 function encode($text, $a, $b)
 {
     $alphabet = range('a', 'z');

--- a/exercises/all-your-base/all-your-base_test.php
+++ b/exercises/all-your-base/all-your-base_test.php
@@ -11,107 +11,107 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
         require 'all-your-base.php';
     }
 
-    public function testSingleBitOneToDecimal()
+    public function testSingleBitOneToDecimal() : void
     {
         $this->assertEquals(rebase(2, [1], 10), [1]);
     }
 
-    public function testBinaryToSingleDecimal()
+    public function testBinaryToSingleDecimal() : void
     {
         $this->assertEquals(rebase(2, [1, 0, 1], 10), [5]);
     }
 
-    public function testSingleDecimalToBinary()
+    public function testSingleDecimalToBinary() : void
     {
         $this->assertEquals(rebase(10, [5], 2), [1, 0, 1]);
     }
 
-    public function testBinaryToMultipleDecimal()
+    public function testBinaryToMultipleDecimal() : void
     {
         $this->assertEquals(rebase(2, [1, 0, 1, 0, 1, 0], 10), [4, 2]);
     }
 
-    public function testDecimalToBinary()
+    public function testDecimalToBinary() : void
     {
         $this->assertEquals(rebase(10, [4, 2], 2), [1, 0, 1, 0, 1, 0]);
     }
 
-    public function testTrinaryToHexadecimal()
+    public function testTrinaryToHexadecimal() : void
     {
         $this->assertEquals(rebase(3, [1, 1, 2, 0], 16), [2, 10]);
     }
 
-    public function testHexadecimalToTrinary()
+    public function testHexadecimalToTrinary() : void
     {
         $this->assertEquals(rebase(16, [2, 10], 3), [1, 1, 2, 0]);
     }
 
-    public function test15BitIntegers()
+    public function test15BitIntegers() : void
     {
         $this->assertEquals(rebase(97, [3, 46, 60], 73), [6, 10, 45]);
     }
 
-    public function testEmptyListReturnsNull()
+    public function testEmptyListReturnsNull() : void
     {
         $this->assertEquals(rebase(10, [], 10), null);
     }
 
-    public function testSingleZeroReturnsNull()
+    public function testSingleZeroReturnsNull() : void
     {
         $this->assertEquals(rebase(10, [0], 2), null);
     }
 
-    public function testMultipleZerosReturnsNull()
+    public function testMultipleZerosReturnsNull() : void
     {
         $this->assertEquals(rebase(10, [0, 0, 0], 2), null);
     }
 
-    public function testLeadingZerosReturnsNull()
+    public function testLeadingZerosReturnsNull() : void
     {
         $this->assertEquals(rebase(10, [0, 6, 0], 2), null);
     }
 
-    public function testFirstBaseIsOne()
+    public function testFirstBaseIsOne() : void
     {
         $this->assertEquals(rebase(1, [6, 0], 2), null);
     }
 
-    public function testFirstBaseIsZero()
+    public function testFirstBaseIsZero() : void
     {
         $this->assertEquals(rebase(0, [6, 0], 2), null);
     }
 
-    public function testFirstBaseIsNegative()
+    public function testFirstBaseIsNegative() : void
     {
         $this->assertEquals(rebase(-1, [6, 0], 2), null);
     }
 
-    public function testNegativeDigit()
+    public function testNegativeDigit() : void
     {
         $this->assertEquals(rebase(10, [1, -1, 0], 2), null);
     }
 
-    public function testInvalidPositiveDigit()
+    public function testInvalidPositiveDigit() : void
     {
         $this->assertEquals(rebase(2, [1, 2, 0], 10), null);
     }
 
-    public function testSecondBaseIsOne()
+    public function testSecondBaseIsOne() : void
     {
         $this->assertEquals(rebase(2, [1, 1, 0], 1), null);
     }
 
-    public function testSecondBaseIsZero()
+    public function testSecondBaseIsZero() : void
     {
         $this->assertEquals(rebase(2, [1, 1, 0], 0), null);
     }
 
-    public function testSecondBaseIsNegative()
+    public function testSecondBaseIsNegative() : void
     {
         $this->assertEquals(rebase(2, [1, 1, 0], -1), null);
     }
 
-    public function testBothBasesIsNegative()
+    public function testBothBasesIsNegative() : void
     {
         $this->assertEquals(rebase(-3, [1, 1, 0], -1), null);
     }

--- a/exercises/all-your-base/all-your-base_test.php
+++ b/exercises/all-your-base/all-your-base_test.php
@@ -8,7 +8,7 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'all-your-base.php';
+        require_once 'all-your-base.php';
     }
 
     public function testSingleBitOneToDecimal() : void

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -4,7 +4,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'allergies.php';
+        require_once 'allergies.php';
     }
 
     /**
@@ -40,6 +40,8 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
 
     public function provideListOfAllergen() : array
     {
+        require_once 'allergies.php';
+
         return [
             [new Allergen(Allergen::CATS), 'Only allergic to cats'],
             [new Allergen(Allergen::CHOCOLATE), 'Only allergic to chocolate'],

--- a/exercises/allergies/allergies_test.php
+++ b/exercises/allergies/allergies_test.php
@@ -7,13 +7,12 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         require 'allergies.php';
     }
 
-
     /**
      * @dataProvider provideListOfAllergen
      *
      * @param Allergen $allergen
      */
-    public function testNoAllergiesMeansNotAllergicToAnything($allergen)
+    public function testNoAllergiesMeansNotAllergicToAnything($allergen) : void
     {
         $allergies = new Allergies(0);
 
@@ -25,7 +24,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
      *
      * @param Allergen $allergicTo
      */
-    public function testAllergiesToOneAllergen($allergicTo)
+    public function testAllergiesToOneAllergen($allergicTo) : void
     {
         $allergies = new Allergies($allergicTo->getScore());
 
@@ -39,7 +38,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         }, $otherAllergen);
     }
 
-    public function provideListOfAllergen()
+    public function provideListOfAllergen() : array
     {
         return [
             [new Allergen(Allergen::CATS), 'Only allergic to cats'],
@@ -53,15 +52,14 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    public function testAllergicToEggsInAdditionToOtherStuff()
+    public function testAllergicToEggsInAdditionToOtherStuff() : void
     {
         $allergies = new Allergies(5);
 
         $this->assertTrue($allergies->isAllergicTo(new Allergen(Allergen::EGGS)));
     }
 
-
-    public function testIsAllergicToLotsOfStuffs()
+    public function testIsAllergicToLotsOfStuffs() : void
     {
         $allergies = new Allergies(248);
 
@@ -74,7 +72,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ], $allergies->getList());
     }
 
-    public function testIsAllergicToEggsAndPeanuts()
+    public function testIsAllergicToEggsAndPeanuts() : void
     {
         $allergies = new Allergies(3);
 
@@ -84,7 +82,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ], $allergies->getList());
     }
 
-    public function testIsAllergicToEggsAndShellfish()
+    public function testIsAllergicToEggsAndShellfish() : void
     {
         $allergies = new Allergies(5);
 
@@ -94,7 +92,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ], $allergies->getList());
     }
 
-    public function testIgnoreNonAllergenScorePart()
+    public function testIgnoreNonAllergenScorePart() : void
     {
         $allergies = new Allergies(509);
 
@@ -112,7 +110,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider provideListOfAllergen
      */
-    public function testIsAllergicToEverything($allergen)
+    public function testIsAllergicToEverything($allergen) : void
     {
         $allergies = new Allergies(255);
 

--- a/exercises/allergies/example.php
+++ b/exercises/allergies/example.php
@@ -9,7 +9,7 @@ class Allergies
         $this->score = $score;
     }
 
-    public function getList()
+    public function getList() : array
     {
         $score = $this->score;
         return array_filter(Allergen::allergenList(), function ($allergen) use ($score) {
@@ -17,12 +17,11 @@ class Allergies
         });
     }
 
-    public function isAllergicTo(Allergen $allergen)
+    public function isAllergicTo(Allergen $allergen) : bool
     {
         return ($this->score & $allergen->getScore()) == $allergen->getScore();
     }
 }
-
 
 class Allergen
 {
@@ -47,7 +46,7 @@ class Allergen
         return $this->score;
     }
 
-    public static function allergenList()
+    public static function allergenList() : array
     {
         return [
             new Allergen(self::CATS),

--- a/exercises/anagram/anagram_test.php
+++ b/exercises/anagram/anagram_test.php
@@ -7,37 +7,37 @@ class AnagramTest extends PHPUnit\Framework\TestCase
         require 'anagram.php';
     }
 
-    public function testNoMatches()
+    public function testNoMatches() : void
     {
         $this->assertEquals([], detectAnagrams('diaper', ['hello', 'world', 'zombies', 'pants']));
     }
 
-    public function testDetectsSimpleAnagram()
+    public function testDetectsSimpleAnagram() : void
     {
         $this->assertEquals(['tan'], detectAnagrams('ant', ['tan', 'stand', 'at']));
     }
 
-    public function testDoesNotDetectFalsePositives()
+    public function testDoesNotDetectFalsePositives() : void
     {
         $this->assertEquals([], detectAnagrams('galea', ['eagle']));
     }
 
-    public function testDetectsMultipleAnagrams()
+    public function testDetectsMultipleAnagrams() : void
     {
         $this->assertEquals(['stream', 'maters'], detectAnagrams('master', ['stream', 'pigeon', 'maters']));
     }
 
-    public function testDoesNotDetectAnagramSubsets()
+    public function testDoesNotDetectAnagramSubsets() : void
     {
         $this->assertEquals([], detectAnagrams('good', ['dog', 'goody']));
     }
 
-    public function testDetectsAnagram()
+    public function testDetectsAnagram() : void
     {
         $this->assertEquals(['inlets'], detectAnagrams('listen', ['enlists', 'google', 'inlets', 'banana']));
     }
 
-    public function testDetectsMultipleAnagrams2()
+    public function testDetectsMultipleAnagrams2() : void
     {
         $this->assertEquals(
             ['gallery', 'regally', 'largely'],
@@ -45,67 +45,67 @@ class AnagramTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDoesNotDetectIdenticalWords()
+    public function testDoesNotDetectIdenticalWords() : void
     {
         $this->assertEquals(['cron'], detectAnagrams('corn', ['corn', 'dark', 'Corn', 'rank', 'CORN', 'cron', 'park']));
     }
 
-    public function testDoesNotDetectNonAnagramsWithIdenticalChecksum()
+    public function testDoesNotDetectNonAnagramsWithIdenticalChecksum() : void
     {
         $this->assertEquals([], detectAnagrams('mass', ['last']));
     }
 
-    public function testDetectsAnagramsCaseInsensitively()
+    public function testDetectsAnagramsCaseInsensitively() : void
     {
         $this->assertEquals(['Carthorse'], detectAnagrams('Orchestra', ['cashregister', 'Carthorse', 'radishes']));
     }
 
-    public function testDetectsAnagramsUsingCaseInsensitiveSubject()
+    public function testDetectsAnagramsUsingCaseInsensitiveSubject() : void
     {
         $this->assertEquals(['carthorse'], detectAnagrams('Orchestra', ['cashregister', 'carthorse', 'radishes']));
     }
 
-    public function testDetectsAnagramsUsingCaseInsensitvePossibleMatches()
+    public function testDetectsAnagramsUsingCaseInsensitvePossibleMatches() : void
     {
         $this->assertEquals(['Carthorse'], detectAnagrams('orchestra', ['cashregister', 'Carthorse', 'radishes']));
     }
 
-    public function testDoesNotDetectAWordAsItsOwnAnagram()
+    public function testDoesNotDetectAWordAsItsOwnAnagram() : void
     {
         $this->assertEquals([], detectAnagrams('banana', ['Banana']));
     }
 
-    public function testDoesNotDetectAAnagramIfTheOriginalWordIsRepeated()
+    public function testDoesNotDetectAAnagramIfTheOriginalWordIsRepeated() : void
     {
         $this->assertEquals([], detectAnagrams('go', ['go Go GO']));
     }
 
-    public function testAnagramsMustUseAllLettersExactlyOnce()
+    public function testAnagramsMustUseAllLettersExactlyOnce() : void
     {
         $this->assertEquals([], detectAnagrams('tapper', ['patter']));
     }
 
-    public function testEliminatesAnagramsWithTheSameChecksum()
+    public function testEliminatesAnagramsWithTheSameChecksum() : void
     {
         $this->assertEquals([], detectAnagrams('mass', ['last']));
     }
 
-    public function testDetectsUnicodeAnagrams()
+    public function testDetectsUnicodeAnagrams() : void
     {
         $this->assertEquals(['ΒΓΑ', 'γβα'], detectAnagrams('ΑΒΓ', ['ΒΓΑ', 'ΒΓΔ', 'γβα']));
     }
 
-    public function testEliminatesMisleadingUnicodeAnagrams()
+    public function testEliminatesMisleadingUnicodeAnagrams() : void
     {
         $this->assertEquals([], detectAnagrams('ΑΒΓ', ['ABΓ']));
     }
 
-    public function testCapitalWordIsNotOwnAnagram()
+    public function testCapitalWordIsNotOwnAnagram() : void
     {
         $this->assertEquals([], detectAnagrams('BANANA', ['Banana']));
     }
 
-    public function testAnagramsMustUseAllLettersExactlyOnce2()
+    public function testAnagramsMustUseAllLettersExactlyOnce2() : void
     {
         $this->assertEquals([], detectAnagrams('patter', ['tapper']));
     }

--- a/exercises/anagram/anagram_test.php
+++ b/exercises/anagram/anagram_test.php
@@ -4,7 +4,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'anagram.php';
+        require_once 'anagram.php';
     }
 
     public function testNoMatches() : void

--- a/exercises/armstrong-numbers/armstrong-numbers_test.php
+++ b/exercises/armstrong-numbers/armstrong-numbers_test.php
@@ -4,7 +4,7 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'armstrong-numbers.php';
+        require_once 'armstrong-numbers.php';
     }
 
     public function testZero() : void

--- a/exercises/armstrong-numbers/armstrong-numbers_test.php
+++ b/exercises/armstrong-numbers/armstrong-numbers_test.php
@@ -7,47 +7,47 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
         require 'armstrong-numbers.php';
     }
 
-    public function testZero()
+    public function testZero() : void
     {
         $this->assertTrue(isArmstrongNumber(0));
     }
 
-    public function testSingleDigit()
+    public function testSingleDigit() : void
     {
         $this->assertTrue(isArmstrongNumber(5));
     }
 
-    public function testDoubleDigit()
+    public function testDoubleDigit() : void
     {
         $this->assertFalse(isArmstrongNumber(10));
     }
 
-    public function testThreeDigitIsArmstrongNumber()
+    public function testThreeDigitIsArmstrongNumber() : void
     {
         $this->assertTrue(isArmstrongNumber(153));
     }
 
-    public function testThreeDigitIsNotArmstrongNumber()
+    public function testThreeDigitIsNotArmstrongNumber() : void
     {
         $this->assertFalse(isArmstrongNumber(100));
     }
 
-    public function testFourDigitIsArmstrongNumber()
+    public function testFourDigitIsArmstrongNumber() : void
     {
         $this->assertTrue(isArmstrongNumber(9474));
     }
 
-    public function testFourDigitIsNotArmstrongNumber()
+    public function testFourDigitIsNotArmstrongNumber() : void
     {
         $this->assertFalse(isArmstrongNumber(9475));
     }
 
-    public function testSevenDigitIsArmstrongNumber()
+    public function testSevenDigitIsArmstrongNumber() : void
     {
         $this->assertTrue(isArmstrongNumber(9926315));
     }
 
-    public function testSevenDigitIsNotArmstrongNumber()
+    public function testSevenDigitIsNotArmstrongNumber() : void
     {
         $this->assertFalse(isArmstrongNumber(9926314));
     }

--- a/exercises/atbash-cipher/atbash-cipher_test.php
+++ b/exercises/atbash-cipher/atbash-cipher_test.php
@@ -7,42 +7,42 @@ class AtbashTest extends PHPUnit\Framework\TestCase
         require 'atbash-cipher.php';
     }
 
-    public function testEncodeNo()
+    public function testEncodeNo() : void
     {
         $this->assertEquals('ml', encode('no'));
     }
 
-    public function testEncodeYes()
+    public function testEncodeYes() : void
     {
         $this->assertEquals('bvh', encode('yes'));
     }
 
-    public function testEncodeOmg()
+    public function testEncodeOmg() : void
     {
         $this->assertEquals('lnt', encode('OMG'));
     }
 
-    public function testEncodeOmgWithSpaces()
+    public function testEncodeOmgWithSpaces() : void
     {
         $this->assertEquals('lnt', encode('O M G'));
     }
 
-    public function testEncodeLongWord()
+    public function testEncodeLongWord() : void
     {
         $this->assertEquals('nrmwy oldrm tob', encode('mindblowingly'));
     }
 
-    public function testEncodeNumbers()
+    public function testEncodeNumbers() : void
     {
         $this->assertEquals('gvhgr mt123 gvhgr mt', encode('Testing, 1 2 3, testing.'));
     }
 
-    public function testEncodeSentence()
+    public function testEncodeSentence() : void
     {
         $this->assertEquals('gifgs rhurx grlm', encode('Truth is fiction.'));
     }
 
-    public function testEncodeAllTheThings()
+    public function testEncodeAllTheThings() : void
     {
         $plaintext = 'The quick brown fox jumps over the lazy dog.';
         $encoded = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt';

--- a/exercises/atbash-cipher/atbash-cipher_test.php
+++ b/exercises/atbash-cipher/atbash-cipher_test.php
@@ -4,7 +4,7 @@ class AtbashTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'atbash-cipher.php';
+        require_once 'atbash-cipher.php';
     }
 
     public function testEncodeNo() : void

--- a/exercises/beer-song/beer-song_test.php
+++ b/exercises/beer-song/beer-song_test.php
@@ -4,7 +4,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'beer-song.php';
+        require_once 'beer-song.php';
     }
 
     public function testFirstVerse() : void

--- a/exercises/beer-song/beer-song_test.php
+++ b/exercises/beer-song/beer-song_test.php
@@ -7,7 +7,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         require 'beer-song.php';
     }
 
-    public function testFirstVerse()
+    public function testFirstVerse() : void
     {
         $expected = "99 bottles of beer on the wall, 99 bottles of beer.\n" .
             "Take one down and pass it around, 98 bottles of beer on the wall.\n";
@@ -15,7 +15,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $song->verse(99));
     }
 
-    public function testVerse2()
+    public function testVerse2() : void
     {
         $expected = "2 bottles of beer on the wall, 2 bottles of beer.\n" .
             "Take one down and pass it around, 1 bottle of beer on the wall.\n";
@@ -23,7 +23,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $song->verse(2));
     }
 
-    public function testVerse1()
+    public function testVerse1() : void
     {
         $expected = "1 bottle of beer on the wall, 1 bottle of beer.\n" .
             "Take it down and pass it around, no more bottles of beer on the wall.\n";
@@ -31,7 +31,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $song->verse(1));
     }
 
-    public function testVerse0()
+    public function testVerse0() : void
     {
         $expected = "No more bottles of beer on the wall, no more bottles of beer.\n" .
             "Go to the store and buy some more, 99 bottles of beer on the wall.";
@@ -39,7 +39,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $song->verse(0));
     }
 
-    public function testACoupleVerses()
+    public function testACoupleVerses() : void
     {
         $expected = "99 bottles of beer on the wall, 99 bottles of beer.\n" .
             "Take one down and pass it around, 98 bottles of beer on the wall.\n" .
@@ -50,7 +50,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $song->verses(99, 98));
     }
 
-    public function testAFewVerses()
+    public function testAFewVerses() : void
     {
         $expected = "2 bottles of beer on the wall, 2 bottles of beer.\n" .
             "Take one down and pass it around, 1 bottle of beer on the wall.\n" .
@@ -64,7 +64,7 @@ class BeerSongTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $song->verses(2, 0));
     }
 
-    public function testWholeSong()
+    public function testWholeSong() : void
     {
         $expected = <<<SONG
 99 bottles of beer on the wall, 99 bottles of beer.

--- a/exercises/beer-song/example.php
+++ b/exercises/beer-song/example.php
@@ -2,7 +2,7 @@
 
 class BeerSong
 {
-    public function verse($number)
+    public function verse($number) : string
     {
         $decrement = $number - 1;
         switch ($number) {
@@ -20,8 +20,8 @@ class BeerSong
                     "Take one down and pass it around, {$decrement} bottles of beer on the wall.\n";
         }
     }
-  
-    public function verses($start, $finish)
+
+    public function verses($start, $finish) : string
     {
         $output = '';
         foreach (range($start, $finish) as $number) {
@@ -33,8 +33,8 @@ class BeerSong
 
         return $output;
     }
-  
-    public function lyrics()
+
+    public function lyrics() : string
     {
         return $this->verses(99, 0);
     }

--- a/exercises/binary-search/binary-search_test.php
+++ b/exercises/binary-search/binary-search_test.php
@@ -7,46 +7,46 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
         require 'binary-search.php';
     }
 
-    public function testItWorksWithOneElement()
+    public function testItWorksWithOneElement() : void
     {
         $this->assertEquals(0, find(6, [6]));
     }
 
-    public function testItFindsValueInMiddle()
+    public function testItFindsValueInMiddle() : void
     {
         $this->assertEquals(3, find(6, [1, 3, 4, 6, 8, 9, 11]));
     }
 
-    public function testItFindsValueInBeginning()
+    public function testItFindsValueInBeginning() : void
     {
         $this->assertEquals(0, find(1, [1, 3, 4, 6, 8, 9, 11]));
     }
 
-    public function testItFindsValueAtEnd()
+    public function testItFindsValueAtEnd() : void
     {
         $this->assertEquals(6, find(11, [1, 3, 4, 6, 8, 9, 11]));
     }
 
-    public function testItFindsValueInOddLengthArray()
+    public function testItFindsValueInOddLengthArray() : void
     {
         $this->assertEquals(9, find(144, [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634]));
     }
 
-    public function testItFindsValueInEvenLengthArray()
+    public function testItFindsValueInEvenLengthArray() : void
     {
         $this->assertEquals(5, find(21, [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]));
     }
-    public function testLowerThanLowestValueNotIn()
+    public function testLowerThanLowestValueNotIn() : void
     {
         $this->assertEquals(-1, find(0, [1, 3, 4, 6, 8, 9, 11]));
     }
 
-    public function testLargerThanLargestValueNotIn()
+    public function testLargerThanLargestValueNotIn() : void
     {
         $this->assertEquals(-1, find(13, [1, 3, 4, 6, 8, 9, 11]));
     }
 
-    public function testNothingInEmptyArray()
+    public function testNothingInEmptyArray() : void
     {
         $this->assertEquals(-1, find(1, []));
     }

--- a/exercises/binary-search/binary-search_test.php
+++ b/exercises/binary-search/binary-search_test.php
@@ -4,7 +4,7 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'binary-search.php';
+        require_once 'binary-search.php';
     }
 
     public function testItWorksWithOneElement() : void

--- a/exercises/binary/binary_test.php
+++ b/exercises/binary/binary_test.php
@@ -4,7 +4,7 @@ class BinaryTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'binary.php';
+        require_once 'binary.php';
     }
 
     public function testItParsesBinary0ToDecimal0() : void

--- a/exercises/binary/binary_test.php
+++ b/exercises/binary/binary_test.php
@@ -7,17 +7,17 @@ class BinaryTest extends PHPUnit\Framework\TestCase
         require 'binary.php';
     }
 
-    public function testItParsesBinary0ToDecimal0()
+    public function testItParsesBinary0ToDecimal0() : void
     {
         $this->assertEquals(0, parse_binary('0'));
     }
 
-    public function testItParsesBinary1ToDecimal1()
+    public function testItParsesBinary1ToDecimal1() : void
     {
         $this->assertEquals(1, parse_binary('1'));
     }
 
-    public function testItParsesDigits()
+    public function testItParsesDigits() : void
     {
         $this->assertEquals(2, parse_binary('10'));
         $this->assertEquals(3, parse_binary('11'));
@@ -25,7 +25,7 @@ class BinaryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(9, parse_binary('1001'));
     }
 
-    public function testItParsesHundreds()
+    public function testItParsesHundreds() : void
     {
         $this->assertEquals(128, parse_binary('10000000'));
         $this->assertEquals(315, parse_binary('100111011'));
@@ -33,7 +33,7 @@ class BinaryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(999, parse_binary('1111100111'));
     }
 
-    public function testItParsesMaxInt()
+    public function testItParsesMaxInt() : void
     {
         $this->assertEquals(
             9223372036854775807,
@@ -41,7 +41,7 @@ class BinaryTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testItParsesValuesWithLeadingZeros()
+    public function testItParsesValuesWithLeadingZeros() : void
     {
         $this->assertEquals(1, parse_binary('01'));
         $this->assertEquals(2, parse_binary('0010'));
@@ -51,14 +51,14 @@ class BinaryTest extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider invalidValues
      */
-    public function testItOnlyAcceptsStringsContainingZerosAndOnes($value)
+    public function testItOnlyAcceptsStringsContainingZerosAndOnes($value) : void
     {
         $this->expectException(InvalidArgumentException::class);
 
         parse_binary($value);
     }
 
-    public function invalidValues()
+    public function invalidValues() : array
     {
         return [
             ['2'], ['12345'], ['a'], ['0abcdef'],

--- a/exercises/bob/bob_test.php
+++ b/exercises/bob/bob_test.php
@@ -4,7 +4,7 @@ class BobTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'bob.php';
+        require_once 'bob.php';
     }
 
     /**

--- a/exercises/bob/bob_test.php
+++ b/exercises/bob/bob_test.php
@@ -12,52 +12,52 @@ class BobTest extends PHPUnit\Framework\TestCase
      */
     private $bob;
 
-    public function setUp(): void
+    public function setUp() : void
     {
         $this->bob = new Bob;
     }
 
-    public function testStatingSomething()
+    public function testStatingSomething() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("Tom-ay-to, tom-aaaah-to."));
     }
 
-    public function testShouting()
+    public function testShouting() : void
     {
         $this->assertEquals("Whoa, chill out!", $this->bob->respondTo("WATCH OUT!"));
     }
 
-    public function testShoutingGibberish()
+    public function testShoutingGibberish() : void
     {
         $this->assertEquals("Whoa, chill out!", $this->bob->respondTo("FCECDFCAAB"));
     }
 
-    public function testAskingAQuestion()
+    public function testAskingAQuestion() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo("Does this cryogenic chamber make me look fat?"));
     }
 
-    public function testAskingANumericQuestion()
+    public function testAskingANumericQuestion() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo("You are, what, like 15?"));
     }
 
-    public function testAskingGibberish()
+    public function testAskingGibberish() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo("fffbbcbeab?"));
     }
 
-    public function testTalkingForcefully()
+    public function testTalkingForcefully() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("Let's go make out behind the gym!"));
     }
 
-    public function testUsingAcronymsInRegularSpeech()
+    public function testUsingAcronymsInRegularSpeech() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("It's OK if you don't want to go to the DMV."));
     }
 
-    public function testForcefulQuestion()
+    public function testForcefulQuestion() : void
     {
         $this->assertEquals(
             "Calm down, I know what I'm doing!",
@@ -65,79 +65,77 @@ class BobTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testShoutingNumbers()
+    public function testShoutingNumbers() : void
     {
         $this->assertEquals("Whoa, chill out!", $this->bob->respondTo("1, 2, 3 GO!"));
     }
 
-    public function testOnlyNumbers()
+    public function testOnlyNumbers() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("1, 2, 3"));
     }
 
-    public function testQuestionWithOnlyNumbers()
+    public function testQuestionWithOnlyNumbers() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo("4?"));
     }
 
-    public function testShoutingWithSpecialCharacters()
+    public function testShoutingWithSpecialCharacters() : void
     {
         $this->assertEquals("Whoa, chill out!", $this->bob->respondTo("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"));
     }
 
-
-    public function testShoutingWithNoExclamationMark()
+    public function testShoutingWithNoExclamationMark() : void
     {
         $this->assertEquals("Whoa, chill out!", $this->bob->respondTo("I HATE YOU"));
     }
 
-    public function testStatementContainingQuestionMark()
+    public function testStatementContainingQuestionMark() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("Ending with ? means a question."));
     }
 
-    public function testNonLettersWithQuestion()
+    public function testNonLettersWithQuestion() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo(":) ?"));
     }
 
-    public function testPrattlingOn()
+    public function testPrattlingOn() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo("Wait! Hang on. Are you going to be OK?"));
     }
 
-    public function testSilence()
+    public function testSilence() : void
     {
         $this->assertEquals("Fine. Be that way!", $this->bob->respondTo(""));
     }
 
-    public function testProlongedSilence()
+    public function testProlongedSilence() : void
     {
         $this->assertEquals("Fine. Be that way!", $this->bob->respondTo("         "));
     }
 
-    public function testAlternateSilence()
+    public function testAlternateSilence() : void
     {
         $this->assertEquals("Fine. Be that way!", $this->bob->respondTo("\t\t\t\t\t\t\t\t\t\t"));
     }
 
-    public function testMultipleLineQuestion()
+    public function testMultipleLineQuestion() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("\nDoes this cryogenic chamber make me look fat?\nno"));
     }
 
-    public function testStartingWithWhitespace()
+    public function testStartingWithWhitespace() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("        hmmmmmmm..."));
     }
 
-    public function testEndingWithWhitespace()
+    public function testEndingWithWhitespace() : void
     {
         $this->assertEquals("Sure.", $this->bob->respondTo("Okay if like my  spacebar  quite a bit?   "));
     }
 
-
-    public function testNonQuestionEndingWithWhitespace()
+    public function testNonQuestionEndingWithWhitespace() : void
     {
         $this->assertEquals("Whatever.", $this->bob->respondTo("This is a statement ending with whitespace      "));
     }

--- a/exercises/bob/example.php
+++ b/exercises/bob/example.php
@@ -8,7 +8,7 @@ class Bob
      * @param string $str
      * @return string
      */
-    public function respondTo($str)
+    public function respondTo($str) : string
     {
         $str = $this->prepareText($str);
 
@@ -31,14 +31,13 @@ class Bob
         return "Whatever.";
     }
 
-
     /**
      * Test if the string is being yelled
      *
      * @param string $str
      * @return bool
      */
-    private function isAllCapitals($str)
+    private function isAllCapitals($str) : bool
     {
         return strtoupper($str) == $str;
     }
@@ -52,7 +51,7 @@ class Bob
      * @param string $str
      * @return int
      */
-    private function containsCharacters($str)
+    private function containsCharacters($str) : int
     {
         return preg_match('/\p{L}/', $str);
     }
@@ -63,7 +62,7 @@ class Bob
      * @param $str
      * @return bool
      */
-    private function isYelling($str)
+    private function isYelling($str) : bool
     {
         return $this->containsCharacters($str) && $this->isAllCapitals($str);
     }
@@ -76,7 +75,7 @@ class Bob
      * @param string $str
      * @return int
      */
-    private function isQuestion($str)
+    private function isQuestion($str) : int
     {
         return preg_match('/\?$/', $str);
     }
@@ -87,7 +86,7 @@ class Bob
      * @param string $str
      * @return bool
      */
-    private function isSilence($str)
+    private function isSilence($str) : bool
     {
         return empty($str);
     }
@@ -98,7 +97,7 @@ class Bob
      * @param string $str
      * @return string
      */
-    private function prepareText($str)
+    private function prepareText($str) : string
     {
         return trim($str);
     }

--- a/exercises/book-store/book-store_test.php
+++ b/exercises/book-store/book-store_test.php
@@ -1,7 +1,5 @@
 <?php
 
-include_once 'book-store.php';
-
 /**
  * Calculate lowest price for shopping basket only
  * containing books from a single series. There is no
@@ -11,6 +9,11 @@ include_once 'book-store.php';
 
 class BookStoreTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass() : void
+    {
+        require_once 'book-store.php';
+    }
+
     /**
      * A basket containing only a single book.
      * Target grouping: [[1]]

--- a/exercises/book-store/book-store_test.php
+++ b/exercises/book-store/book-store_test.php
@@ -11,12 +11,11 @@ include_once 'book-store.php';
 
 class BookStoreTest extends PHPUnit\Framework\TestCase
 {
-
     /**
      * A basket containing only a single book.
      * Target grouping: [[1]]
      */
-    public function testSingleBook()
+    public function testSingleBook() : void
     {
         $basket = [1];
         $this->assertEquals(8.0, total($basket));
@@ -26,7 +25,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * A basket containing only two of the same book.
      * Target grouping: [[2], [2]]
      */
-    public function testTwoSame()
+    public function testTwoSame() : void
     {
         $basket = [2, 2];
         $this->assertEquals(16.0, total($basket));
@@ -36,7 +35,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * No charge to carry around an empty basket.
      * Target grouping: []
      */
-    public function testEmpty()
+    public function testEmpty() : void
     {
         $basket = [];
         $this->assertEquals(0.0, total($basket));
@@ -46,7 +45,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * A basket containing only two different books.
      * Target grouping: [[1, 2]]
      */
-    public function testTwoDifferent()
+    public function testTwoDifferent() : void
     {
         $basket = [1, 2];
         $this->assertEquals(15.2, total($basket));
@@ -56,7 +55,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * A basket of three different books.
      * Target grouping: [[1, 2, 3]]
      */
-    public function testThreeDifferent()
+    public function testThreeDifferent() : void
     {
         $basket = [1, 2, 3];
         $this->assertEquals(21.60, total($basket));
@@ -66,7 +65,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * A basket of four different books.
      * Target grouping: [[1, 2, 3, 4]]
      */
-    public function testFourDifferent()
+    public function testFourDifferent() : void
     {
         $basket = [1, 2, 3, 4];
         $this->assertEquals(25.60, total($basket));
@@ -76,7 +75,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * A basket of five different books.
      * Target grouping: [[1, 2, 3, 4, 5]]
      */
-    public function testFiveDifferent()
+    public function testFiveDifferent() : void
     {
         $basket = [1, 2, 3, 4, 5];
         $this->assertEquals(30.00, total($basket));
@@ -91,7 +90,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * discount.
      * Target grouping: [[1, 2, 3, 4], [1, 2, 3, 5]]
      */
-    public function testEight()
+    public function testEight() : void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 5];
         $this->assertEquals(51.20, total($basket));
@@ -103,7 +102,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * the last book.
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4]],
      */
-    public function testFourPairsPlusOne()
+    public function testFourPairsPlusOne() : void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5];
         $this->assertEquals(55.60, total($basket));
@@ -114,7 +113,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * copies of each book in the series.
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]]
      */
-    public function testFivePairs()
+    public function testFivePairs() : void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5];
         $this->assertEquals(60.00, total($basket));
@@ -126,7 +125,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * of the remaining four books in the series.
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1]]
      */
-    public function testFivePairsPlusOne()
+    public function testFivePairsPlusOne() : void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1];
         $this->assertEquals(68.00, total($basket));
@@ -138,7 +137,7 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * each of the remaining three books in the series.
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2]]
      */
-    public function testTwelve()
+    public function testTwelve() : void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2];
         $this->assertEquals(75.20, total($basket));

--- a/exercises/bowling/bowling_test.php
+++ b/exercises/bowling/bowling_test.php
@@ -14,19 +14,19 @@ class GameTest extends PHPUnit\Framework\TestCase
     /** @var Game */
     private $game;
 
-    public function setUp(): void
+    public function setUp() : void
     {
         $this->game = new Game();
     }
 
-    public function testShouldBeAbleToScoreAGameWithAllZeros()
+    public function testShouldBeAbleToScoreAGameWithAllZeros() : void
     {
         $this->rollMany(20, 0);
 
         $this->assertEquals(0, $this->game->score());
     }
 
-    public function testShouldBeAbleToScoreAGameWithNoStrikesOrSpares()
+    public function testShouldBeAbleToScoreAGameWithNoStrikesOrSpares() : void
     {
         $this->game->roll(3);
         $this->game->roll(6);
@@ -52,7 +52,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(90, $this->game->score());
     }
 
-    public function testASpareFollowedByZerosIsWorthTenPoints()
+    public function testASpareFollowedByZerosIsWorthTenPoints() : void
     {
         $this->game->roll(6);
         $this->game->roll(4);
@@ -61,7 +61,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(10, $this->game->score());
     }
 
-    public function testPointsScoredInTheRollAfterASpareAreCountedTwice()
+    public function testPointsScoredInTheRollAfterASpareAreCountedTwice() : void
     {
         $this->game->roll(6);
         $this->game->roll(4);
@@ -71,7 +71,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(16, $this->game->score());
     }
 
-    public function testConsecutiveSparesEachGetAOneRollBonus()
+    public function testConsecutiveSparesEachGetAOneRollBonus() : void
     {
         $this->game->roll(5);
         $this->game->roll(5);
@@ -83,7 +83,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(31, $this->game->score());
     }
 
-    public function testASpareInTheLastFrameGetsAOneRollBonusThatIsCountedOnce()
+    public function testASpareInTheLastFrameGetsAOneRollBonusThatIsCountedOnce() : void
     {
         $this->rollMany(18, 0);
         $this->game->roll(7);
@@ -93,7 +93,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(17, $this->game->score());
     }
 
-    public function testAStrikeEarnsTenPointsInFrameWithASingleRoll()
+    public function testAStrikeEarnsTenPointsInFrameWithASingleRoll() : void
     {
         $this->game->roll(10);
         $this->rollMany(18, 0);
@@ -101,7 +101,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(10, $this->game->score());
     }
 
-    public function testPointsScoredInTheTwoRollsAfterAStrikeAreCountedTwiceAsABonus()
+    public function testPointsScoredInTheTwoRollsAfterAStrikeAreCountedTwiceAsABonus() : void
     {
         $this->game->roll(10);
         $this->game->roll(5);
@@ -111,7 +111,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(26, $this->game->score());
     }
 
-    public function testConsecutiveStrikesEachGetTheTwoRollBonus()
+    public function testConsecutiveStrikesEachGetTheTwoRollBonus() : void
     {
         $this->game->roll(10);
         $this->game->roll(10);
@@ -123,7 +123,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(81, $this->game->score());
     }
 
-    public function testAStrikeInTheLastFrameGetsATwoRollBonusThatIsCountedOnce()
+    public function testAStrikeInTheLastFrameGetsATwoRollBonusThatIsCountedOnce() : void
     {
         $this->rollMany(18, 0);
         $this->game->roll(10);
@@ -133,7 +133,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(18, $this->game->score());
     }
 
-    public function testRollingASpareWithTheTwoRollBonusDoesNotGetABonusRoll()
+    public function testRollingASpareWithTheTwoRollBonusDoesNotGetABonusRoll() : void
     {
         $this->rollMany(18, 0);
         $this->game->roll(10);
@@ -143,7 +143,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(30, $this->game->score());
     }
 
-    public function testAStrikeWithTheOneRollBonusAfterASpareInTheLastFrameDoesNotGetABonus()
+    public function testAStrikeWithTheOneRollBonusAfterASpareInTheLastFrameDoesNotGetABonus() : void
     {
         $this->rollMany(18, 0);
         $this->game->roll(7);
@@ -153,7 +153,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(20, $this->game->score());
     }
 
-    public function testStrikesWithTheTwoRollBonusDoNotGetBonusRolls()
+    public function testStrikesWithTheTwoRollBonusDoNotGetBonusRolls() : void
     {
         $this->rollMany(18, 0);
         $this->game->roll(10);
@@ -163,21 +163,21 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(20, $this->game->score());
     }
 
-    public function testAllStrikesIsAPerfectGame()
+    public function testAllStrikesIsAPerfectGame() : void
     {
         $this->rollMany(12, 10);
 
         $this->assertEquals(300, $this->game->score());
     }
 
-    public function testRollsCanNotScoreNegativePoints()
+    public function testRollsCanNotScoreNegativePoints() : void
     {
         $this->expectException(Exception::class);
 
         $this->game->roll(-1);
     }
 
-    public function testARollCanNotScoreMoreThan10Points()
+    public function testARollCanNotScoreMoreThan10Points() : void
     {
         $this->expectException(Exception::class);
         $this->game->roll(11);
@@ -186,7 +186,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testTwoRollsInAFrameCanNotScoreMoreThan10Points()
+    public function testTwoRollsInAFrameCanNotScoreMoreThan10Points() : void
     {
         $this->expectException(Exception::class);
         $this->game->roll(5);
@@ -196,7 +196,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testTwoBonusRollsAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points()
+    public function testTwoBonusRollsAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points() : void
     {
         $this->expectException(Exception::class);
 
@@ -208,14 +208,14 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testAnUnstartedGameCanNotBeScored()
+    public function testAnUnstartedGameCanNotBeScored() : void
     {
         $this->expectException(Exception::class);
 
         $this->game->score();
     }
 
-    public function testAnIncompleteGameCanNotBeScored()
+    public function testAnIncompleteGameCanNotBeScored() : void
     {
         $this->expectException(Exception::class);
         $this->game->roll(0);
@@ -224,7 +224,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testAGameWithMoreThanTenFramesCanNotBeScored()
+    public function testAGameWithMoreThanTenFramesCanNotBeScored() : void
     {
         $this->expectException(Exception::class);
         $this->rollMany(21, 0);
@@ -232,7 +232,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testBonusRollsForAStrikeInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated()
+    public function testBonusRollsForAStrikeInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated() : void
     {
         $this->expectException(Exception::class);
         $this->rollMany(18, 0);
@@ -241,7 +241,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testBothBonusRollsForAStrikeInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated()
+    public function testBothBonusRollsForAStrikeInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated() : void
     {
         $this->expectException(Exception::class);
         $this->rollMany(18, 0);
@@ -251,7 +251,7 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    public function testBonusRollForASpareInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated()
+    public function testBonusRollForASpareInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated() : void
     {
         $this->expectException(Exception::class);
         $this->rollMany(18, 0);
@@ -261,17 +261,17 @@ class GameTest extends PHPUnit\Framework\TestCase
         $this->game->score();
     }
 
-    private function rollStrike()
+    private function rollStrike() : void
     {
         $this->game->roll(10);
     }
 
-    private function rollSpare()
+    private function rollSpare() : void
     {
         $this->rollMany(2, 5);
     }
 
-    private function rollMany($n, $pins)
+    private function rollMany($n, $pins) : void
     {
         for ($i = 0; $i < $n; $i++) {
             $this->game->roll($pins);

--- a/exercises/bowling/bowling_test.php
+++ b/exercises/bowling/bowling_test.php
@@ -8,7 +8,7 @@ class GameTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'bowling.php';
+        require_once 'bowling.php';
     }
 
     /** @var Game */

--- a/exercises/bowling/example.php
+++ b/exercises/bowling/example.php
@@ -8,7 +8,7 @@ class Game
 {
     private $rolls = [];
 
-    public function roll($pins)
+    public function roll($pins) : void
     {
         if ($pins < 0 || $pins > 10) {
             throw new Exception('Pins must be between 0 and 10');
@@ -38,7 +38,7 @@ class Game
         return $score;
     }
 
-    private function isStrike($frameIndex)
+    private function isStrike($frameIndex) : bool
     {
         return $this->rolls[$frameIndex] === 10;
     }
@@ -57,7 +57,7 @@ class Game
         return $sum;
     }
 
-    private function isSpare($frameIndex)
+    private function isSpare($frameIndex) : bool
     {
         return $this->rolls[$frameIndex] + $this->rolls[$frameIndex + 1] === 10;
     }
@@ -79,14 +79,14 @@ class Game
         return $sum;
     }
 
-    private function guardAgainstIncompleteGame($frameIndex)
+    private function guardAgainstIncompleteGame($frameIndex) : void
     {
         if (!isset($this->rolls[$frameIndex])) {
             throw new Exception('Incomplete game');
         }
     }
 
-    private function guardAgainstTooManyFrames($frameIndex)
+    private function guardAgainstTooManyFrames($frameIndex) : void
     {
         $rollsCount = count($this->rolls);
         if ($this->isStrike($frameIndex - 1)) {

--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -7,27 +7,27 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         require 'change.php';
     }
 
-    public function testSingleCoinChange()
+    public function testSingleCoinChange() : void
     {
         $this->assertEquals([25], findFewestCoins([1, 5, 10, 25, 100], 25));
     }
 
-    public function testChange()
+    public function testChange() : void
     {
         $this->assertEquals([5, 10], findFewestCoins([1, 5, 10, 25, 100], 15));
     }
 
-    public function testChangeWithLilliputianCoins()
+    public function testChangeWithLilliputianCoins() : void
     {
         $this->assertEquals([4, 4, 15], findFewestCoins([1, 4, 15, 20, 50], 23));
     }
 
-    public function testChangeWithLowerElboniaCoins()
+    public function testChangeWithLowerElboniaCoins() : void
     {
         $this->assertEquals([21, 21, 21], findFewestCoins([1, 5, 10, 21, 25], 63));
     }
 
-    public function testWithLargeTargetValue()
+    public function testWithLargeTargetValue() : void
     {
         $this->assertEquals(
             [2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100],
@@ -35,7 +35,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testPossibleChangeWithoutUnitCoinsAvailable()
+    public function testPossibleChangeWithoutUnitCoinsAvailable() : void
     {
         $this->assertEquals(
             [2, 2, 2, 5, 10],
@@ -43,7 +43,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testAnotherPossibleChangeWithoutUnitCoinsAvailable()
+    public function testAnotherPossibleChangeWithoutUnitCoinsAvailable() : void
     {
         $this->assertEquals(
             [4, 4, 4, 5, 5, 5],
@@ -51,12 +51,12 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testNoCoinsForZero()
+    public function testNoCoinsForZero() : void
     {
         $this->assertEquals([], findFewestCoins([1, 5, 10, 21, 25], 0));
     }
 
-    public function testForChangeSmallerThanAvailableCoins()
+    public function testForChangeSmallerThanAvailableCoins() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No coins small enough to make change');
@@ -64,7 +64,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         findFewestCoins([5, 10], 3);
     }
 
-    public function testErrorIfNoCombinationCanAddUpToTarget()
+    public function testErrorIfNoCombinationCanAddUpToTarget() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No combination can add up to target');
@@ -72,7 +72,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
         findFewestCoins([5, 10], 94);
     }
 
-    public function testChangeValueLessThanZero()
+    public function testChangeValueLessThanZero() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot make change for negative value');

--- a/exercises/change/change_test.php
+++ b/exercises/change/change_test.php
@@ -4,7 +4,7 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'change.php';
+        require_once 'change.php';
     }
 
     public function testSingleCoinChange() : void

--- a/exercises/change/example.php
+++ b/exercises/change/example.php
@@ -1,7 +1,7 @@
 <?php
 
 // adapted from the python example
-function findFewestCoins(array $coins, int $total_change): array
+function findFewestCoins(array $coins, int $total_change) : array
 {
     // Some checks
     if ($total_change == 0) {

--- a/exercises/clock/clock_test.php
+++ b/exercises/clock/clock_test.php
@@ -7,21 +7,21 @@ class ClockTest extends PHPUnit\Framework\TestCase
         require 'clock.php';
     }
 
-    public function testOnTheHour()
+    public function testOnTheHour() : void
     {
         $clock = new Clock(8);
 
         $this->assertEquals('08:00', $clock->__toString());
     }
 
-    public function testPastTheHour()
+    public function testPastTheHour() : void
     {
         $clock = new Clock(11, 9);
 
         $this->assertEquals('11:09', $clock->__toString());
     }
 
-    public function testAddingAFewMinutes()
+    public function testAddingAFewMinutes() : void
     {
         $clock = new Clock(10);
 
@@ -30,7 +30,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('10:03', $clock->__toString());
     }
 
-    public function testAddingZeroMinutes()
+    public function testAddingZeroMinutes() : void
     {
         $clock = new Clock(6, 41);
 
@@ -39,7 +39,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('06:41', $clock->__toString());
     }
 
-    public function testAddingOverAnHour()
+    public function testAddingOverAnHour() : void
     {
         $clock = new Clock(10);
 
@@ -48,7 +48,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('11:01', $clock->__toString());
     }
 
-    public function testAddingMoreThanTwoHoursWithCarry()
+    public function testAddingMoreThanTwoHoursWithCarry() : void
     {
         $clock = new Clock(0, 45);
 
@@ -57,7 +57,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('03:25', $clock->__toString());
     }
 
-    public function testAddingMoreThanTwoDays()
+    public function testAddingMoreThanTwoDays() : void
     {
         $clock = new Clock(1, 1);
 
@@ -66,7 +66,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('11:21', $clock->__toString());
     }
 
-    public function testWrapAroundAtMidnight()
+    public function testWrapAroundAtMidnight() : void
     {
         $clock = new Clock(23, 30);
 
@@ -75,7 +75,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('00:30', $clock->__toString());
     }
 
-    public function testSubtractMinutes()
+    public function testSubtractMinutes() : void
     {
         $clock = new Clock(10);
 
@@ -84,7 +84,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('08:30', $clock->__toString());
     }
 
-    public function testSubtractMoreThanTwoHours()
+    public function testSubtractMoreThanTwoHours() : void
     {
         $clock = new Clock(6, 15);
 
@@ -93,7 +93,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('03:35', $clock->__toString());
     }
 
-    public function testSubtractMoreThanTwoHoursWithNegativeAdd()
+    public function testSubtractMoreThanTwoHoursWithNegativeAdd() : void
     {
         $clock = new Clock(6, 15);
 
@@ -102,7 +102,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('03:35', $clock->__toString());
     }
 
-    public function testSubtractMoreThanTwoDays()
+    public function testSubtractMoreThanTwoDays() : void
     {
         $clock = new Clock(2, 20);
 
@@ -111,7 +111,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('00:20', $clock->__toString());
     }
 
-    public function testWrapAroundBackwards()
+    public function testWrapAroundBackwards() : void
     {
         $clock = new Clock(0, 30);
 
@@ -120,7 +120,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('23:30', $clock->__toString());
     }
 
-    public function testWrapAroundDay()
+    public function testWrapAroundDay() : void
     {
         $clock = new Clock(5, 32);
 
@@ -129,7 +129,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('06:32', $clock->__toString());
     }
 
-    public function testWrapAroundDayBackwards()
+    public function testWrapAroundDayBackwards() : void
     {
         $clock = new Clock(5, 32);
 
@@ -138,72 +138,72 @@ class ClockTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('04:32', $clock->__toString());
     }
 
-    public function testEquivalentClocks()
+    public function testEquivalentClocks() : void
     {
         $this->assertEquals(new Clock(15, 37), new Clock(15, 37));
     }
 
-    public function testInequivalentClocks()
+    public function testInequivalentClocks() : void
     {
         $this->assertNotEquals(new Clock(01, 01), new Clock(18, 32));
     }
 
-    public function testEquivalentClocksWithHourOverflowBySeveralDays()
+    public function testEquivalentClocksWithHourOverflowBySeveralDays() : void
     {
         $this->assertEquals(new Clock(3, 11), new Clock(99, 11));
     }
 
-    public function testEquivalentClocksWithNegativeHour()
+    public function testEquivalentClocksWithNegativeHour() : void
     {
         $this->assertEquals(new Clock(22, 40), new Clock(-2, 40));
     }
 
-    public function testEquivalentClocksWithNegativeHourThatWraps()
+    public function testEquivalentClocksWithNegativeHourThatWraps() : void
     {
         $this->assertEquals(new Clock(17, 3), new Clock(-31, 3));
     }
 
-    public function testEquivalentClocksWithMinuteOverflowBySeveralDays()
+    public function testEquivalentClocksWithMinuteOverflowBySeveralDays() : void
     {
         $this->assertEquals(new Clock(2, 2), new Clock(2, 4322));
     }
 
-    public function testEquivalentClocksWithNegativeMinuteOverflow()
+    public function testEquivalentClocksWithNegativeMinuteOverflow() : void
     {
         $this->assertEquals(new Clock(2, 40), new Clock(3, -20));
     }
 
-    public function testEquivalentClocksWithNegativeHoursAndMinutes()
+    public function testEquivalentClocksWithNegativeHoursAndMinutes() : void
     {
         $this->assertEquals(new Clock(7, 32), new Clock(-12, -268));
     }
 
-    public function testHoursRollOver()
+    public function testHoursRollOver() : void
     {
         $this->assertEquals('04:00', (new Clock(100))->__toString());
     }
 
-    public function testMinutesRollOver()
+    public function testMinutesRollOver() : void
     {
         $this->assertEquals('04:43', (new Clock(0, 1723))->__toString());
     }
 
-    public function testHoursAndMinutesRollOver()
+    public function testHoursAndMinutesRollOver() : void
     {
         $this->assertEquals('00:00', (new Clock(72, 8640))->__toString());
     }
 
-    public function testNegativeHoursRollOver()
+    public function testNegativeHoursRollOver() : void
     {
         $this->assertEquals('05:00', (new Clock(-91))->__toString());
     }
 
-    public function testNegativeMinutesRollOver()
+    public function testNegativeMinutesRollOver() : void
     {
         $this->assertEquals('16:40', (new Clock(1, -4820))->__toString());
     }
 
-    public function testNegativeHoursAndMinutesRollOver()
+    public function testNegativeHoursAndMinutesRollOver() : void
     {
         $this->assertEquals('22:10', (new Clock(-121, -5810))->__toString());
     }

--- a/exercises/clock/clock_test.php
+++ b/exercises/clock/clock_test.php
@@ -4,7 +4,7 @@ class ClockTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'clock.php';
+        require_once 'clock.php';
     }
 
     public function testOnTheHour() : void

--- a/exercises/clock/example.php
+++ b/exercises/clock/example.php
@@ -29,7 +29,7 @@ class Clock
      *
      * @return Clock
      */
-    public function add($minutes)
+    public function add($minutes) : \Clock
     {
         return new Clock(0, $this->minutes + $minutes);
     }
@@ -41,7 +41,7 @@ class Clock
      *
      * @return Clock
      */
-    public function sub($minutes)
+    public function sub($minutes) : \Clock
     {
         return $this->add(-$minutes);
     }
@@ -62,7 +62,7 @@ class Clock
      *
      * @return int
      */
-    private function calculateTotalMinutes($hour, $minutes)
+    private function calculateTotalMinutes($hour, $minutes) : int
     {
         return ($hour * 60) + $minutes;
     }
@@ -72,7 +72,7 @@ class Clock
      *
      * @return int
      */
-    private function ignoreWholeDays($minutes)
+    private function ignoreWholeDays($minutes) : int
     {
         return $minutes % (24 * 60);
     }
@@ -82,7 +82,7 @@ class Clock
      *
      * @return int
      */
-    private function ensurePositiveMinutes($minutes)
+    private function ensurePositiveMinutes($minutes) : int
     {
         return ($minutes < 0) ? $minutes + 1440 : $minutes;
     }

--- a/exercises/collatz-conjecture/collatz-conjecture_test.php
+++ b/exercises/collatz-conjecture/collatz-conjecture_test.php
@@ -4,7 +4,7 @@ class CollatzConjecture extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'collatz-conjecture.php';
+        require_once 'collatz-conjecture.php';
     }
 
     public function testZeroStepsForOne() : void

--- a/exercises/collatz-conjecture/collatz-conjecture_test.php
+++ b/exercises/collatz-conjecture/collatz-conjecture_test.php
@@ -7,27 +7,27 @@ class CollatzConjecture extends PHPUnit\Framework\TestCase
         require 'collatz-conjecture.php';
     }
 
-    public function testZeroStepsForOne()
+    public function testZeroStepsForOne() : void
     {
         $this->assertEquals(0, steps(1));
     }
 
-    public function testDivideIfEven()
+    public function testDivideIfEven() : void
     {
         $this->assertEquals(4, steps(16));
     }
 
-    public function testEvenAndOddSteps()
+    public function testEvenAndOddSteps() : void
     {
         $this->assertEquals(9, steps(12));
     }
 
-    public function testLargeNumberOfEvenAndOddSteps()
+    public function testLargeNumberOfEvenAndOddSteps() : void
     {
         $this->assertEquals(152, steps(1000000));
     }
 
-    public function testZeroIsAnError()
+    public function testZeroIsAnError() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Only positive numbers are allowed');
@@ -35,7 +35,7 @@ class CollatzConjecture extends PHPUnit\Framework\TestCase
         steps(0);
     }
 
-    public function testNegativeValueIsAnError()
+    public function testNegativeValueIsAnError() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Only positive numbers are allowed');

--- a/exercises/connect/connect_test.php
+++ b/exercises/connect/connect_test.php
@@ -4,7 +4,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'connect.php';
+        require_once 'connect.php';
     }
 
     /**

--- a/exercises/connect/connect_test.php
+++ b/exercises/connect/connect_test.php
@@ -10,14 +10,14 @@ class ConnectTest extends PHPUnit\Framework\TestCase
     /**
      * Strip off the spaces which are only for readability.
      */
-    private function makeBoard($lines)
+    private function makeBoard($lines) : array
     {
         return array_map(function ($line) {
             return str_replace(" ", "", $line);
         }, $lines);
     }
 
-    public function testEmptyBoardHasNoWinner()
+    public function testEmptyBoardHasNoWinner() : void
     {
         $lines = [
             ". . . . .",
@@ -32,7 +32,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
     /**
      * @depends testEmptyBoardHasNoWinner
      */
-    public function testOneByOneBoardBlack()
+    public function testOneByOneBoardBlack() : void
     {
         $lines = ["X"];
         $this->assertEquals("black", resultFor($this->makeBoard($lines)));
@@ -41,7 +41,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
     /**
      * @depends testEmptyBoardHasNoWinner
      */
-    public function testOneByOneBoardWhite()
+    public function testOneByOneBoardWhite() : void
     {
         $lines = ["O"];
         $this->assertEquals("white", resultFor($this->makeBoard($lines)));
@@ -51,7 +51,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      * @depends testOneByOneBoardBlack
      * @depends testOneByOneBoardWhite
      */
-    public function testConvultedPath()
+    public function testConvultedPath() : void
     {
         $lines = [
             ". X X . .",
@@ -66,7 +66,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
     /**
      * @depends testConvultedPath
      */
-    public function testRectangleWhiteWins()
+    public function testRectangleWhiteWins() : void
     {
         $lines = [
             ". O . .",
@@ -81,7 +81,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
     /**
      * @depends testConvultedPath
      */
-    public function testRectangleBlackWins()
+    public function testRectangleBlackWins() : void
     {
         $lines = [
             ". O . .",
@@ -97,7 +97,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      * @depends testRectangleWhiteWins
      * @depends testRectangleBlackWins
      */
-    public function testSpiralBlackWins()
+    public function testSpiralBlackWins() : void
     {
         $lines = [
             "OXXXXXXXX",
@@ -117,7 +117,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      * @depends testRectangleWhiteWins
      * @depends testRectangleBlackWins
      */
-    public function testSpiralNobodyWins()
+    public function testSpiralNobodyWins() : void
     {
         $lines = [
             "OXXXXXXXX",
@@ -137,7 +137,7 @@ class ConnectTest extends PHPUnit\Framework\TestCase
      * @depends testSpiralBlackWins
      * @depends testSpiralNobodyWins
      */
-    public function testIllegalDiagonalNobodyWins()
+    public function testIllegalDiagonalNobodyWins() : void
     {
         $lines = [
             "X O . .",

--- a/exercises/connect/example.php
+++ b/exercises/connect/example.php
@@ -47,12 +47,12 @@ class Board
         return $this->fields[$c[1]][$c[0]];
     }
 
-    public function update($c, $flag)
+    public function update($c, $flag) : void
     {
         $this->fields[$c[1]][$c[0]] |= $flag;
     }
 
-    public function neighbours($c)
+    public function neighbours($c) : array
     {
         $coords = [
             [$c[0] + 1, $c[1]],
@@ -68,7 +68,7 @@ class Board
         return array_filter($coords, $validCoord);
     }
 
-    public function isGoalEdge($c, $color)
+    public function isGoalEdge($c, $color) : ?bool
     {
         if ($color === WHITE) {
             return $c[1] === $this->height - 1;
@@ -77,7 +77,7 @@ class Board
         }
     }
 
-    public function whiteStartCoords()
+    public function whiteStartCoords() : array
     {
         $coords = [];
         for ($i = 0; $i < $this->width; $i++) {
@@ -86,7 +86,7 @@ class Board
         return $coords;
     }
 
-    public function blackStartCoords()
+    public function blackStartCoords() : array
     {
         $coords = [];
         for ($i = 0; $i < $this->height; $i++) {
@@ -97,7 +97,7 @@ class Board
 
     // Prints the board, occasionally useful for debugging.
     // Capital letters indicate a connect flag has been set.
-    public function dump()
+    public function dump() : void
     {
         print "\n";
         for ($y = 0; $y < $this->height; $y++) {

--- a/exercises/crypto-square/crypto-square_test.php
+++ b/exercises/crypto-square/crypto-square_test.php
@@ -4,7 +4,7 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'crypto-square.php';
+        require_once 'crypto-square.php';
     }
 
     public function testEmptyPlaintextResultsInAnEmptyCiphertext() : void

--- a/exercises/crypto-square/crypto-square_test.php
+++ b/exercises/crypto-square/crypto-square_test.php
@@ -7,37 +7,37 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
         require 'crypto-square.php';
     }
 
-    public function testEmptyPlaintextResultsInAnEmptyCiphertext()
+    public function testEmptyPlaintextResultsInAnEmptyCiphertext() : void
     {
         $this->assertEquals("", crypto_square(""));
     }
 
-    public function testLowercase()
+    public function testLowercase() : void
     {
         $this->assertEquals("a", crypto_square("A"));
     }
 
-    public function testRemoveSpaces()
+    public function testRemoveSpaces() : void
     {
         $this->assertEquals("b", crypto_square("  b "));
     }
 
-    public function testRemovePunctuation()
+    public function testRemovePunctuation() : void
     {
         $this->assertEquals("1", crypto_square("@1,%!"));
     }
 
-    public function test9CharacterPlaintextResultsIn3ChunksOf3Characters()
+    public function test9CharacterPlaintextResultsIn3ChunksOf3Characters() : void
     {
         $this->assertEquals("tsf hiu isn", crypto_square("This is fun!"));
     }
 
-    public function test8CharacterPlaintextResultsIn3ChunksTheLastOneWithATrailingSpace()
+    public function test8CharacterPlaintextResultsIn3ChunksTheLastOneWithATrailingSpace() : void
     {
         $this->assertEquals("clu hlt io ", crypto_square("Chill out."));
     }
 
-    public function test54CharacterPlaintextResultsIn7ChunksTheLastTwoWithTrailingSpaces()
+    public function test54CharacterPlaintextResultsIn7ChunksTheLastTwoWithTrailingSpaces() : void
     {
         $this->assertEquals(
             "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ",

--- a/exercises/diamond/diamond_test.php
+++ b/exercises/diamond/diamond_test.php
@@ -7,12 +7,12 @@ class DiamondTest extends PHPUnit\Framework\TestCase
         require 'diamond.php';
     }
 
-    public function testDegenerateCaseWithASingleARow()
+    public function testDegenerateCaseWithASingleARow() : void
     {
         $this->assertEquals(diamond("A"), [ "A" ]);
     }
 
-    public function testDegenerateCaseWithNoRowContaining3DistinctGroupsOfSpaces()
+    public function testDegenerateCaseWithNoRowContaining3DistinctGroupsOfSpaces() : void
     {
         $this->assertEquals(
             diamond("B"),
@@ -24,7 +24,7 @@ class DiamondTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSmallestNonDegenerateCaseWithOddDiamondSideLength()
+    public function testSmallestNonDegenerateCaseWithOddDiamondSideLength() : void
     {
         $this->assertEquals(
             diamond("C"),
@@ -38,7 +38,7 @@ class DiamondTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSmallestNonDegenerateCaseWithEvenDiamondSideLength()
+    public function testSmallestNonDegenerateCaseWithEvenDiamondSideLength() : void
     {
         $this->assertEquals(
             diamond("D"),
@@ -54,7 +54,7 @@ class DiamondTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testLargestPossibleDiamond()
+    public function testLargestPossibleDiamond() : void
     {
         $this->assertEquals(
             diamond("Z"),

--- a/exercises/diamond/diamond_test.php
+++ b/exercises/diamond/diamond_test.php
@@ -4,7 +4,7 @@ class DiamondTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'diamond.php';
+        require_once 'diamond.php';
     }
 
     public function testDegenerateCaseWithASingleARow() : void

--- a/exercises/difference-of-squares/difference-of-squares_test.php
+++ b/exercises/difference-of-squares/difference-of-squares_test.php
@@ -4,7 +4,7 @@ class SquaresTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'difference-of-squares.php';
+        require_once 'difference-of-squares.php';
     }
 
     public function testSquareOfSumTo5() : void

--- a/exercises/difference-of-squares/difference-of-squares_test.php
+++ b/exercises/difference-of-squares/difference-of-squares_test.php
@@ -7,47 +7,47 @@ class SquaresTest extends PHPUnit\Framework\TestCase
         require 'difference-of-squares.php';
     }
 
-    public function testSquareOfSumTo5()
+    public function testSquareOfSumTo5() : void
     {
         $this->assertEquals(225, squareOfSum(5));
     }
 
-    public function testSumOfSquaresTo5()
+    public function testSumOfSquaresTo5() : void
     {
         $this->assertEquals(55, sumOfSquares(5));
     }
 
-    public function testDifferenceOfSumTo5()
+    public function testDifferenceOfSumTo5() : void
     {
         $this->assertEquals(170, difference(5));
     }
 
-    public function testSquareOfSumTo10()
+    public function testSquareOfSumTo10() : void
     {
         $this->assertEquals(3025, squareOfSum(10));
     }
 
-    public function testSumOfSquaresTo10()
+    public function testSumOfSquaresTo10() : void
     {
         $this->assertEquals(385, sumOfSquares(10));
     }
 
-    public function testDifferenceOfSumTo10()
+    public function testDifferenceOfSumTo10() : void
     {
         $this->assertEquals(2640, difference(10));
     }
 
-    public function testSquareOfSumTo100()
+    public function testSquareOfSumTo100() : void
     {
         $this->assertEquals(25502500, squareOfSum(100));
     }
 
-    public function testSumOfSquaresTo100()
+    public function testSumOfSquaresTo100() : void
     {
         $this->assertEquals(338350, sumOfSquares(100));
     }
 
-    public function testDifferenceOfSumTo100()
+    public function testDifferenceOfSumTo100() : void
     {
         $this->assertEquals(25164150, difference(100));
     }

--- a/exercises/etl/etl_test.php
+++ b/exercises/etl/etl_test.php
@@ -7,28 +7,28 @@ class TransformTest extends PHPUnit\Framework\TestCase
         require 'etl.php';
     }
 
-    public function testTransformOneValue()
+    public function testTransformOneValue() : void
     {
         $old         = [ '1' => ['A'] ];
         $expected    = [ 'a' => 1 ];
         $this->assertEquals($expected, transform($old));
     }
 
-    public function testTransformMoreValues()
+    public function testTransformMoreValues() : void
     {
         $old         = [ '1' => str_split('AEIOU') ];
         $expected    = [ 'a' => 1, 'e' => 1, 'i' => 1, 'o' => 1, 'u' => 1 ];
         $this->assertEquals($expected, transform($old));
     }
 
-    public function testTransformMoreKeys()
+    public function testTransformMoreKeys() : void
     {
         $old         = [ '1' => str_split('AE'), '2' => str_split('DG') ];
         $expected    = [ 'a' => 1, 'e' => 1, 'd' => 2, 'g' => 2 ];
         $this->assertEquals($expected, transform($old));
     }
 
-    public function testTransformFullDataset()
+    public function testTransformFullDataset() : void
     {
         $old = [
             '1' => str_split('AEIOULNRST'),

--- a/exercises/etl/etl_test.php
+++ b/exercises/etl/etl_test.php
@@ -4,7 +4,7 @@ class TransformTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'etl.php';
+        require_once 'etl.php';
     }
 
     public function testTransformOneValue() : void

--- a/exercises/flatten-array/flatten-array_test.php
+++ b/exercises/flatten-array/flatten-array_test.php
@@ -7,40 +7,40 @@ class FlattenArrayTest extends PHPUnit\Framework\TestCase
         require 'flatten-array.php';
     }
 
-    public function testWithOutNesting()
+    public function testWithOutNesting() : void
     {
         $input = [0, 1, 2];
         $expected = [0, 1, 2];
         $this->assertEquals($expected, flatten($input));
     }
-    public function testArrayWithJustIntegersPresent()
+    public function testArrayWithJustIntegersPresent() : void
     {
         $input = [1, [2, 3, 4, 5, 6, 7], 8];
         $expected = [1, 2, 3, 4, 5, 6, 7, 8];
         $this->assertEquals($expected, flatten($input));
     }
 
-    public function testFiveLevelNesting()
+    public function testFiveLevelNesting() : void
     {
         $input = [0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2];
         $expected = [0, 2, 2, 3, 8, 100, 4, 50, -2];
         $this->assertEquals($expected, flatten($input));
     }
 
-    public function testSixLevelNesting()
+    public function testSixLevelNesting() : void
     {
         $input = [1, [2, [[3]], [4, [[5]]], 6, 7], 8];
         $expected = [1, 2, 3, 4, 5, 6, 7, 8];
         $this->assertEquals($expected, flatten($input));
     }
-    public function testSixLevelNestListWithNullValues()
+    public function testSixLevelNestListWithNullValues() : void
     {
         $input = [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2];
         $expected = [0, 2, 2, 3, 8, 100, -2];
         $this->assertEquals($expected, flatten($input));
     }
 
-    public function testAllValuesInNestedListAreNull()
+    public function testAllValuesInNestedListAreNull() : void
     {
         $input = [null, [[[null]]], null, null, [[null, null], null], null];
         $expected = [];

--- a/exercises/flatten-array/flatten-array_test.php
+++ b/exercises/flatten-array/flatten-array_test.php
@@ -4,7 +4,7 @@ class FlattenArrayTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'flatten-array.php';
+        require_once 'flatten-array.php';
     }
 
     public function testWithOutNesting() : void

--- a/exercises/gigasecond/gigasecond_test.php
+++ b/exercises/gigasecond/gigasecond_test.php
@@ -4,7 +4,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'gigasecond.php';
+        require_once 'gigasecond.php';
     }
 
     public function dateSetup($date) : \DateTimeImmutable

--- a/exercises/gigasecond/gigasecond_test.php
+++ b/exercises/gigasecond/gigasecond_test.php
@@ -7,13 +7,13 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         require 'gigasecond.php';
     }
 
-    public function dateSetup($date)
+    public function dateSetup($date) : \DateTimeImmutable
     {
         $UTC = new DateTimeZone("UTC");
         return new DateTimeImmutable($date, $UTC);
     }
 
-    public function testDate1()
+    public function testDate1() : void
     {
         $date = $this->dateSetup("2011-04-25");
         $gs = from($date);
@@ -21,7 +21,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         $this->assertSame("2043-01-01 01:46:40", $gs->format("Y-m-d H:i:s"));
     }
 
-    public function testDate2()
+    public function testDate2() : void
     {
         $date = $this->dateSetup("1977-06-13");
         $gs = from($date);
@@ -29,7 +29,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         $this->assertSame("2009-02-19 01:46:40", $gs->format("Y-m-d H:i:s"));
     }
 
-    public function testPreUnixEpoch()
+    public function testPreUnixEpoch() : void
     {
         $date = $this->dateSetup("1959-7-19");
         $gs = from($date);
@@ -37,7 +37,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         $this->assertSame("1991-03-27 01:46:40", $gs->format("Y-m-d H:i:s"));
     }
 
-    public function testDateWithTime1()
+    public function testDateWithTime1() : void
     {
         $date = $this->dateSetup("2015-01-24 22:00:00");
         $gs = from($date);
@@ -45,7 +45,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         $this->assertSame("2046-10-02 23:46:40", $gs->format("Y-m-d H:i:s"));
     }
 
-    public function testDateWithTime2()
+    public function testDateWithTime2() : void
     {
         $date = $this->dateSetup("2015-01-24 23:59:59");
         $gs = from($date);
@@ -53,7 +53,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         $this->assertSame("2046-10-03 01:46:39", $gs->format("Y-m-d H:i:s"));
     }
 
-    public function testNoMutation()
+    public function testNoMutation() : void
     {
         $date = $this->dateSetup("2015-01-24");
         $gs = from($date);
@@ -61,7 +61,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         $this->assertNotEquals($date, $gs);
     }
 
-    public function testYourself()
+    public function testYourself() : void
     {
         // Replace the string "your_birthday" with your birthday's datestring
 

--- a/exercises/grade-school/example.php
+++ b/exercises/grade-school/example.php
@@ -4,7 +4,7 @@ class School
 {
     private $students = [];
 
-    public function add($name, $grade)
+    public function add($name, $grade) : void
     {
         $this->students[$grade][] = $name;
     }
@@ -14,7 +14,7 @@ class School
         return (array_key_exists($grade, $this->students) ? $this->students[$grade] : []);
     }
 
-    public function studentsByGradeAlphabetical()
+    public function studentsByGradeAlphabetical() : array
     {
         ksort($this->students);
 

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -11,18 +11,18 @@ class GradeSchoolTest extends TestCase
 
     protected $school;
 
-    protected function setUp(): void
+    protected function setUp() : void
     {
         $this->school = new School();
     }
 
-    public function testAddStudent()
+    public function testAddStudent() : void
     {
         $this->school->add("Claire", 2);
         $this->assertContains('Claire', $this->school->grade(2));
     }
 
-    public function testAddStudentsInSameGrade()
+    public function testAddStudentsInSameGrade() : void
     {
         $this->school->add("Marc", 2);
         $this->school->add("Virginie", 2);
@@ -36,7 +36,7 @@ class GradeSchoolTest extends TestCase
         );
     }
 
-    public function testAddStudentInDifferentGrades()
+    public function testAddStudentInDifferentGrades() : void
     {
         $this->school->add("Marc", 3);
         $this->school->add("Claire", 6);
@@ -47,12 +47,12 @@ class GradeSchoolTest extends TestCase
         $this->assertNotContains('Claire', $this->school->grade(3));
     }
 
-    public function testEmptyGrade()
+    public function testEmptyGrade() : void
     {
         $this->assertEmpty($this->school->grade(1));
     }
 
-    public function testSortSchool()
+    public function testSortSchool() : void
     {
         $this->school->add("Marc", 5);
         $this->school->add("Virginie", 5);

--- a/exercises/grade-school/grade-school_test.php
+++ b/exercises/grade-school/grade-school_test.php
@@ -6,7 +6,7 @@ class GradeSchoolTest extends TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'grade-school.php';
+        require_once 'grade-school.php';
     }
 
     protected $school;

--- a/exercises/grains/grains_test.php
+++ b/exercises/grains/grains_test.php
@@ -1,9 +1,12 @@
 <?php
 
-include_once 'grains.php';
-
 class GrainsTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass() : void
+    {
+        require_once 'grains.php';
+    }
+
     /**
      * PHP integers greater than 2^31 (32-bit systems)
      * or 2^63 (64-bit) are casted to floats.

--- a/exercises/grains/grains_test.php
+++ b/exercises/grains/grains_test.php
@@ -16,63 +16,63 @@ class GrainsTest extends PHPUnit\Framework\TestCase
      * Try to make the solution for virtually any board size.
      */
 
-    public function testInput1()
+    public function testInput1() : void
     {
         $this->assertSame('1', square(1));
     }
 
-    public function testInput2()
+    public function testInput2() : void
     {
         $this->assertSame('2', square(2));
     }
 
-    public function testInput3()
+    public function testInput3() : void
     {
         $this->assertSame('4', square(3));
     }
 
-    public function testInput4()
+    public function testInput4() : void
     {
         $this->assertSame('8', square(4));
     }
 
-    public function testInput16()
+    public function testInput16() : void
     {
         $this->assertSame('32768', square(16));
     }
 
-    public function testInput32()
+    public function testInput32() : void
     {
         $this->assertSame('2147483648', square(32));
     }
 
-    public function testInput64()
+    public function testInput64() : void
     {
         $this->assertSame('9223372036854775808', square(64));
     }
 
-    public function testRejectsZero()
+    public function testRejectsZero() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
         square(0);
     }
 
-    public function testRejectsNegative()
+    public function testRejectsNegative() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
         square(-1);
     }
 
-    public function testRejectsGreaterThan64()
+    public function testRejectsGreaterThan64() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
         square(65);
     }
 
-    public function testTotal()
+    public function testTotal() : void
     {
         $this->assertSame('18446744073709551615', total());
     }

--- a/exercises/hamming/hamming.php
+++ b/exercises/hamming/hamming.php
@@ -7,7 +7,7 @@ convenience to get you started writing code faster.
 Remove this comment before submitting your exercise.
 */
 
-function distance(string $strandA, string $strandB): int
+function distance(string $strandA, string $strandB) : int
 {
     //
     // YOUR CODE GOES HERE

--- a/exercises/hamming/hamming_test.php
+++ b/exercises/hamming/hamming_test.php
@@ -7,42 +7,42 @@ class HammingComparatorTest extends PHPUnit\Framework\TestCase
         require 'hamming.php';
     }
 
-    public function testNoDifferenceBetweenIdenticalStrands()
+    public function testNoDifferenceBetweenIdenticalStrands() : void
     {
         $this->assertEquals(0, distance('A', 'A'));
     }
 
-    public function testCompleteHammingDistanceOfForSingleNucleotideStrand()
+    public function testCompleteHammingDistanceOfForSingleNucleotideStrand() : void
     {
         $this->assertEquals(1, distance('A', 'G'));
     }
 
-    public function testCompleteHammingDistanceForSmallStrand()
+    public function testCompleteHammingDistanceForSmallStrand() : void
     {
         $this->assertEquals(2, distance('AG', 'CT'));
     }
 
-    public function testSmallHammingDistance()
+    public function testSmallHammingDistance() : void
     {
         $this->assertEquals(1, distance('AT', 'CT'));
     }
 
-    public function testSmallHammingDistanceInLongerStrand()
+    public function testSmallHammingDistanceInLongerStrand() : void
     {
         $this->assertEquals(1, distance('GGACG', 'GGTCG'));
     }
 
-    public function testLargeHammingDistance()
+    public function testLargeHammingDistance() : void
     {
         $this->assertEquals(4, distance('GATACA', 'GCATAA'));
     }
 
-    public function testHammingDistanceInVeryLongStrand()
+    public function testHammingDistanceInVeryLongStrand() : void
     {
         $this->assertEquals(9, distance('GGACGGATTCTG', 'AGGACGGATTCT'));
     }
 
-    public function testExceptionThrownWhenStrandsAreDifferentLength()
+    public function testExceptionThrownWhenStrandsAreDifferentLength() : void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('DNA strands must be of equal length.');

--- a/exercises/hamming/hamming_test.php
+++ b/exercises/hamming/hamming_test.php
@@ -4,7 +4,7 @@ class HammingComparatorTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'hamming.php';
+        require_once 'hamming.php';
     }
 
     public function testNoDifferenceBetweenIdenticalStrands() : void

--- a/exercises/hello-world/hello-world_test.php
+++ b/exercises/hello-world/hello-world_test.php
@@ -4,7 +4,7 @@ class HelloWorldTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'hello-world.php';
+        require_once 'hello-world.php';
     }
 
     public function testHelloWorld() : void

--- a/exercises/hello-world/hello-world_test.php
+++ b/exercises/hello-world/hello-world_test.php
@@ -7,7 +7,7 @@ class HelloWorldTest extends PHPUnit\Framework\TestCase
         require 'hello-world.php';
     }
 
-    public function testHelloWorld()
+    public function testHelloWorld() : void
     {
         $this->assertEquals('Hello, World!', helloWorld());
     }

--- a/exercises/isogram/isogram_test.php
+++ b/exercises/isogram/isogram_test.php
@@ -7,52 +7,52 @@ class IsogramTest extends PHPUnit\Framework\TestCase
         require 'isogram.php';
     }
 
-    public function testIsogram()
+    public function testIsogram() : void
     {
         $this->assertTrue(isIsogram('duplicates'));
     }
 
-    public function testNotIsogram()
+    public function testNotIsogram() : void
     {
         $this->assertFalse(isIsogram('eleven'));
     }
 
-    public function testMediumLongIsogram()
+    public function testMediumLongIsogram() : void
     {
         $this->assertTrue(isIsogram('subdermatoglyphic'));
     }
 
-    public function testCaseInsensitive()
+    public function testCaseInsensitive() : void
     {
         $this->assertFalse(isIsogram('Alphabet'));
     }
 
-    public function testIsogramWithHyphen()
+    public function testIsogramWithHyphen() : void
     {
         $this->assertTrue(isIsogram('thumbscrew-japingly'));
     }
 
-    public function testIgnoresMultipleHyphens()
+    public function testIgnoresMultipleHyphens() : void
     {
         $this->assertTrue(isIsogram('Hjelmqvist-Gryb-Zock-Pfund-Wax'));
     }
 
-    public function testWorksWithGermanLetters()
+    public function testWorksWithGermanLetters() : void
     {
         $this->assertTrue(isIsogram('Heizölrückstoßabdämpfung'));
     }
 
-    public function testIgnoresSpaces()
+    public function testIgnoresSpaces() : void
     {
         $this->assertFalse(isIsogram('the quick brown fox'));
     }
 
-    public function testIgnoresSpaces2()
+    public function testIgnoresSpaces2() : void
     {
         $this->assertTrue(isIsogram('Emily Jung Schwartzkopf'));
     }
 
-    public function testDuplicateAccentedLetters()
+    public function testDuplicateAccentedLetters() : void
     {
         $this->assertFalse(isIsogram('éléphant'));
     }

--- a/exercises/isogram/isogram_test.php
+++ b/exercises/isogram/isogram_test.php
@@ -4,7 +4,7 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'isogram.php';
+        require_once 'isogram.php';
     }
 
     public function testIsogram() : void

--- a/exercises/largest-series-product/example.php
+++ b/exercises/largest-series-product/example.php
@@ -2,7 +2,6 @@
 
 class Series
 {
-
     /**
      * The the digits to test
      *
@@ -36,7 +35,7 @@ class Series
      * @param int $span
      * @return int
      */
-    public function largestProduct($span)
+    public function largestProduct($span) : int
     {
         if (0 == $span) {
             return 1;
@@ -53,7 +52,7 @@ class Series
      * @param int $span
      * @throws InvalidArgumentException
      */
-    private function validateSpan($span)
+    private function validateSpan($span) : void
     {
         if ($span < 0) {
             throw new InvalidArgumentException(sprintf(
@@ -77,7 +76,7 @@ class Series
      * @param int $span
      * @return int
      */
-    private function largestSeriesProduct($span)
+    private function largestSeriesProduct($span) : int
     {
         $products = [];
         for ($start = 0; $start <= $this->sequenceLength - $span; $start++) {
@@ -86,14 +85,13 @@ class Series
         return max($products);
     }
 
-
     /**
      * Multiplies a numerical string section
      *
      * @param string $stringSection
      * @return int
      */
-    private function multiplyStringSection($stringSection)
+    private function multiplyStringSection($stringSection) : int
     {
         return array_product(str_split($stringSection));
     }
@@ -104,7 +102,7 @@ class Series
      * @param $digits
      * @throws InvalidArgumentException
      */
-    private function validateSequence($digits)
+    private function validateSequence($digits) : void
     {
         if (! empty($digits) && ! is_numeric($digits)) {
             throw new InvalidArgumentException(sprintf(

--- a/exercises/largest-series-product/largest-series-product_test.php
+++ b/exercises/largest-series-product/largest-series-product_test.php
@@ -9,7 +9,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
      * We will deal with the series of digits as strings to avoid having them cast to floats.
      */
 
-    public function testCanFindTheLargestProductOf2WithNumbersInOrder()
+    public function testCanFindTheLargestProductOf2WithNumbersInOrder() : void
     {
         // The number starts with a 0, qualifying it to be an octal
         // So it needs to be a string so PHP doesn't complain
@@ -17,43 +17,43 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(72, $series->largestProduct(2));
     }
 
-    public function testCanFindTheLargestProductOf2()
+    public function testCanFindTheLargestProductOf2() : void
     {
         $series = new Series(576802143);
         $this->assertEquals(48, $series->largestProduct(2));
     }
 
-    public function testFindsTheLargestProductIfSpanEqualsLength()
+    public function testFindsTheLargestProductIfSpanEqualsLength() : void
     {
         $series = new Series(29);
         $this->assertEquals(18, $series->largestProduct(2));
     }
 
-    public function testCanFindTheLargestProductOf3WithNumbersInOrder()
+    public function testCanFindTheLargestProductOf3WithNumbersInOrder() : void
     {
         $series = new Series(123456789);
         $this->assertEquals(504, $series->largestProduct(3));
     }
 
-    public function testCanFindTheLargestProductOf3()
+    public function testCanFindTheLargestProductOf3() : void
     {
         $series = new Series(1027839564);
         $this->assertEquals(270, $series->largestProduct(3));
     }
 
-    public function testCanFindTheLargestProductOf5WithNumbersInOrder()
+    public function testCanFindTheLargestProductOf5WithNumbersInOrder() : void
     {
         $series = new Series("0123456789");
         $this->assertEquals(15120, $series->largestProduct(5));
     }
 
-    public function testCanGetTheLargestProductOfABigNumber()
+    public function testCanGetTheLargestProductOfABigNumber() : void
     {
         $series = new Series("73167176531330624919225119674426574742355349194934");
         $this->assertEquals(23520, $series->largestProduct(6));
     }
 
-    public function testCanGetTheLargestProductOfABigNumberProjectEuler()
+    public function testCanGetTheLargestProductOfABigNumberProjectEuler() : void
     {
         $digits = "731671765313306249192251196744265747423553491949349698352031277450632623957831801698480186947"
             . "8851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096"
@@ -71,19 +71,19 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(23514624000, $series->largestProduct(13));
     }
 
-    public function testReportsZeroIfTheOnlyDigitsAreZero()
+    public function testReportsZeroIfTheOnlyDigitsAreZero() : void
     {
         $series = new Series("0000");
         $this->assertEquals(0, $series->largestProduct(2));
     }
 
-    public function testReportsZeroIfAllSpansIncludeZero()
+    public function testReportsZeroIfAllSpansIncludeZero() : void
     {
         $series = new Series(99099);
         $this->assertEquals(0, $series->largestProduct(3));
     }
 
-    public function testRejectsSpanLongerThanStringLength()
+    public function testRejectsSpanLongerThanStringLength() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -106,7 +106,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
      * So LSP('123', 4) errors and LSP('', 0) does NOT
      *
      */
-    public function testReports1ForEmptyStringAndEmptyProduct0Span()
+    public function testReports1ForEmptyStringAndEmptyProduct0Span() : void
     {
         $series = new Series("");
         $this->assertEquals(1, $series->largestProduct(0));
@@ -116,13 +116,13 @@ class SeriesTest extends PHPUnit\Framework\TestCase
      * As above, there is one 0-character string in '123'.
      * So again no error. It's the empty product, 1.
      */
-    public function testReports1ForNonemptyStringAndEmptyProduct0Span()
+    public function testReports1ForNonemptyStringAndEmptyProduct0Span() : void
     {
         $series = new Series("123");
         $this->assertEquals(1, $series->largestProduct(0));
     }
 
-    public function testRejectsEmptyStringAndNonzeroSpan()
+    public function testRejectsEmptyStringAndNonzeroSpan() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -130,7 +130,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $series->largestProduct(1);
     }
 
-    public function testRejectsInvalidCharacterInDigits()
+    public function testRejectsInvalidCharacterInDigits() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -138,7 +138,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         $series->largestProduct(2);
     }
 
-    public function testRejectsNegativeSpan()
+    public function testRejectsNegativeSpan() : void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/exercises/largest-series-product/largest-series-product_test.php
+++ b/exercises/largest-series-product/largest-series-product_test.php
@@ -1,9 +1,12 @@
 <?php
 
-include_once 'largest-series-product.php';
-
 class SeriesTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass() : void
+    {
+        require_once 'largest-series-product.php';
+    }
+
     /**
      * Since PHP can only support Integers between +/- 9223372036854775807
      * We will deal with the series of digits as strings to avoid having them cast to floats.

--- a/exercises/leap/leap_test.php
+++ b/exercises/leap/leap_test.php
@@ -7,27 +7,27 @@ class YearTest extends PHPUnit\Framework\TestCase
         require 'leap.php';
     }
 
-    public function testLeapYear()
+    public function testLeapYear() : void
     {
         $this->assertTrue(isLeap(1996));
     }
 
-    public function testNonLeapYear()
+    public function testNonLeapYear() : void
     {
         $this->assertFalse(isLeap(1997));
     }
 
-    public function testNonLeapEvenYear()
+    public function testNonLeapEvenYear() : void
     {
         $this->assertFalse(isLeap(1998));
     }
 
-    public function testCentury()
+    public function testCentury() : void
     {
         $this->assertFalse(isLeap(1900));
     }
 
-    public function testFourthCentury()
+    public function testFourthCentury() : void
     {
         $this->assertTrue(isLeap(2400));
     }

--- a/exercises/leap/leap_test.php
+++ b/exercises/leap/leap_test.php
@@ -4,7 +4,7 @@ class YearTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'leap.php';
+        require_once 'leap.php';
     }
 
     public function testLeapYear() : void

--- a/exercises/luhn/luhn_test.php
+++ b/exercises/luhn/luhn_test.php
@@ -7,72 +7,72 @@ class LuhnValidatorTest extends PHPUnit\Framework\TestCase
         require 'luhn.php';
     }
 
-    public function testSingleDigitInvalid()
+    public function testSingleDigitInvalid() : void
     {
         $this->assertFalse(isValid("1"));
     }
 
-    public function testSingleZeroInvalid()
+    public function testSingleZeroInvalid() : void
     {
         $this->assertFalse(isValid("0"));
     }
 
-    public function testSimpleValidNumber()
+    public function testSimpleValidNumber() : void
     {
         $this->assertTrue(isValid("59"));
     }
 
-    public function testSpaceHandling()
+    public function testSpaceHandling() : void
     {
         $this->assertTrue(isValid(" 5 9 "));
     }
 
-    public function testValidCanadianSocialInsuranceNumber()
+    public function testValidCanadianSocialInsuranceNumber() : void
     {
         $this->assertTrue(isValid("046 454 286"));
     }
 
-    public function testInvalidCanadianSocialInsuranceNumber()
+    public function testInvalidCanadianSocialInsuranceNumber() : void
     {
         $this->assertFalse(isValid("046 454 287"));
     }
 
-    public function testInvalidCreditCard()
+    public function testInvalidCreditCard() : void
     {
         $this->assertFalse(isValid("8273 1232 7352 0569"));
     }
 
-    public function testNonDigitCharacterInValidStringInvalidatesTheString()
+    public function testNonDigitCharacterInValidStringInvalidatesTheString() : void
     {
         $this->assertFalse(isValid("046a 454 286"));
     }
 
-    public function testThatStringContainingSymbolsIsInvalid()
+    public function testThatStringContainingSymbolsIsInvalid() : void
     {
         $this->assertFalse(isValid("055£ 444$ 285"));
     }
 
-    public function testThatStringContainingPunctuationIsInvalid()
+    public function testThatStringContainingPunctuationIsInvalid() : void
     {
         $this->assertFalse(isValid("055-444-285"));
     }
 
-    public function testSpaceAndSingleZeroIsInvalid()
+    public function testSpaceAndSingleZeroIsInvalid() : void
     {
         $this->assertFalse(isValid(" 0"));
     }
 
-    public function testMultipleZerosIsValid()
+    public function testMultipleZerosIsValid() : void
     {
         $this->assertTrue(isValid(" 00000"));
     }
 
-    public function testThatDoublingNineIsHandledCorrectly()
+    public function testThatDoublingNineIsHandledCorrectly() : void
     {
         $this->assertTrue(isValid("091"));
     }
 
-    public function testThatStringContainingSymbolsWhichCouldBeZeroIsInvalid()
+    public function testThatStringContainingSymbolsWhichCouldBeZeroIsInvalid() : void
     {
         $this->assertFalse(isValid(" ABCDEF"));
     }

--- a/exercises/luhn/luhn_test.php
+++ b/exercises/luhn/luhn_test.php
@@ -4,7 +4,7 @@ class LuhnValidatorTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'luhn.php';
+        require_once 'luhn.php';
     }
 
     public function testSingleDigitInvalid() : void

--- a/exercises/markdown/markdown_test.php
+++ b/exercises/markdown/markdown_test.php
@@ -7,42 +7,42 @@ class MarkdownTest extends PHPUnit\Framework\TestCase
         require 'markdown.php';
     }
 
-    public function testParsingParagraph()
+    public function testParsingParagraph() : void
     {
         $this->assertEquals('<p>This will be a paragraph</p>', parseMarkdown('This will be a paragraph'));
     }
 
-    public function testParsingItalics()
+    public function testParsingItalics() : void
     {
         $this->assertEquals('<p><i>This will be italic</i></p>', parseMarkdown('_This will be italic_'));
     }
 
-    public function testParsingBoldText()
+    public function testParsingBoldText() : void
     {
         $this->assertEquals('<p><em>This will be bold</em></p>', parseMarkdown('__This will be bold__'));
     }
 
-    public function testMixedNormalItalicsAndBoldText()
+    public function testMixedNormalItalicsAndBoldText() : void
     {
         $this->assertEquals('<p>This will <i>be</i> <em>mixed</em></p>', parseMarkdown('This will _be_ __mixed__'));
     }
 
-    public function testWithH1Headerlevel()
+    public function testWithH1Headerlevel() : void
     {
         $this->assertEquals('<h1>This will be an h1</h1>', parseMarkdown('# This will be an h1'));
     }
 
-    public function testWithH2Headerlevel()
+    public function testWithH2Headerlevel() : void
     {
         $this->assertEquals('<h2>This will be an h2</h2>', parseMarkdown('## This will be an h2'));
     }
 
-    public function testWithH6Headerlevel()
+    public function testWithH6Headerlevel() : void
     {
         $this->assertEquals('<h6>This will be an h6</h6>', parseMarkdown('###### This will be an h6'));
     }
 
-    public function testUnorderedLists()
+    public function testUnorderedLists() : void
     {
         $this->assertEquals(
             '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li></ul>',
@@ -50,7 +50,7 @@ class MarkdownTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testWithALittleBitOfEverything()
+    public function testWithALittleBitOfEverything() : void
     {
         $this->assertEquals(
             '<h1>Header!</h1><ul><li><em>Bold Item</em></li><li><i>Italic Item</i></li></ul>',

--- a/exercises/markdown/markdown_test.php
+++ b/exercises/markdown/markdown_test.php
@@ -4,7 +4,7 @@ class MarkdownTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'markdown.php';
+        require_once 'markdown.php';
     }
 
     public function testParsingParagraph() : void

--- a/exercises/matching-brackets/matching-brackets_test.php
+++ b/exercises/matching-brackets/matching-brackets_test.php
@@ -7,67 +7,67 @@ class BracketTest extends PHPUnit\Framework\TestCase
         require 'matching-brackets.php';
     }
 
-    public function testPairedSquareBrackets()
+    public function testPairedSquareBrackets() : void
     {
         $this->assertTrue(brackets_match('[]'));
     }
 
-    public function testEmptyString()
+    public function testEmptyString() : void
     {
         $this->assertTrue(brackets_match(''));
     }
 
-    public function testUnpairedBrackets()
+    public function testUnpairedBrackets() : void
     {
         $this->assertFalse(brackets_match('[['));
     }
 
-    public function testWrongOrderedBrackets()
+    public function testWrongOrderedBrackets() : void
     {
         $this->assertFalse(brackets_match('}{'));
     }
 
-    public function testPairedWithWhitespace()
+    public function testPairedWithWhitespace() : void
     {
         $this->assertTrue(brackets_match('{ }'));
     }
 
-    public function testSimpleNestedBrackets()
+    public function testSimpleNestedBrackets() : void
     {
         $this->assertTrue(brackets_match('{[]}'));
     }
 
-    public function testSeveralPairedBrackets()
+    public function testSeveralPairedBrackets() : void
     {
         $this->assertTrue(brackets_match('{}[]'));
     }
 
-    public function testPairedAndNestedBrackets()
+    public function testPairedAndNestedBrackets() : void
     {
         $this->assertTrue(brackets_match('([{}({}[])])'));
     }
 
-    public function testUnopenedClosingBrackets()
+    public function testUnopenedClosingBrackets() : void
     {
         $this->assertFalse(brackets_match('{[)][]}'));
     }
 
-    public function testUnpairedAndNestedBrackets()
+    public function testUnpairedAndNestedBrackets() : void
     {
         $this->assertFalse(brackets_match('([{])'));
     }
 
-    public function testPairedAndWrongNestedBrackets()
+    public function testPairedAndWrongNestedBrackets() : void
     {
         $this->assertFalse(brackets_match('[({]})'));
     }
 
-    public function testMathExpression()
+    public function testMathExpression() : void
     {
         $this->assertTrue(brackets_match('(((185 + 223.85) * 15) - 543)/2'));
     }
 
-    public function testComplexLatexExpression()
+    public function testComplexLatexExpression() : void
     {
         $this->assertTrue(brackets_match(
             "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ "

--- a/exercises/matching-brackets/matching-brackets_test.php
+++ b/exercises/matching-brackets/matching-brackets_test.php
@@ -4,7 +4,7 @@ class BracketTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'matching-brackets.php';
+        require_once 'matching-brackets.php';
     }
 
     public function testPairedSquareBrackets() : void

--- a/exercises/meetup/meetup_test.php
+++ b/exercises/meetup/meetup_test.php
@@ -4,7 +4,7 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'meetup.php';
+        require_once 'meetup.php';
     }
 
     public function testMonteenthOfMay2013() : void

--- a/exercises/meetup/meetup_test.php
+++ b/exercises/meetup/meetup_test.php
@@ -7,477 +7,477 @@ class MeetupTest extends PHPUnit\Framework\TestCase
         require 'meetup.php';
     }
 
-    public function testMonteenthOfMay2013()
+    public function testMonteenthOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "teenth", "Monday"), new DateTimeImmutable("2013/5/13"));
     }
 
-    public function testMonteenthOfAugust2013()
+    public function testMonteenthOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "teenth", "Monday"), new DateTimeImmutable("2013/8/19"));
     }
 
-    public function testMonteenthOfSeptember2013()
+    public function testMonteenthOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "teenth", "Monday"), new DateTimeImmutable("2013/9/16"));
     }
 
-    public function testTuesteenthOfMarch2013()
+    public function testTuesteenthOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "teenth", "Tuesday"), new DateTimeImmutable("2013/3/19"));
     }
 
-    public function testTuesteenthOfApril2013()
+    public function testTuesteenthOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "teenth", "Tuesday"), new DateTimeImmutable("2013/4/16"));
     }
 
-    public function testTuesteenthOfAugust2013()
+    public function testTuesteenthOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "teenth", "Tuesday"), new DateTimeImmutable("2013/8/13"));
     }
 
-    public function testWednesteenthOfJanuary2013()
+    public function testWednesteenthOfJanuary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 1, "teenth", "Wednesday"), new DateTimeImmutable("2013/1/16"));
     }
 
-    public function testWednesteenthOfFebruary2013()
+    public function testWednesteenthOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "teenth", "Wednesday"), new DateTimeImmutable("2013/2/13"));
     }
 
-    public function testWednesteenthOfJune2013()
+    public function testWednesteenthOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "teenth", "Wednesday"), new DateTimeImmutable("2013/6/19"));
     }
 
-    public function testThursteenthOfMay2013()
+    public function testThursteenthOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "teenth", "Thursday"), new DateTimeImmutable("2013/5/16"));
     }
 
-    public function testThursteenthOfJune2013()
+    public function testThursteenthOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "teenth", "Thursday"), new DateTimeImmutable("2013/6/13"));
     }
 
-    public function testThursteenthOfSeptember2013()
+    public function testThursteenthOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "teenth", "Thursday"), new DateTimeImmutable("2013/9/19"));
     }
 
-    public function testFriteenthOfApril2013()
+    public function testFriteenthOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "teenth", "Friday"), new DateTimeImmutable("2013/4/19"));
     }
 
-    public function testFriteenthOfAugust2013()
+    public function testFriteenthOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "teenth", "Friday"), new DateTimeImmutable("2013/8/16"));
     }
 
-    public function testFriteenthOfSeptember2013()
+    public function testFriteenthOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "teenth", "Friday"), new DateTimeImmutable("2013/9/13"));
     }
 
-    public function testSaturteenthOfFebruary2013()
+    public function testSaturteenthOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "teenth", "Saturday"), new DateTimeImmutable("2013/2/16"));
     }
 
-    public function testSaturteenthOfApril2013()
+    public function testSaturteenthOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "teenth", "Saturday"), new DateTimeImmutable("2013/4/13"));
     }
 
-    public function testSaturteenthOfOctober2013()
+    public function testSaturteenthOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "teenth", "Saturday"), new DateTimeImmutable("2013/10/19"));
     }
 
-    public function testSunteenthOfMay2013()
+    public function testSunteenthOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "teenth", "Sunday"), new DateTimeImmutable("2013/5/19"));
     }
 
-    public function testSunteenthOfJune2013()
+    public function testSunteenthOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "teenth", "Sunday"), new DateTimeImmutable("2013/6/16"));
     }
 
-    public function testSunteenthOfOctober2013()
+    public function testSunteenthOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "teenth", "Sunday"), new DateTimeImmutable("2013/10/13"));
     }
 
-    public function testFirstMondayOfMarch2013()
+    public function testFirstMondayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "first", "Monday"), new DateTimeImmutable("2013/3/4"));
     }
 
-    public function testFirstMondayOfApril2013()
+    public function testFirstMondayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "first", "Monday"), new DateTimeImmutable("2013/4/1"));
     }
 
-    public function testFirstTuesdayOfMay2013()
+    public function testFirstTuesdayOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "first", "Tuesday"), new DateTimeImmutable("2013/5/7"));
     }
 
-    public function testFirstTuesdayOfJune2013()
+    public function testFirstTuesdayOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "first", "Tuesday"), new DateTimeImmutable("2013/6/4"));
     }
 
-    public function testFirstWednesdayOfJuly2013()
+    public function testFirstWednesdayOfJuly2013() : void
     {
         $this->assertEquals(meetup_day(2013, 7, "first", "Wednesday"), new DateTimeImmutable("2013/7/3"));
     }
 
-    public function testFirstWednesdayOfAugust2013()
+    public function testFirstWednesdayOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "first", "Wednesday"), new DateTimeImmutable("2013/8/7"));
     }
 
-    public function testFirstThursdayOfSeptember2013()
+    public function testFirstThursdayOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "first", "Thursday"), new DateTimeImmutable("2013/9/5"));
     }
 
-    public function testFirstThursdayOfOctober2013()
+    public function testFirstThursdayOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "first", "Thursday"), new DateTimeImmutable("2013/10/3"));
     }
 
-    public function testFirstFridayOfNovember2013()
+    public function testFirstFridayOfNovember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 11, "first", "Friday"), new DateTimeImmutable("2013/11/1"));
     }
 
-    public function testFirstFridayOfDecember2013()
+    public function testFirstFridayOfDecember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 12, "first", "Friday"), new DateTimeImmutable("2013/12/6"));
     }
 
-    public function testFirstSaturdayOfJanuary2013()
+    public function testFirstSaturdayOfJanuary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 1, "first", "Saturday"), new DateTimeImmutable("2013/1/5"));
     }
 
-    public function testFirstSaturdayOfFebruary2013()
+    public function testFirstSaturdayOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "first", "Saturday"), new DateTimeImmutable("2013/2/2"));
     }
 
-    public function testFirstSundayOfMarch2013()
+    public function testFirstSundayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "first", "Sunday"), new DateTimeImmutable("2013/3/3"));
     }
 
-    public function testFirstSundayOfApril2013()
+    public function testFirstSundayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "first", "Sunday"), new DateTimeImmutable("2013/4/7"));
     }
 
-    public function testSecondMondayOfMarch2013()
+    public function testSecondMondayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "second", "Monday"), new DateTimeImmutable("2013/3/11"));
     }
 
-    public function testSecondMondayOfApril2013()
+    public function testSecondMondayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "second", "Monday"), new DateTimeImmutable("2013/4/8"));
     }
 
-    public function testSecondTuesdayOfMay2013()
+    public function testSecondTuesdayOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "second", "Tuesday"), new DateTimeImmutable("2013/5/14"));
     }
 
-    public function testSecondTuesdayOfJune2013()
+    public function testSecondTuesdayOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "second", "Tuesday"), new DateTimeImmutable("2013/6/11"));
     }
 
-    public function testSecondWednesdayOfJuly2013()
+    public function testSecondWednesdayOfJuly2013() : void
     {
         $this->assertEquals(meetup_day(2013, 7, "second", "Wednesday"), new DateTimeImmutable("2013/7/10"));
     }
 
-    public function testSecondWednesdayOfAugust2013()
+    public function testSecondWednesdayOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "second", "Wednesday"), new DateTimeImmutable("2013/8/14"));
     }
 
-    public function testSecondThursdayOfSeptember2013()
+    public function testSecondThursdayOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "second", "Thursday"), new DateTimeImmutable("2013/9/12"));
     }
 
-    public function testSecondThursdayOfOctober2013()
+    public function testSecondThursdayOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "second", "Thursday"), new DateTimeImmutable("2013/10/10"));
     }
 
-    public function testSecondFridayOfNovember2013()
+    public function testSecondFridayOfNovember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 11, "second", "Friday"), new DateTimeImmutable("2013/11/8"));
     }
 
-    public function testSecondFridayOfDecember2013()
+    public function testSecondFridayOfDecember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 12, "second", "Friday"), new DateTimeImmutable("2013/12/13"));
     }
 
-    public function testSecondSaturdayOfJanuary2013()
+    public function testSecondSaturdayOfJanuary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 1, "second", "Saturday"), new DateTimeImmutable("2013/1/12"));
     }
 
-    public function testSecondSaturdayOfFebruary2013()
+    public function testSecondSaturdayOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "second", "Saturday"), new DateTimeImmutable("2013/2/9"));
     }
 
-    public function testSecondSundayOfMarch2013()
+    public function testSecondSundayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "second", "Sunday"), new DateTimeImmutable("2013/3/10"));
     }
 
-    public function testSecondSundayOfApril2013()
+    public function testSecondSundayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "second", "Sunday"), new DateTimeImmutable("2013/4/14"));
     }
 
-    public function testThirdMondayOfMarch2013()
+    public function testThirdMondayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "third", "Monday"), new DateTimeImmutable("2013/3/18"));
     }
 
-    public function testThirdMondayOfApril2013()
+    public function testThirdMondayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "third", "Monday"), new DateTimeImmutable("2013/4/15"));
     }
 
-    public function testThirdTuesdayOfMay2013()
+    public function testThirdTuesdayOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "third", "Tuesday"), new DateTimeImmutable("2013/5/21"));
     }
 
-    public function testThirdTuesdayOfJune2013()
+    public function testThirdTuesdayOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "third", "Tuesday"), new DateTimeImmutable("2013/6/18"));
     }
 
-    public function testThirdWednesdayOfJuly2013()
+    public function testThirdWednesdayOfJuly2013() : void
     {
         $this->assertEquals(meetup_day(2013, 7, "third", "Wednesday"), new DateTimeImmutable("2013/7/17"));
     }
 
-    public function testThirdWednesdayOfAugust2013()
+    public function testThirdWednesdayOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "third", "Wednesday"), new DateTimeImmutable("2013/8/21"));
     }
 
-    public function testThirdThursdayOfSeptember2013()
+    public function testThirdThursdayOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "third", "Thursday"), new DateTimeImmutable("2013/9/19"));
     }
 
-    public function testThirdThursdayOfOctober2013()
+    public function testThirdThursdayOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "third", "Thursday"), new DateTimeImmutable("2013/10/17"));
     }
 
-    public function testThirdFridayOfNovember2013()
+    public function testThirdFridayOfNovember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 11, "third", "Friday"), new DateTimeImmutable("2013/11/15"));
     }
 
-    public function testThirdFridayOfDecember2013()
+    public function testThirdFridayOfDecember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 12, "third", "Friday"), new DateTimeImmutable("2013/12/20"));
     }
 
-    public function testThirdSaturdayOfJanuary2013()
+    public function testThirdSaturdayOfJanuary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 1, "third", "Saturday"), new DateTimeImmutable("2013/1/19"));
     }
 
-    public function testThirdSaturdayOfFebruary2013()
+    public function testThirdSaturdayOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "third", "Saturday"), new DateTimeImmutable("2013/2/16"));
     }
 
-    public function testThirdSundayOfMarch2013()
+    public function testThirdSundayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "third", "Sunday"), new DateTimeImmutable("2013/3/17"));
     }
 
-    public function testThirdSundayOfApril2013()
+    public function testThirdSundayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "third", "Sunday"), new DateTimeImmutable("2013/4/21"));
     }
 
-    public function testFourthMondayOfMarch2013()
+    public function testFourthMondayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "fourth", "Monday"), new DateTimeImmutable("2013/3/25"));
     }
 
-    public function testFourthMondayOfApril2013()
+    public function testFourthMondayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "fourth", "Monday"), new DateTimeImmutable("2013/4/22"));
     }
 
-    public function testFourthTuesdayOfMay2013()
+    public function testFourthTuesdayOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "fourth", "Tuesday"), new DateTimeImmutable("2013/5/28"));
     }
 
-    public function testFourthTuesdayOfJune2013()
+    public function testFourthTuesdayOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "fourth", "Tuesday"), new DateTimeImmutable("2013/6/25"));
     }
 
-    public function testFourthWednesdayOfJuly2013()
+    public function testFourthWednesdayOfJuly2013() : void
     {
         $this->assertEquals(meetup_day(2013, 7, "fourth", "Wednesday"), new DateTimeImmutable("2013/7/24"));
     }
 
-    public function testFourthWednesdayOfAugust2013()
+    public function testFourthWednesdayOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "fourth", "Wednesday"), new DateTimeImmutable("2013/8/28"));
     }
 
-    public function testFourthThursdayOfSeptember2013()
+    public function testFourthThursdayOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "fourth", "Thursday"), new DateTimeImmutable("2013/9/26"));
     }
 
-    public function testFourthThursdayOfOctober2013()
+    public function testFourthThursdayOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "fourth", "Thursday"), new DateTimeImmutable("2013/10/24"));
     }
 
-    public function testFourthFridayOfNovember2013()
+    public function testFourthFridayOfNovember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 11, "fourth", "Friday"), new DateTimeImmutable("2013/11/22"));
     }
 
-    public function testFourthFridayOfDecember2013()
+    public function testFourthFridayOfDecember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 12, "fourth", "Friday"), new DateTimeImmutable("2013/12/27"));
     }
 
-    public function testFourthSaturdayOfJanuary2013()
+    public function testFourthSaturdayOfJanuary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 1, "fourth", "Saturday"), new DateTimeImmutable("2013/1/26"));
     }
 
-    public function testFourthSaturdayOfFebruary2013()
+    public function testFourthSaturdayOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "fourth", "Saturday"), new DateTimeImmutable("2013/2/23"));
     }
 
-    public function testFourthSundayOfMarch2013()
+    public function testFourthSundayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "fourth", "Sunday"), new DateTimeImmutable("2013/3/24"));
     }
 
-    public function testFourthSundayOfApril2013()
+    public function testFourthSundayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "fourth", "Sunday"), new DateTimeImmutable("2013/4/28"));
     }
 
-    public function testLastMondayOfMarch2013()
+    public function testLastMondayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "last", "Monday"), new DateTimeImmutable("2013/3/25"));
     }
 
-    public function testLastMondayOfApril2013()
+    public function testLastMondayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "last", "Monday"), new DateTimeImmutable("2013/4/29"));
     }
 
-    public function testLastTuesdayOfMay2013()
+    public function testLastTuesdayOfMay2013() : void
     {
         $this->assertEquals(meetup_day(2013, 5, "last", "Tuesday"), new DateTimeImmutable("2013/5/28"));
     }
 
-    public function testLastTuesdayOfJune2013()
+    public function testLastTuesdayOfJune2013() : void
     {
         $this->assertEquals(meetup_day(2013, 6, "last", "Tuesday"), new DateTimeImmutable("2013/6/25"));
     }
 
-    public function testLastWednesdayOfJuly2013()
+    public function testLastWednesdayOfJuly2013() : void
     {
         $this->assertEquals(meetup_day(2013, 7, "last", "Wednesday"), new DateTimeImmutable("2013/7/31"));
     }
 
-    public function testLastWednesdayOfAugust2013()
+    public function testLastWednesdayOfAugust2013() : void
     {
         $this->assertEquals(meetup_day(2013, 8, "last", "Wednesday"), new DateTimeImmutable("2013/8/28"));
     }
 
-    public function testLastThursdayOfSeptember2013()
+    public function testLastThursdayOfSeptember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 9, "last", "Thursday"), new DateTimeImmutable("2013/9/26"));
     }
 
-    public function testLastThursdayOfOctober2013()
+    public function testLastThursdayOfOctober2013() : void
     {
         $this->assertEquals(meetup_day(2013, 10, "last", "Thursday"), new DateTimeImmutable("2013/10/31"));
     }
 
-    public function testLastFridayOfNovember2013()
+    public function testLastFridayOfNovember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 11, "last", "Friday"), new DateTimeImmutable("2013/11/29"));
     }
 
-    public function testLastFridayOfDecember2013()
+    public function testLastFridayOfDecember2013() : void
     {
         $this->assertEquals(meetup_day(2013, 12, "last", "Friday"), new DateTimeImmutable("2013/12/27"));
     }
 
-    public function testLastSaturdayOfJanuary2013()
+    public function testLastSaturdayOfJanuary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 1, "last", "Saturday"), new DateTimeImmutable("2013/1/26"));
     }
 
-    public function testLastSaturdayOfFebruary2013()
+    public function testLastSaturdayOfFebruary2013() : void
     {
         $this->assertEquals(meetup_day(2013, 2, "last", "Saturday"), new DateTimeImmutable("2013/2/23"));
     }
 
-    public function testLastSundayOfMarch2013()
+    public function testLastSundayOfMarch2013() : void
     {
         $this->assertEquals(meetup_day(2013, 3, "last", "Sunday"), new DateTimeImmutable("2013/3/31"));
     }
 
-    public function testLastSundayOfApril2013()
+    public function testLastSundayOfApril2013() : void
     {
         $this->assertEquals(meetup_day(2013, 4, "last", "Sunday"), new DateTimeImmutable("2013/4/28"));
     }
 
-    public function testLastWednesdayOfFebruary2012()
+    public function testLastWednesdayOfFebruary2012() : void
     {
         $this->assertEquals(meetup_day(2012, 2, "last", "Wednesday"), new DateTimeImmutable("2012/2/29"));
     }
 
-    public function testLastWednesdayOfDecember2014()
+    public function testLastWednesdayOfDecember2014() : void
     {
         $this->assertEquals(meetup_day(2014, 12, "last", "Wednesday"), new DateTimeImmutable("2014/12/31"));
     }
 
-    public function testLastSundayOfFebruary2015()
+    public function testLastSundayOfFebruary2015() : void
     {
         $this->assertEquals(meetup_day(2015, 2, "last", "Sunday"), new DateTimeImmutable("2015/2/22"));
     }
 
-    public function testFirstFridayOfDecember2012()
+    public function testFirstFridayOfDecember2012() : void
     {
         $this->assertEquals(meetup_day(2012, 12, "first", "Friday"), new DateTimeImmutable("2012/12/7"));
     }

--- a/exercises/minesweeper/minesweeper_test.php
+++ b/exercises/minesweeper/minesweeper_test.php
@@ -4,7 +4,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'minesweeper.php';
+        require_once 'minesweeper.php';
     }
 
     public function testAnEmptyBoard() : void

--- a/exercises/minesweeper/minesweeper_test.php
+++ b/exercises/minesweeper/minesweeper_test.php
@@ -7,7 +7,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         require 'minesweeper.php';
     }
 
-    public function testAnEmptyBoard()
+    public function testAnEmptyBoard() : void
     {
         $emptyBoard = '
 +--+
@@ -17,7 +17,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         $this->assertSame($emptyBoard, solve($emptyBoard));
     }
 
-    public function testAnIncompleteSideBorderThrowsAnException()
+    public function testAnIncompleteSideBorderThrowsAnException() : void
     {
         $incompleteBoard = '
 +--+
@@ -29,7 +29,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         solve($incompleteBoard);
     }
 
-    public function testAnIncompleteTopBorderThrowsAnException()
+    public function testAnIncompleteTopBorderThrowsAnException() : void
     {
         $incompleteBoard = '
 + -+
@@ -41,7 +41,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         solve($incompleteBoard);
     }
 
-    public function testAMissingCornerThrowsAnException()
+    public function testAMissingCornerThrowsAnException() : void
     {
         $incompleteBoard = '
 +--
@@ -53,7 +53,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         solve($incompleteBoard);
     }
 
-    public function testABoardWithLessThan2SquaresThrowsAnException()
+    public function testABoardWithLessThan2SquaresThrowsAnException() : void
     {
         $tinyBoard = '
 +-+
@@ -65,7 +65,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         solve($tinyBoard);
     }
 
-    public function testRowsOfSameLength($value = '')
+    public function testRowsOfSameLength($value = '') : void
     {
         $unequalBoard = '
 +---+
@@ -79,7 +79,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         solve($unequalBoard);
     }
 
-    public function testCanOnlyContainMines($value = '')
+    public function testCanOnlyContainMines($value = '') : void
     {
         $badBoard = '
 +---+
@@ -94,7 +94,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         solve($badBoard);
     }
 
-    public function testBoardWithOneMineToLeft()
+    public function testBoardWithOneMineToLeft() : void
     {
         $oneMine = '
 +--+
@@ -111,7 +111,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, solve($oneMine));
     }
 
-    public function testBoardWithOneMineToRight()
+    public function testBoardWithOneMineToRight() : void
     {
         $oneMine = '
 +--+
@@ -128,7 +128,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, solve($oneMine));
     }
 
-    public function testBoardWithAMineToTopAndRight()
+    public function testBoardWithAMineToTopAndRight() : void
     {
         $twoMines = '
 +--+
@@ -147,7 +147,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, solve($twoMines));
     }
 
-    public function testBoardWithAMineToBottomAndLeftAndDiagonal()
+    public function testBoardWithAMineToBottomAndLeftAndDiagonal() : void
     {
         $threeMines = '
 +--+
@@ -166,7 +166,7 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, solve($threeMines));
     }
 
-    public function testAComplicatedBoard()
+    public function testAComplicatedBoard() : void
     {
         $fourMines = '
 +-----+

--- a/exercises/nth-prime/nth-prime_test.php
+++ b/exercises/nth-prime/nth-prime_test.php
@@ -7,23 +7,23 @@ class NthPrimeTest extends PHPUnit\Framework\TestCase
         require 'nth-prime.php';
     }
 
-    public function testFirstPrime()
+    public function testFirstPrime() : void
     {
         $this->assertEquals(2, prime(1));
     }
-    public function testSecondPrime()
+    public function testSecondPrime() : void
     {
         $this->assertEquals(3, prime(2));
     }
-    public function testSixthPrime()
+    public function testSixthPrime() : void
     {
         $this->assertEquals(13, prime(6));
     }
-    public function testBigPrime()
+    public function testBigPrime() : void
     {
         $this->assertEquals(104743, prime(10001));
     }
-    public function testZeroPrime()
+    public function testZeroPrime() : void
     {
         $this->assertEquals(false, prime(0));
     }

--- a/exercises/nth-prime/nth-prime_test.php
+++ b/exercises/nth-prime/nth-prime_test.php
@@ -4,7 +4,7 @@ class NthPrimeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'nth-prime.php';
+        require_once 'nth-prime.php';
     }
 
     public function testFirstPrime() : void

--- a/exercises/nucleotide-count/example.php
+++ b/exercises/nucleotide-count/example.php
@@ -1,6 +1,5 @@
 <?php
 
-
 function nucleotideCount($dna)
 {
     $nucleotides = [];

--- a/exercises/nucleotide-count/nucleotide-count_test.php
+++ b/exercises/nucleotide-count/nucleotide-count_test.php
@@ -7,7 +7,7 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         require 'nucleotide-count.php';
     }
 
-    public function testEmptyDNASequence()
+    public function testEmptyDNASequence() : void
     {
         $this->assertSame([
             'a' => 0,
@@ -17,7 +17,7 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount(''));
     }
 
-    public function testRepetitiveDNASequence()
+    public function testRepetitiveDNASequence() : void
     {
         $this->assertSame([
             'a' => 9,
@@ -27,7 +27,7 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount('AAAAAAAAA'));
     }
 
-    public function testDNASequence()
+    public function testDNASequence() : void
     {
         $this->assertSame([
             'a' => 20,

--- a/exercises/nucleotide-count/nucleotide-count_test.php
+++ b/exercises/nucleotide-count/nucleotide-count_test.php
@@ -4,7 +4,7 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'nucleotide-count.php';
+        require_once 'nucleotide-count.php';
     }
 
     public function testEmptyDNASequence() : void

--- a/exercises/ocr-numbers/example.php
+++ b/exercises/ocr-numbers/example.php
@@ -9,19 +9,17 @@ class OcrBlock
 {
     protected $ocr = [];
 
-
     public function __construct($ocr)
     {
         $this->ocr = $ocr;
         $this->validate();
     }
 
-
     /**
      * Validate OCR block format: size, proportions
      * @throws InvalidArgumentException
      */
-    public function validate()
+    public function validate() : void
     {
         $numRows = count($this->ocr);
         $numColumns = strlen($this->ocr[0]);
@@ -39,13 +37,12 @@ class OcrBlock
         }
     }
 
-
     /**
      * Recognize OCR block: split it into vertical fragments,
      * explode them into symbols and recognize them.
      * @return string
      */
-    public function recognize()
+    public function recognize() : string
     {
         return implode(',', array_map(function ($x) {
             return implode('', array_map(function ($y) {
@@ -54,13 +51,12 @@ class OcrBlock
         }, array_chunk($this->ocr, OcrSymbol::NUM_ROWS)));
     }
 
-
     /**
      * Explode OCR fragment into OCR symbols
-     * @param type $ocrFragment
-     * @return type
+     * @param array $ocrFragment
+     * @return array
      */
-    protected function explode($ocrFragment)
+    protected function explode($ocrFragment) : array
     {
         $exploded = array_map(function ($x) {
             return str_split($x, OcrSymbol::NUM_COLUMNS);
@@ -70,7 +66,6 @@ class OcrBlock
         }, $exploded[0], $exploded[1], $exploded[2], $exploded[3]);
     }
 }
-
 
 class OcrSymbol
 {
@@ -102,7 +97,7 @@ class OcrSymbol
      * Translate OCR to digit
      * @return string
      */
-    public function getDigit()
+    public function getDigit() : string
     {
         if ($this->digit === null) {
             $encoded = str_replace(' ', 'x', implode($this->ocr));

--- a/exercises/ocr-numbers/ocr-numbers_test.php
+++ b/exercises/ocr-numbers/ocr-numbers_test.php
@@ -4,12 +4,11 @@ include_once 'ocr-numbers.php';
 
 class OcrNumbersTest extends PHPUnit\Framework\TestCase
 {
-
     /**
      * Recognition result should be returned as a string
      */
 
-    public function testRecognizes0()
+    public function testRecognizes0() : void
     {
         $input = [
             " _ ",
@@ -20,7 +19,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('0', recognize($input));
     }
 
-    public function testRecognizes1()
+    public function testRecognizes1() : void
     {
         $input = [
             "   ",
@@ -34,7 +33,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
     /**
      * Unreadable but correctly sized inputs return ?
      */
-    public function testUnreadable()
+    public function testUnreadable() : void
     {
         $input = [
             "   ",
@@ -48,7 +47,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
     /**
      * Input with a number of lines that is not a multiple of four raises an error
      */
-    public function testErrorWrongNumberOfLines()
+    public function testErrorWrongNumberOfLines() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -63,7 +62,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
     /**
      * Input with a number of columns that is not a multiple of three raises an error
      */
-    public function testErrorWrongNumberOfColumns()
+    public function testErrorWrongNumberOfColumns() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -76,7 +75,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         recognize($input);
     }
 
-    public function testRecognizes110101100()
+    public function testRecognizes110101100() : void
     {
         $input = [
             "       _     _        _  _ ",
@@ -90,7 +89,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
     /**
      * Garbled numbers in a string are replaced with ?
      */
-    public function testGarbled()
+    public function testGarbled() : void
     {
         $input = [
             "       _     _           _ ",
@@ -101,7 +100,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('11?10?1?0', recognize($input));
     }
 
-    public function testRecognizes2()
+    public function testRecognizes2() : void
     {
         $input = [
             " _ ",
@@ -112,7 +111,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('2', recognize($input));
     }
 
-    public function testRecognizes3()
+    public function testRecognizes3() : void
     {
         $input = [
             " _ ",
@@ -123,7 +122,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('3', recognize($input));
     }
 
-    public function testRecognizes4()
+    public function testRecognizes4() : void
     {
         $input = [
             "   ",
@@ -134,7 +133,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('4', recognize($input));
     }
 
-    public function testRecognizes5()
+    public function testRecognizes5() : void
     {
         $input = [
             " _ ",
@@ -145,7 +144,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('5', recognize($input));
     }
 
-    public function testRecognizes6()
+    public function testRecognizes6() : void
     {
         $input = [
             " _ ",
@@ -156,7 +155,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('6', recognize($input));
     }
 
-    public function testRecognizes7()
+    public function testRecognizes7() : void
     {
         $input = [
             " _ ",
@@ -167,7 +166,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('7', recognize($input));
     }
 
-    public function testRecognizes8()
+    public function testRecognizes8() : void
     {
         $input = [
             " _ ",
@@ -178,7 +177,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('8', recognize($input));
     }
 
-    public function testRecognizes9()
+    public function testRecognizes9() : void
     {
         $input = [
             " _ ",
@@ -189,7 +188,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
         $this->assertSame('9', recognize($input));
     }
 
-    public function testRecognizesStringOfDecimalNumbers()
+    public function testRecognizesStringOfDecimalNumbers() : void
     {
         $input = [
             "    _  _     _  _  _  _  _  _ ",
@@ -203,7 +202,7 @@ class OcrNumbersTest extends PHPUnit\Framework\TestCase
     /**
      * Numbers separated by empty lines are recognized. Lines are joined by commas.
      */
-    public function testLinesWithCommas()
+    public function testLinesWithCommas() : void
     {
         $input = [
             "    _  _ ",

--- a/exercises/ocr-numbers/ocr-numbers_test.php
+++ b/exercises/ocr-numbers/ocr-numbers_test.php
@@ -1,9 +1,12 @@
 <?php
 
-include_once 'ocr-numbers.php';
-
 class OcrNumbersTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass() : void
+    {
+        require_once 'ocr-numbers.php';
+    }
+
     /**
      * Recognition result should be returned as a string
      */

--- a/exercises/palindrome-products/palindrome-products_test.php
+++ b/exercises/palindrome-products/palindrome-products_test.php
@@ -7,7 +7,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         require 'palindrome-products.php';
     }
 
-    public function testFindsTheSmallestPalindromeFromSingleDigitFactors()
+    public function testFindsTheSmallestPalindromeFromSingleDigitFactors() : void
     {
         [ $value, $factors ] = smallest(1, 9);
         $this->assertEquals($value, 1);
@@ -16,7 +16,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindsTheLargestPalindromeFromSingleDigitFactors()
+    public function testFindsTheLargestPalindromeFromSingleDigitFactors() : void
     {
         [ $value, $factors ] = largest(1, 9);
         $this->assertEquals($value, 9);
@@ -26,7 +26,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindTheSmallestPalindromeFromDoubleDigitFactors()
+    public function testFindTheSmallestPalindromeFromDoubleDigitFactors() : void
     {
         [ $value, $factors ] = smallest(10, 99);
         $this->assertEquals($value, 121);
@@ -35,7 +35,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindTheLargestPalindromeFromDoubleDigitFactors()
+    public function testFindTheLargestPalindromeFromDoubleDigitFactors() : void
     {
         [ $value, $factors ] = largest(10, 99);
         $this->assertEquals($value, 9009);
@@ -44,7 +44,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindSmallestPalindromeFromTripleDigitFactors()
+    public function testFindSmallestPalindromeFromTripleDigitFactors() : void
     {
         [ $value, $factors ] = smallest(100, 999);
         $this->assertEquals($value, 10201);
@@ -53,7 +53,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindTheLargestPalindromeFromTripleDigitFactors()
+    public function testFindTheLargestPalindromeFromTripleDigitFactors() : void
     {
         [ $value, $factors ] = largest(100, 999);
         $this->assertEquals($value, 906609);
@@ -62,7 +62,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindSmallestPalindromeFromFourDigitFactors()
+    public function testFindSmallestPalindromeFromFourDigitFactors() : void
     {
         [ $value, $factors ] = smallest(1000, 9999);
         $this->assertEquals($value, 1002001);
@@ -71,7 +71,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testFindTheLargestPalindromeFromFourDigitFactors()
+    public function testFindTheLargestPalindromeFromFourDigitFactors() : void
     {
         [ $value, $factors ] = largest(1000, 9999);
         $this->assertEquals($value, 99000099);
@@ -80,25 +80,25 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testEmptyResultForSmallestIfNoPalindromeInTheRange()
+    public function testEmptyResultForSmallestIfNoPalindromeInTheRange() : void
     {
         $this->expectException(Exception::class);
         smallest(1002, 1003);
     }
 
-    public function testEmptyResultForLargestIfNoPalindromeInTheRange()
+    public function testEmptyResultForLargestIfNoPalindromeInTheRange() : void
     {
         $this->expectException(Exception::class);
         largest(15, 15);
     }
 
-    public function testErrorResultForSmallestIfMinIsMoreThanMax()
+    public function testErrorResultForSmallestIfMinIsMoreThanMax() : void
     {
         $this->expectException(Exception::class);
         smallest(10000, 1);
     }
 
-    public function testErrorResultForLargestIfMinIsMoreThanMax()
+    public function testErrorResultForLargestIfMinIsMoreThanMax() : void
     {
         $this->expectException(Exception::class);
         largest(2, 1);

--- a/exercises/palindrome-products/palindrome-products_test.php
+++ b/exercises/palindrome-products/palindrome-products_test.php
@@ -4,7 +4,7 @@ class PalindromeProductsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'palindrome-products.php';
+        require_once 'palindrome-products.php';
     }
 
     public function testFindsTheSmallestPalindromeFromSingleDigitFactors() : void

--- a/exercises/pangram/pangram_test.php
+++ b/exercises/pangram/pangram_test.php
@@ -7,52 +7,52 @@ class PangramTest extends PHPUnit\Framework\TestCase
         require 'pangram.php';
     }
 
-    public function testSentenceEmpty()
+    public function testSentenceEmpty() : void
     {
         $this->assertFalse(isPangram(''));
     }
 
-    public function testPangramWithOnlyLowerCase()
+    public function testPangramWithOnlyLowerCase() : void
     {
         $this->assertTrue(isPangram('the quick brown fox jumps over the lazy dog'));
     }
 
-    public function testMissingCharacterX()
+    public function testMissingCharacterX() : void
     {
         $this->assertFalse(isPangram('a quick movement of the enemy will jeopardize five gunboats'));
     }
 
-    public function testAnotherMissingCharacterX()
+    public function testAnotherMissingCharacterX() : void
     {
         $this->assertFalse(isPangram('the quick brown fish jumps over the lazy dog'));
     }
 
-    public function testPangramWithUnderscores()
+    public function testPangramWithUnderscores() : void
     {
         $this->assertTrue(isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog'));
     }
 
-    public function testPangramWithNumbers()
+    public function testPangramWithNumbers() : void
     {
         $this->assertTrue(isPangram('the 1 quick brown fox jumps over the 2 lazy dogs'));
     }
 
-    public function testMissingLettersReplacedByNumbers()
+    public function testMissingLettersReplacedByNumbers() : void
     {
         $this->assertFalse(isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog'));
     }
 
-    public function testPangramWithMixedCaseAndPunctuation()
+    public function testPangramWithMixedCaseAndPunctuation() : void
     {
         $this->assertTrue(isPangram('\Five quacking Zephyrs jolt my wax bed.\\'));
     }
 
-    public function testPangramWithNonAsciiCharacters()
+    public function testPangramWithNonAsciiCharacters() : void
     {
         $this->assertTrue(isPangram('Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.'));
     }
 
-    public function testMissingLetterReplacedWithUpperCaseCharacter()
+    public function testMissingLetterReplacedWithUpperCaseCharacter() : void
     {
         $this->assertFalse(isPangram("Tthe quick brown fo jumps over the lazy dog"));
     }

--- a/exercises/pangram/pangram_test.php
+++ b/exercises/pangram/pangram_test.php
@@ -4,7 +4,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'pangram.php';
+        require_once 'pangram.php';
     }
 
     public function testSentenceEmpty() : void

--- a/exercises/pascals-triangle/pascals-triangle_test.php
+++ b/exercises/pascals-triangle/pascals-triangle_test.php
@@ -4,7 +4,7 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'pascals-triangle.php';
+        require_once 'pascals-triangle.php';
     }
 
     public function testZeroRows() : void

--- a/exercises/pascals-triangle/pascals-triangle_test.php
+++ b/exercises/pascals-triangle/pascals-triangle_test.php
@@ -7,32 +7,32 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
         require 'pascals-triangle.php';
     }
 
-    public function testZeroRows()
+    public function testZeroRows() : void
     {
         $this->assertSame([], pascalsTriangleRows(0));
     }
 
-    public function testSingleRow()
+    public function testSingleRow() : void
     {
         $this->assertSame([[1]], pascalsTriangleRows(1));
     }
-    public function testTwoRows()
+    public function testTwoRows() : void
     {
         $this->assertSame([[1], [1, 1]], pascalsTriangleRows(2));
     }
-    public function testThreeRows()
+    public function testThreeRows() : void
     {
         $this->assertSame([[1], [1, 1], [1, 2, 1]], pascalsTriangleRows(3));
     }
-    public function testFourRows()
+    public function testFourRows() : void
     {
         $this->assertSame([[1], [1, 1], [1, 2, 1], [1, 3, 3, 1]], pascalsTriangleRows(4));
     }
-    public function testNegativeRows()
+    public function testNegativeRows() : void
     {
         $this->assertEquals(-1, pascalsTriangleRows(-1));
     }
-    public function testNullNoRows()
+    public function testNullNoRows() : void
     {
         $this->assertEquals(-1, pascalsTriangleRows(null));
     }

--- a/exercises/perfect-numbers/perfect-numbers_test.php
+++ b/exercises/perfect-numbers/perfect-numbers_test.php
@@ -7,69 +7,69 @@ class PerfectNumbersTest extends PHPUnit\Framework\TestCase
         require 'perfect-numbers.php';
     }
 
-    public function testSmallPerfectNumberIsClassifiedCorrectly()
+    public function testSmallPerfectNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("perfect", getClassification(6));
     }
 
-    public function testMediumPerfectNumberIsClassifiedCorrectly()
+    public function testMediumPerfectNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("perfect", getClassification(28));
     }
 
-    public function testLargePerfectNumberIsClassifiedCorrectly()
+    public function testLargePerfectNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("perfect", getClassification(33550336));
     }
 
-    public function testSmallAbundantNumberIsClassifiedCorrectly()
+    public function testSmallAbundantNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("abundant", getClassification(12));
     }
 
-    public function testMediumAbundantNumberIsClassifiedCorrectly()
+    public function testMediumAbundantNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("abundant", getClassification(30));
     }
 
-    public function testLargeAbundantNumberIsClassifiedCorrectly()
+    public function testLargeAbundantNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("abundant", getClassification(33550335));
     }
 
-    public function testSmallestPrimeDeficientNumberIsClassifiedCorrectly()
+    public function testSmallestPrimeDeficientNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("deficient", getClassification(2));
     }
 
-    public function testSmallestNonPrimeDeficientNumberIsClassifiedCorrectly()
+    public function testSmallestNonPrimeDeficientNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("deficient", getClassification(4));
     }
 
-    public function testMediumDeficientNumberIsClassifiedCorrectly()
+    public function testMediumDeficientNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("deficient", getClassification(32));
     }
 
-    public function testLargeDeficientNumberIsClassifiedCorrectly()
+    public function testLargeDeficientNumberIsClassifiedCorrectly() : void
     {
         $this->assertEquals("deficient", getClassification(33550337));
     }
 
-    public function testThatOneIsCorrectlyClassifiedAsDeficient()
+    public function testThatOneIsCorrectlyClassifiedAsDeficient() : void
     {
         $this->assertEquals("deficient", getClassification(1));
     }
 
-    public function testThatNonNegativeIntegerIsRejected()
+    public function testThatNonNegativeIntegerIsRejected() : void
     {
         $this->expectException(InvalidArgumentException::class) ;
 
         getClassification(0) ;
     }
 
-    public function testThatNegativeIntegerIsRejected()
+    public function testThatNegativeIntegerIsRejected() : void
     {
         $this->expectException(InvalidArgumentException::class) ;
 

--- a/exercises/perfect-numbers/perfect-numbers_test.php
+++ b/exercises/perfect-numbers/perfect-numbers_test.php
@@ -4,7 +4,7 @@ class PerfectNumbersTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'perfect-numbers.php';
+        require_once 'perfect-numbers.php';
     }
 
     public function testSmallPerfectNumberIsClassifiedCorrectly() : void

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -7,25 +7,25 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         require 'phone-number.php';
     }
 
-    public function testCleansTheNumber(): void
+    public function testCleansTheNumber() : void
     {
         $number = new PhoneNumber('(223) 456-7890');
         $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testCleansTheNumberWithDots(): void
+    public function testCleansTheNumberWithDots() : void
     {
         $number = new PhoneNumber('223.456.7890');
         $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testCleansTheNumberWithMultipleSpaces(): void
+    public function testCleansTheNumberWithMultipleSpaces() : void
     {
         $number = new PhoneNumber('223 456   7890   ');
         $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testInvalidWhen9Digits(): void
+    public function testInvalidWhen9Digits() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('incorrect number of digits');
@@ -33,7 +33,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('123456789');
     }
 
-    public function testInvalidWhen11DigitsDoesNotStartWithA1(): void
+    public function testInvalidWhen11DigitsDoesNotStartWithA1() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('11 digits must start with 1');
@@ -41,19 +41,19 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('22234567890');
     }
 
-    public function testValidWhen11DigitsAndStartingWith1(): void
+    public function testValidWhen11DigitsAndStartingWith1() : void
     {
         $number = new PhoneNumber('12234567890');
         $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testValidWhen11DigitsAndStartingWith1EvenWithPunctuation(): void
+    public function testValidWhen11DigitsAndStartingWith1EvenWithPunctuation() : void
     {
         $number = new PhoneNumber('+1 (223) 456-7890');
         $this->assertEquals('2234567890', $number->number());
     }
 
-    public function testInvalidWhenMoreThan11Digits(): void
+    public function testInvalidWhenMoreThan11Digits() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('more than 11 digits');
@@ -61,7 +61,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('321234567890');
     }
 
-    public function testInvalidWithLetters(): void
+    public function testInvalidWithLetters() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('letters not permitted');
@@ -69,7 +69,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('123-abc-7890');
     }
 
-    public function testInvalidWithPunctuation(): void
+    public function testInvalidWithPunctuation() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('punctuations not permitted');
@@ -77,7 +77,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('123-@:!-7890');
     }
 
-    public function testInvalidIfAreaCodeStartsWith0(): void
+    public function testInvalidIfAreaCodeStartsWith0() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('area code cannot start with zero');
@@ -85,7 +85,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('(023) 456-7890');
     }
 
-    public function testInvalidIfAreaCodeStartsWith1(): void
+    public function testInvalidIfAreaCodeStartsWith1() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('area code cannot start with one');
@@ -93,7 +93,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('(123) 456-7890');
     }
 
-    public function testInvalidIfExchangeCodeStartsWith0(): void
+    public function testInvalidIfExchangeCodeStartsWith0() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('exchange code cannot start with zero');
@@ -101,7 +101,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('(223) 056-7890');
     }
 
-    public function testInvalidIfExchangeCodeStartsWith1(): void
+    public function testInvalidIfExchangeCodeStartsWith1() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('exchange code cannot start with one');
@@ -109,7 +109,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('(223) 156-7890');
     }
 
-    public function testInvalidIfAreaCodeStartsWith0OnValid11DigitNumber(): void
+    public function testInvalidIfAreaCodeStartsWith0OnValid11DigitNumber() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('area code cannot start with zero');
@@ -117,7 +117,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('1 (023) 456-7890');
     }
 
-    public function testInvalidIfAreaCodeStartsWith1OnValid11DigitNumber(): void
+    public function testInvalidIfAreaCodeStartsWith1OnValid11DigitNumber() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('area code cannot start with one');
@@ -125,7 +125,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('1 (123) 456-7890');
     }
 
-    public function testInvalidIfExchangeCodeStartsWith0OnValid11DigitNumber(): void
+    public function testInvalidIfExchangeCodeStartsWith0OnValid11DigitNumber() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('exchange code cannot start with zero');
@@ -133,7 +133,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
         new PhoneNumber('1 (223) 056-7890');
     }
 
-    public function testInvalidIfExchangeCodeStartsWith1OnValid11DigitNumber(): void
+    public function testInvalidIfExchangeCodeStartsWith1OnValid11DigitNumber() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('exchange code cannot start with one');

--- a/exercises/phone-number/phone-number_test.php
+++ b/exercises/phone-number/phone-number_test.php
@@ -4,7 +4,7 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'phone-number.php';
+        require_once 'phone-number.php';
     }
 
     public function testCleansTheNumber() : void

--- a/exercises/pig-latin/pig-latin_test.php
+++ b/exercises/pig-latin/pig-latin_test.php
@@ -7,104 +7,102 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
         require 'pig-latin.php';
     }
 
-    public function testWordBeginningWithP()
+    public function testWordBeginningWithP() : void
     {
         $this->assertEquals("igpay", translate("pig"));
     }
 
-    public function testWordBeginningWithK()
+    public function testWordBeginningWithK() : void
     {
         $this->assertEquals("oalakay", translate("koala"));
     }
 
-    public function testWordBeginningWithY()
+    public function testWordBeginningWithY() : void
     {
         $this->assertEquals("ellowyay", translate("yellow"));
     }
 
-    public function testWordBeginningWithX()
+    public function testWordBeginningWithX() : void
     {
         $this->assertEquals("enonxay", translate("xenon"));
     }
 
-    public function testWordBeginningWithA()
+    public function testWordBeginningWithA() : void
     {
         $this->assertEquals("appleay", translate("apple"));
     }
 
-    public function testWordBeginningWithE()
+    public function testWordBeginningWithE() : void
     {
         $this->assertEquals("earay", translate("ear"));
     }
 
-    public function testWordBeginningWithI()
+    public function testWordBeginningWithI() : void
     {
         $this->assertEquals("iglooay", translate("igloo"));
     }
 
-    public function testWordBeginningWithO()
+    public function testWordBeginningWithO() : void
     {
         $this->assertEquals("objectay", translate("object"));
     }
 
-    public function testWordBeginningWithU()
+    public function testWordBeginningWithU() : void
     {
         $this->assertEquals("underay", translate("under"));
     }
 
-    public function testWordBeginningVowelFollowedByQu()
+    public function testWordBeginningVowelFollowedByQu() : void
     {
         $this->assertEquals("equalay", translate("equal"));
     }
 
-
-    public function testWordBeginningWithQWithoutAFollowingU()
+    public function testWordBeginningWithQWithoutAFollowingU() : void
     {
         $this->assertEquals("atqay", translate("qat"));
     }
 
-
-    public function testWordBeginningWithCh()
+    public function testWordBeginningWithCh() : void
     {
         $this->assertEquals("airchay", translate("chair"));
     }
 
-    public function testWordBeginningWithQu()
+    public function testWordBeginningWithQu() : void
     {
         $this->assertEquals("eenquay", translate("queen"));
     }
 
-    public function testWordBeginningWithQuAndAPrecedingConsonant()
+    public function testWordBeginningWithQuAndAPrecedingConsonant() : void
     {
         $this->assertEquals("aresquay", translate("square"));
     }
 
-    public function testWordBeginningWithTh()
+    public function testWordBeginningWithTh() : void
     {
         $this->assertEquals("erapythay", translate("therapy"));
     }
 
-    public function testWordBeginningWithThr()
+    public function testWordBeginningWithThr() : void
     {
         $this->assertEquals("ushthray", translate("thrush"));
     }
 
-    public function testWordBeginningWithSch()
+    public function testWordBeginningWithSch() : void
     {
         $this->assertEquals("oolschay", translate("school"));
     }
 
-    public function testWordBeginningWithYt()
+    public function testWordBeginningWithYt() : void
     {
         $this->assertEquals("yttriaay", translate("yttria"));
     }
 
-    public function testWordBeginningWithXr()
+    public function testWordBeginningWithXr() : void
     {
         $this->assertEquals("xrayay", translate("xray"));
     }
 
-    public function testAWholePhrase()
+    public function testAWholePhrase() : void
     {
         $this->assertEquals("ickquay astfay unray", translate("quick fast run"));
     }

--- a/exercises/pig-latin/pig-latin_test.php
+++ b/exercises/pig-latin/pig-latin_test.php
@@ -4,7 +4,7 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'pig-latin.php';
+        require_once 'pig-latin.php';
     }
 
     public function testWordBeginningWithP() : void

--- a/exercises/prime-factors/prime-factors_test.php
+++ b/exercises/prime-factors/prime-factors_test.php
@@ -7,37 +7,37 @@ class PrimeFactorsTest extends PHPUnit\Framework\TestCase
         require 'prime-factors.php';
     }
 
-    public function testNoFactors()
+    public function testNoFactors() : void
     {
         $this->assertSame([], factors(1));
     }
 
-    public function testOneFactor()
+    public function testOneFactor() : void
     {
         $this->assertSame([2], factors(2));
     }
 
-    public function testSquareOfPrime()
+    public function testSquareOfPrime() : void
     {
         $this->assertSame([3, 3], factors(9));
     }
 
-    public function testCubeOfPrime()
+    public function testCubeOfPrime() : void
     {
         $this->assertSame([2, 2, 2], factors(8));
     }
 
-    public function testProductOfPrimesAndNon()
+    public function testProductOfPrimesAndNon() : void
     {
         $this->assertEquals([2, 2, 3], factors(12));
     }
 
-    public function testProductOfPrimes()
+    public function testProductOfPrimes() : void
     {
         $this->assertEquals([5, 17, 23, 461], factors(901255));
     }
 
-    public function testFactorsIncludeLargePrime()
+    public function testFactorsIncludeLargePrime() : void
     {
         $this->assertEquals([11, 9539, 894119], factors(93819012551));
     }

--- a/exercises/prime-factors/prime-factors_test.php
+++ b/exercises/prime-factors/prime-factors_test.php
@@ -4,7 +4,7 @@ class PrimeFactorsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'prime-factors.php';
+        require_once 'prime-factors.php';
     }
 
     public function testNoFactors() : void

--- a/exercises/queen-attack/queen-attack_test.php
+++ b/exercises/queen-attack/queen-attack_test.php
@@ -10,7 +10,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test a queen is placed in a valid position.
      */
-    public function testCreateQueenWithValidPosition()
+    public function testCreateQueenWithValidPosition() : void
     {
         $this->assertTrue(placeQueen(2, 2));
     }
@@ -18,7 +18,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test the queen is placed on a positive rank.
      */
-    public function testQueenHasPositiveRank()
+    public function testQueenHasPositiveRank() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The rank and file numbers must be positive.');
@@ -29,7 +29,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test the queen has a rank on the board.
      */
-    public function testQueenHasRankOnBoard()
+    public function testQueenHasRankOnBoard() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The position must be on a standard size chess board.');
@@ -40,7 +40,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test the queen is placed on a positive file.
      */
-    public function testQueenHasPositiveFile()
+    public function testQueenHasPositiveFile() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The rank and file numbers must be positive.');
@@ -51,7 +51,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test the queen has a file on the board.
      */
-    public function testQueenHasFileOnBoard()
+    public function testQueenHasFileOnBoard() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The position must be on a standard size chess board.');
@@ -62,7 +62,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other.
      */
-    public function testQueensCanAttack()
+    public function testQueensCanAttack() : void
     {
         $this->assertFalse(canAttack([2, 4], [6, 6]));
     }
@@ -70,7 +70,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other on the same rank.
      */
-    public function testQueensCanAttackOnSameRank()
+    public function testQueensCanAttackOnSameRank() : void
     {
         $this->assertTrue(canAttack([2, 4], [2, 6]));
     }
@@ -78,7 +78,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other on the same file.
      */
-    public function testQueensCanAttackOnSameFile()
+    public function testQueensCanAttackOnSameFile() : void
     {
         $this->assertTrue(canAttack([4, 5], [2, 5]));
     }
@@ -86,7 +86,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other on the first diagonal.
      */
-    public function testQueensCanAttackOnFirstDiagonal()
+    public function testQueensCanAttackOnFirstDiagonal() : void
     {
         $this->assertTrue(canAttack([2, 2], [0, 4]));
     }
@@ -94,7 +94,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other on the second diagonal.
      */
-    public function testQueensCanAttackOnSecondDiagonal()
+    public function testQueensCanAttackOnSecondDiagonal() : void
     {
         $this->assertTrue(canAttack([2, 2], [3, 1]));
     }
@@ -102,7 +102,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other on the third diagonal.
      */
-    public function testQueensCanAttackOnThirdDiagonal()
+    public function testQueensCanAttackOnThirdDiagonal() : void
     {
         $this->assertTrue(canAttack([2, 2], [1, 1]));
     }
@@ -110,7 +110,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
     /**
      * Test if queens can attack each other on the fourth diagonal.
      */
-    public function testQueensCanAttackOnFourthDiagonal()
+    public function testQueensCanAttackOnFourthDiagonal() : void
     {
         $this->assertTrue(canAttack([2, 2], [5, 5]));
     }

--- a/exercises/queen-attack/queen-attack_test.php
+++ b/exercises/queen-attack/queen-attack_test.php
@@ -4,7 +4,7 @@ class QueenAttackTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'queen-attack.php';
+        require_once 'queen-attack.php';
     }
 
     /**

--- a/exercises/rail-fence-cipher/rail-fence-cipher_test.php
+++ b/exercises/rail-fence-cipher/rail-fence-cipher_test.php
@@ -7,11 +7,10 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
         require 'rail-fence-cipher.php';
     }
 
-
     /**
      * Test encode with two rails.
      */
-    public function testEncodeWithTwoRails()
+    public function testEncodeWithTwoRails() : void
     {
         $plainText  = "XOXOXOXOXOXOXOXOXO";
         $rails = 2;
@@ -21,7 +20,7 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Test encode with three rails.
      */
-    public function testEncodeWithThreeRails()
+    public function testEncodeWithThreeRails() : void
     {
         $plainText  = "WEAREDISCOVEREDFLEEATONCE";
         $rails = 3;
@@ -32,7 +31,7 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Test encode with ending in the middle.
      */
-    public function testEncodeWithEndingInTheMiddle()
+    public function testEncodeWithEndingInTheMiddle() : void
     {
         $plainText  = "EXERCISES";
         $rails = 4;
@@ -43,7 +42,7 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Test decode with three rails.
      */
-    public function testDecodeWithThreeRails()
+    public function testDecodeWithThreeRails() : void
     {
         $encryptedText  = "TEITELHDVLSNHDTISEIIEA";
         $rails = 3;
@@ -53,7 +52,7 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Test decode with five rails.
      */
-    public function testDecodeWithFiveRails()
+    public function testDecodeWithFiveRails() : void
     {
         $encryptedText  = "EIEXMSMESAORIWSCE";
         $rails = 5;
@@ -64,7 +63,7 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Test decode with six rails.
      */
-    public function testDecodeWithSixRails()
+    public function testDecodeWithSixRails() : void
     {
         $encryptedText  = "133714114238148966225439541018335470986172518171757571896261";
         $rails = 6;

--- a/exercises/rail-fence-cipher/rail-fence-cipher_test.php
+++ b/exercises/rail-fence-cipher/rail-fence-cipher_test.php
@@ -4,7 +4,7 @@ class RailFenceCipherTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'rail-fence-cipher.php';
+        require_once 'rail-fence-cipher.php';
     }
 
     /**

--- a/exercises/raindrops/raindrops_test.php
+++ b/exercises/raindrops/raindrops_test.php
@@ -7,82 +7,82 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
         require 'raindrops.php';
     }
 
-    public function test1()
+    public function test1() : void
     {
         $this->assertSame("1", raindrops(1));
     }
 
-    public function test3()
+    public function test3() : void
     {
         $this->assertSame("Pling", raindrops(3));
     }
 
-    public function test5()
+    public function test5() : void
     {
         $this->assertSame("Plang", raindrops(5));
     }
 
-    public function test7()
+    public function test7() : void
     {
         $this->assertSame("Plong", raindrops(7));
     }
 
-    public function test6()
+    public function test6() : void
     {
         $this->assertSame("Pling", raindrops(6));
     }
 
-    public function test9()
+    public function test9() : void
     {
         $this->assertSame("Pling", raindrops(9));
     }
 
-    public function test10()
+    public function test10() : void
     {
         $this->assertSame("Plang", raindrops(10));
     }
 
-    public function test14()
+    public function test14() : void
     {
         $this->assertSame("Plong", raindrops(14));
     }
 
-    public function test15()
+    public function test15() : void
     {
         $this->assertSame("PlingPlang", raindrops(15));
     }
 
-    public function test21()
+    public function test21() : void
     {
         $this->assertSame("PlingPlong", raindrops(21));
     }
 
-    public function test25()
+    public function test25() : void
     {
         $this->assertSame("Plang", raindrops(25));
     }
 
-    public function test35()
+    public function test35() : void
     {
         $this->assertSame("PlangPlong", raindrops(35));
     }
 
-    public function test49()
+    public function test49() : void
     {
         $this->assertSame("Plong", raindrops(49));
     }
 
-    public function test52()
+    public function test52() : void
     {
         $this->assertSame("52", raindrops(52));
     }
 
-    public function test105()
+    public function test105() : void
     {
         $this->assertSame("PlingPlangPlong", raindrops(105));
     }
 
-    public function test12121()
+    public function test12121() : void
     {
         $this->assertSame("12121", raindrops(12121));
     }

--- a/exercises/raindrops/raindrops_test.php
+++ b/exercises/raindrops/raindrops_test.php
@@ -4,7 +4,7 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'raindrops.php';
+        require_once 'raindrops.php';
     }
 
     public function test1() : void

--- a/exercises/rna-transcription/rna-transcription_test.php
+++ b/exercises/rna-transcription/rna-transcription_test.php
@@ -7,27 +7,27 @@ class ComplementTest extends PHPUnit\Framework\TestCase
         require 'rna-transcription.php';
     }
 
-    public function testTranscribesGuanineToCytosine()
+    public function testTranscribesGuanineToCytosine() : void
     {
         $this->assertSame('G', toRna('C'));
     }
 
-    public function testTranscribesCytosineToGuanine()
+    public function testTranscribesCytosineToGuanine() : void
     {
         $this->assertSame('C', toRna('G'));
     }
 
-    public function testTranscribesThymineToAdenine()
+    public function testTranscribesThymineToAdenine() : void
     {
         $this->assertSame('A', toRna('T'));
     }
 
-    public function testTranscribesAdenineToUracil()
+    public function testTranscribesAdenineToUracil() : void
     {
         $this->assertSame('U', toRna('A'));
     }
 
-    public function testTranscribesAllOccurencesOne()
+    public function testTranscribesAllOccurencesOne() : void
     {
         $this->assertSame('UGCACCAGAAUU', toRna('ACGTGGTCTTAA'));
     }

--- a/exercises/rna-transcription/rna-transcription_test.php
+++ b/exercises/rna-transcription/rna-transcription_test.php
@@ -4,7 +4,7 @@ class ComplementTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'rna-transcription.php';
+        require_once 'rna-transcription.php';
     }
 
     public function testTranscribesGuanineToCytosine() : void

--- a/exercises/robot-name/example.php
+++ b/exercises/robot-name/example.php
@@ -13,7 +13,7 @@ class Robot
      *
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
@@ -21,7 +21,7 @@ class Robot
     /**
      * Reset name
      */
-    public function reset()
+    public function reset() : void
     {
         $this->name = NamesRegistry::connect()->getNewName();
     }
@@ -42,7 +42,7 @@ class NamesRegistry
      *
      * @return NamesRegistry
      */
-    public static function connect()
+    public static function connect() : \NamesRegistry
     {
         if (empty(self::$registry)) {
             self::$registry = new NamesRegistry();
@@ -63,7 +63,7 @@ class NamesRegistry
      *
      * @return string New Robot name     *
      */
-    public function getNewName()
+    public function getNewName() : string
     {
         do {
             shuffle(self::$letters);

--- a/exercises/robot-name/robot-name_test.php
+++ b/exercises/robot-name/robot-name_test.php
@@ -10,24 +10,24 @@ class RobotTest extends PHPUnit\Framework\TestCase
     /** @var Robot $robot */
     protected $robot = null;
 
-    public function setUp(): void
+    public function setUp() : void
     {
         $this->robot = new Robot();
     }
 
-    public function testHasName()
+    public function testHasName() : void
     {
         $this->assertRegExp('/^[a-z]{2}\d{3}$/i', $this->robot->getName());
     }
 
-    public function testNameSticks()
+    public function testNameSticks() : void
     {
         $old = $this->robot->getName();
 
         $this->assertSame($this->robot->getName(), $old);
     }
 
-    public function testDifferentRobotsHaveDifferentNames()
+    public function testDifferentRobotsHaveDifferentNames() : void
     {
         $other_bot = new Robot();
 
@@ -36,7 +36,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
         unset($other_bot);
     }
 
-    public function testresetName()
+    public function testresetName() : void
     {
         $name1 = $this->robot->getName();
 
@@ -49,7 +49,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
         $this->assertRegExp('/\w{2}\d{3}/', $name2);
     }
 
-    public function testNameArentRecycled()
+    public function testNameArentRecycled() : void
     {
         $names = [];
 
@@ -62,7 +62,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
     }
 
     // This test is optional.
-    public function testNameUniquenessManyRobots()
+    public function testNameUniquenessManyRobots() : void
     {
         $names = [];
 

--- a/exercises/robot-name/robot-name_test.php
+++ b/exercises/robot-name/robot-name_test.php
@@ -4,7 +4,7 @@ class RobotTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'robot-name.php';
+        require_once 'robot-name.php';
     }
 
     /** @var Robot $robot */

--- a/exercises/robot-simulator/example.php
+++ b/exercises/robot-simulator/example.php
@@ -19,13 +19,11 @@ class Robot
      */
     protected $direction;
 
-
     public function __construct(array $position, string $direction)
     {
         $this->position = $position;
         $this->direction = $direction;
     }
-
 
     /**
      * Make protected properties read-only.
@@ -39,34 +37,31 @@ class Robot
         return property_exists(self::class, $name) ? $this->$name : null;
     }
 
-
     /**
      * Turn the Robot clockwise
      * @return Robot
      */
-    public function turnRight()
+    public function turnRight() : \Robot
     {
         $this->direction = self::listDirectionsClockwize()[$this->direction];
         return $this;
     }
 
-
     /**
      * Turn the Robot counterclockwise
      * @return Robot
      */
-    public function turnLeft()
+    public function turnLeft() : \Robot
     {
         $this->direction = self::listDirectionsCounterClockwize()[$this->direction];
         return $this;
     }
 
-
     /**
      * Advance the Robot one step forward
      * @return Robot
      */
-    public function advance()
+    public function advance() : \Robot
     {
         switch ($this->direction) {
             case self::DIRECTION_NORTH:
@@ -88,7 +83,6 @@ class Robot
         return $this;
     }
 
-
     /**
      * Move the Robot according to instructions: R = Turn Right, L = Turn Left and A = Advance
      */
@@ -104,12 +98,11 @@ class Robot
         return $this;
     }
 
-
     /**
      * List all possible clockwise turn combinations
      * @return array
      */
-    public static function listDirectionsClockwize()
+    public static function listDirectionsClockwize() : array
     {
         return [
             self::DIRECTION_NORTH => self::DIRECTION_EAST,
@@ -119,23 +112,21 @@ class Robot
         ];
     }
 
-
     /**
      * List all possible counterclockwise turn combinations
      * @return array
      */
-    public static function listDirectionsCounterClockwize()
+    public static function listDirectionsCounterClockwize() : array
     {
         return array_flip(self::listDirectionsClockwize());
     }
-
 
     /**
      * Translate instructions string to actions
      * @param string $stringInstructions
      * @return string[]
      */
-    protected function mapInsructionsToActions($stringInstructions)
+    protected function mapInsructionsToActions($stringInstructions) : array
     {
         return array_map(function ($x) {
             return [

--- a/exercises/robot-simulator/robot-simulator_test.php
+++ b/exercises/robot-simulator/robot-simulator_test.php
@@ -1,9 +1,12 @@
 <?php
 
-include_once 'robot-simulator.php';
-
 class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass() : void
+    {
+        require_once 'robot-simulator.php';
+    }
+
     /**
      * A robot is created with a position and a direction
      */

--- a/exercises/robot-simulator/robot-simulator_test.php
+++ b/exercises/robot-simulator/robot-simulator_test.php
@@ -4,12 +4,10 @@ include_once 'robot-simulator.php';
 
 class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 {
-
-
     /**
      * A robot is created with a position and a direction
      */
-    public function testCreate()
+    public function testCreate() : void
     {
         // Robots are created with a position and direction
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
@@ -22,11 +20,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
     }
 
-
     /**
      * Rotate the robot's direction 90 degrees clockwise
      */
-    public function testTurnRight()
+    public function testTurnRight() : void
     {
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
 
@@ -54,7 +51,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     /**
      * Rotate the robot's direction 90 degrees counterclockwise
      */
-    public function testTurnLeft()
+    public function testTurnLeft() : void
     {
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
 
@@ -79,11 +76,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
     }
 
-
     /**
      * Move the robot forward 1 space in the direction it is pointing
      */
-    public function testAdvance()
+    public function testAdvance() : void
     {
         // Increases the y coordinate by one when facing north
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
@@ -110,13 +106,12 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
     }
 
-
     /**
      * Where R = Turn Right, L = Turn Left and A = Advance,
      * the robot can follow a series of instructions
      * and end up with the correct position and direction
      */
-    public function testInstructions()
+    public function testInstructions() : void
     {
         // Instructions to move west and north
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
@@ -137,7 +132,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
     }
 
-    public function testMalformedInstructions()
+    public function testMalformedInstructions() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -145,11 +140,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         $robot->instructions('LARX');
     }
 
-
     /**
      * Optional instructions chaining
      */
-    public function testInstructionsChaining()
+    public function testInstructionsChaining() : void
     {
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
         $robot->turnLeft()

--- a/exercises/roman-numerals/example.php
+++ b/exercises/roman-numerals/example.php
@@ -1,6 +1,5 @@
 <?php
 
-
 function toRoman($number)
 {
     $mapping = [

--- a/exercises/roman-numerals/roman-numerals_test.php
+++ b/exercises/roman-numerals/roman-numerals_test.php
@@ -4,7 +4,7 @@ class RomanTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'roman-numerals.php';
+        require_once 'roman-numerals.php';
     }
 
     public function test1() : void

--- a/exercises/roman-numerals/roman-numerals_test.php
+++ b/exercises/roman-numerals/roman-numerals_test.php
@@ -7,107 +7,107 @@ class RomanTest extends PHPUnit\Framework\TestCase
         require 'roman-numerals.php';
     }
 
-    public function test1()
+    public function test1() : void
     {
         $this->assertSame('I', toRoman(1));
     }
 
-    public function test2()
+    public function test2() : void
     {
         $this->assertSame('II', toRoman(2));
     }
 
-    public function test3()
+    public function test3() : void
     {
         $this->assertSame('III', toRoman(3));
     }
 
-    public function test4()
+    public function test4() : void
     {
         $this->assertSame('IV', toRoman(4));
     }
 
-    public function test5()
+    public function test5() : void
     {
         $this->assertSame('V', toRoman(5));
     }
 
-    public function test6()
+    public function test6() : void
     {
         $this->assertSame('VI', toRoman(6));
     }
 
-    public function test9()
+    public function test9() : void
     {
         $this->assertSame('IX', toRoman(9));
     }
 
-    public function test27()
+    public function test27() : void
     {
         $this->assertSame('XXVII', toRoman(27));
     }
 
-    public function test48()
+    public function test48() : void
     {
         $this->assertSame('XLVIII', toRoman(48));
     }
 
-    public function test49()
+    public function test49() : void
     {
         $this->assertSame('XLIX', toRoman(49));
     }
 
-    public function test59()
+    public function test59() : void
     {
         $this->assertSame('LIX', toRoman(59));
     }
 
-    public function test93()
+    public function test93() : void
     {
         $this->assertSame('XCIII', toRoman(93));
     }
 
-    public function test141()
+    public function test141() : void
     {
         $this->assertSame('CXLI', toRoman(141));
     }
 
-    public function test163()
+    public function test163() : void
     {
         $this->assertSame('CLXIII', toRoman(163));
     }
 
-    public function test402()
+    public function test402() : void
     {
         $this->assertSame('CDII', toRoman(402));
     }
 
-    public function test575()
+    public function test575() : void
     {
         $this->assertSame('DLXXV', toRoman(575));
     }
 
-    public function test911()
+    public function test911() : void
     {
         $this->assertSame('CMXI', toRoman(911));
     }
 
-    public function test1024()
+    public function test1024() : void
     {
         $this->assertSame('MXXIV', toRoman(1024));
     }
 
-    public function test1998()
+    public function test1998() : void
     {
         $this->assertSame('MCMXCVIII', toRoman(1998));
     }
 
-    public function test2999()
+    public function test2999() : void
     {
         $this->assertSame('MMCMXCIX', toRoman(2999));
     }
 
-    public function test3000()
+    public function test3000() : void
     {
         $this->assertSame('MMM', toRoman(3000));
     }

--- a/exercises/run-length-encoding/run-length-encoding_test.php
+++ b/exercises/run-length-encoding/run-length-encoding_test.php
@@ -7,37 +7,37 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
         require 'run-length-encoding.php';
     }
 
-    public function testEncodeEmptyString()
+    public function testEncodeEmptyString() : void
     {
         $this->assertEquals('', encode(''));
     }
 
-    public function testEncodeSingleCharactersOnly()
+    public function testEncodeSingleCharactersOnly() : void
     {
         $this->assertEquals('XYZ', encode('XYZ'));
     }
 
-    public function testDecodeEmptyString()
+    public function testDecodeEmptyString() : void
     {
         $this->assertEquals('', decode(''));
     }
 
-    public function testDecodeSingleCharactersOnly()
+    public function testDecodeSingleCharactersOnly() : void
     {
         $this->assertEquals('XYZ', decode('XYZ'));
     }
 
-    public function testEncodeSimple()
+    public function testEncodeSimple() : void
     {
         $this->assertEquals('2A3B4C', encode('AABBBCCCC'));
     }
 
-    public function testDecodeSimple()
+    public function testDecodeSimple() : void
     {
         $this->assertEquals('AABBBCCCC', decode('2A3B4C'));
     }
 
-    public function testEncodeWithSingleValues()
+    public function testEncodeWithSingleValues() : void
     {
         $this->assertEquals(
             '12WB12W3B24WB',
@@ -45,7 +45,7 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeWithSingleValues()
+    public function testDecodeWithSingleValues() : void
     {
         $this->assertEquals(
             'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB',
@@ -53,12 +53,12 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testDecodeMultipleWhitespaceMixedInString()
+    public function testDecodeMultipleWhitespaceMixedInString() : void
     {
         $this->assertEquals('  hsqq qww  ', decode('2 hs2q q2w2 '));
     }
 
-    public function testEncodeDecodeCombination()
+    public function testEncodeDecodeCombination() : void
     {
         $this->assertEquals('zzz ZZ  zZ', decode(encode('zzz ZZ  zZ')));
     }

--- a/exercises/run-length-encoding/run-length-encoding_test.php
+++ b/exercises/run-length-encoding/run-length-encoding_test.php
@@ -4,7 +4,7 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'run-length-encoding.php';
+        require_once 'run-length-encoding.php';
     }
 
     public function testEncodeEmptyString() : void

--- a/exercises/scrabble-score/scrabble-score_test.php
+++ b/exercises/scrabble-score/scrabble-score_test.php
@@ -1,14 +1,15 @@
-
-
 <?php
-
-include_once 'scrabble-score.php';
 
 /**
  * Calculate the value of scrabble score for a given word.
  */
 class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass() : void
+    {
+        require_once 'scrabble-score.php';
+    }
+
     /**
      * Test lowercase single letter word.
      */

--- a/exercises/scrabble-score/scrabble-score_test.php
+++ b/exercises/scrabble-score/scrabble-score_test.php
@@ -12,7 +12,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test lowercase single letter word.
      */
-    public function testLowercaseSingleLetter()
+    public function testLowercaseSingleLetter() : void
     {
         $word = 'a';
         $this->assertEquals(1, score($word));
@@ -21,7 +21,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test uppercase single letter word.
      */
-    public function testUppercaseSingleLetter()
+    public function testUppercaseSingleLetter() : void
     {
         $word = 'A';
         $this->assertEquals(1, score($word));
@@ -30,7 +30,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test valuable single letter word.
      */
-    public function testValuableSingleLetter()
+    public function testValuableSingleLetter() : void
     {
         $word = 'f';
         $this->assertEquals(4, score($word));
@@ -39,7 +39,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test short word.
      */
-    public function testShortWord()
+    public function testShortWord() : void
     {
         $word = 'at';
         $this->assertEquals(2, score($word));
@@ -48,7 +48,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test short valuable word.
      */
-    public function testShortValuableWord()
+    public function testShortValuableWord() : void
     {
         $word = 'zoo';
         $this->assertEquals(12, score($word));
@@ -57,7 +57,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test medium word.
      */
-    public function testMediumWord()
+    public function testMediumWord() : void
     {
         $word = 'street';
         $this->assertEquals(6, score($word));
@@ -66,7 +66,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test medium valuable word.
      */
-    public function testMediumValuableWord()
+    public function testMediumValuableWord() : void
     {
         $word = 'quirky';
         $this->assertEquals(22, score($word));
@@ -75,7 +75,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test long mixed-case word.
      */
-    public function testLongMixedCaseWord()
+    public function testLongMixedCaseWord() : void
     {
         $word = 'OxyphenButazone';
         $this->assertEquals(41, score($word));
@@ -84,7 +84,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test english-like word.
      */
-    public function testEnglishLikeWord()
+    public function testEnglishLikeWord() : void
     {
         $word = 'pinata';
         $this->assertEquals(8, score($word));
@@ -93,7 +93,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /**
      * Test empty word score.
      */
-    public function testEmptyWordScore()
+    public function testEmptyWordScore() : void
     {
         $word = '';
         $this->assertEquals(0, score($word));
@@ -102,7 +102,7 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
     /*
      * Test entire alphabet word.
      */
-    public function testEntireAlphabetWord()
+    public function testEntireAlphabetWord() : void
     {
         $word = 'abcdefghijklmnopqrstuvwxyz';
         $this->assertEquals(87, score($word));

--- a/exercises/series/series_test.php
+++ b/exercises/series/series_test.php
@@ -4,7 +4,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'series.php';
+        require_once 'series.php';
     }
 
     public function testSlicesOfOne() : void

--- a/exercises/series/series_test.php
+++ b/exercises/series/series_test.php
@@ -7,7 +7,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         require 'series.php';
     }
 
-    public function testSlicesOfOne()
+    public function testSlicesOfOne() : void
     {
         $this->assertEquals(
             ["0", "1", "2", "3", "4"],
@@ -15,7 +15,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSlicesOfTwo()
+    public function testSlicesOfTwo() : void
     {
         $this->assertEquals(
             ["97", "78", "86", "67", "75", "56", "64"],
@@ -23,7 +23,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSlicesOfThree()
+    public function testSlicesOfThree() : void
     {
         $this->assertEquals(
             ["978", "786", "867", "675", "756", "564"],
@@ -31,7 +31,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSlicesOfFour()
+    public function testSlicesOfFour() : void
     {
         $this->assertEquals(
             ["0123", "1234"],
@@ -39,7 +39,7 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSlicesOfFive()
+    public function testSlicesOfFive() : void
     {
         $this->assertEquals(
             ["01234"],
@@ -47,13 +47,13 @@ class SeriesTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testOverlyLongSlice()
+    public function testOverlyLongSlice() : void
     {
         $this->expectException(Exception::class);
         slices("012", 4);
     }
 
-    public function testOverlyShortSlice()
+    public function testOverlyShortSlice() : void
     {
         $this->expectException(Exception::class);
         slices("01234", 0);

--- a/exercises/sieve/example.php
+++ b/exercises/sieve/example.php
@@ -14,16 +14,16 @@ function sieve($number)
     }
     return array_values($candidates);
 }
-function _getNumbersFrom2To($number): array
+function _getNumbersFrom2To($number) : array
 {
     $candidates = range(2, $number);
     return $candidates;
 }
-function _areDifferent($multiple, $prime): bool
+function _areDifferent($multiple, $prime) : bool
 {
     return ($multiple != $prime);
 }
-function _areMultiples($multiple, $prime): bool
+function _areMultiples($multiple, $prime) : bool
 {
     return ($multiple % $prime == 0);
 }

--- a/exercises/sieve/sieve_test.php
+++ b/exercises/sieve/sieve_test.php
@@ -4,7 +4,7 @@ class SieveTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'sieve.php';
+        require_once 'sieve.php';
     }
 
     public function testNoPrimesUnderTwo() : void

--- a/exercises/sieve/sieve_test.php
+++ b/exercises/sieve/sieve_test.php
@@ -7,23 +7,23 @@ class SieveTest extends PHPUnit\Framework\TestCase
         require 'sieve.php';
     }
 
-    public function testNoPrimesUnderTwo()
+    public function testNoPrimesUnderTwo() : void
     {
         $this->assertEquals([], sieve(1));
     }
-    public function testFindFirstPrime()
+    public function testFindFirstPrime() : void
     {
         $this->assertEquals([2], sieve(2));
     }
-    public function testFindPrimesUpTo10()
+    public function testFindPrimesUpTo10() : void
     {
         $this->assertEquals([2, 3, 5, 7], sieve(10));
     }
-    public function testLimitIsPrime()
+    public function testLimitIsPrime() : void
     {
         $this->assertEquals([2, 3, 5, 7, 11, 13], sieve(13));
     }
-    public function testFindPrimesUpTo1000()
+    public function testFindPrimesUpTo1000() : void
     {
         $this->assertEquals(
             [

--- a/exercises/space-age/space-age_test.php
+++ b/exercises/space-age/space-age_test.php
@@ -9,55 +9,55 @@ class SpaceAgeTester extends PHPUnit\Framework\TestCase
 
     public const DELTA = 0.01;
 
-    public function testAgeInSeconds()
+    public function testAgeInSeconds() : void
     {
         $age = new SpaceAge(1000000);
         $this->assertEquals(1000000, $age->seconds());
     }
 
-    public function testAgeOnEarth()
+    public function testAgeOnEarth() : void
     {
         $age = new SpaceAge(1000000000);
         $this->assertEqualsWithDelta(31.69, $age->earth(), self::DELTA);
     }
 
-    public function testAgeOnMercury()
+    public function testAgeOnMercury() : void
     {
         $age = new SpaceAge(2134835688);
         $this->assertEqualsWithDelta(280.88, $age->mercury(), self::DELTA);
     }
 
-    public function testAgeOnVenus()
+    public function testAgeOnVenus() : void
     {
         $age = new SpaceAge(189839836);
         $this->assertEqualsWithDelta(9.78, $age->venus(), self::DELTA);
     }
 
-    public function testAgeOnMars()
+    public function testAgeOnMars() : void
     {
         $age = new SpaceAge(2329871239);
         $this->assertEqualsWithDelta(39.25, $age->mars(), self::DELTA);
     }
 
-    public function testAgeOnJupiter()
+    public function testAgeOnJupiter() : void
     {
         $age = new SpaceAge(901876382);
         $this->assertEqualsWithDelta(2.41, $age->jupiter(), self::DELTA);
     }
 
-    public function testAgeOnSaturn()
+    public function testAgeOnSaturn() : void
     {
         $age = new SpaceAge(3000000000);
         $this->assertEqualsWithDelta(3.23, $age->saturn(), self::DELTA);
     }
 
-    public function testAgeOnUranus()
+    public function testAgeOnUranus() : void
     {
         $age = new SpaceAge(3210123456);
         $this->assertEqualsWithDelta(1.21, $age->uranus(), self::DELTA);
     }
 
-    public function testAgeOnNeptune()
+    public function testAgeOnNeptune() : void
     {
         $age = new SpaceAge(8210123456);
         $this->assertEqualsWithDelta(1.58, $age->neptune(), self::DELTA);

--- a/exercises/space-age/space-age_test.php
+++ b/exercises/space-age/space-age_test.php
@@ -4,7 +4,7 @@ class SpaceAgeTester extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'space-age.php';
+        require_once 'space-age.php';
     }
 
     public const DELTA = 0.01;

--- a/exercises/sum-of-multiples/sum-of-multiples_test.php
+++ b/exercises/sum-of-multiples/sum-of-multiples_test.php
@@ -7,61 +7,61 @@ class SumOfMultiplesTest extends PHPUnit\Framework\TestCase
         require 'sum-of-multiples.php';
     }
 
-    public function testSumToOne()
+    public function testSumToOne() : void
     {
         $this->assertEquals(0, sumOfMultiples(1, [3, 5]));
     }
 
-    public function testSumToThree()
+    public function testSumToThree() : void
     {
         $this->assertEquals(3, sumOfMultiples(4, [3, 5]));
     }
 
-    public function testSumToTen()
+    public function testSumToTen() : void
     {
         $this->assertEquals(23, sumOfMultiples(10, [3, 5]));
     }
 
-    public function testSumToTwenty()
+    public function testSumToTwenty() : void
     {
         $this->assertEquals(78, sumOfMultiples(20, [3, 5]));
     }
 
-    public function testSumToHundred()
+    public function testSumToHundred() : void
     {
         $this->assertEquals(2318, sumOfMultiples(100, [3, 5]));
     }
 
-    public function testSumToThousand()
+    public function testSumToThousand() : void
     {
         $this->assertEquals(233168, sumOfMultiples(1000, [3, 5]));
     }
 
-    public function testConfigureToTwenty()
+    public function testConfigureToTwenty() : void
     {
         $this->assertEquals(51, sumOfMultiples(20, [7, 13, 17]));
     }
 
-    public function testConfigureToFifteen()
+    public function testConfigureToFifteen() : void
     {
         $this->assertEquals(30, sumOfMultiples(15, [4, 6]));
     }
 
-    public function testConfigureToOneFifty()
+    public function testConfigureToOneFifty() : void
     {
         $this->assertEquals(4419, sumOfMultiples(150, [5, 6, 8]));
     }
 
-    public function testConfigureToFortySeven()
+    public function testConfigureToFortySeven() : void
     {
         $this->assertEquals(2203160, sumOfMultiples(10000, [43, 47]));
     }
 
-    public function testMultiplesOfOneToHundred()
+    public function testMultiplesOfOneToHundred() : void
     {
         $this->assertEquals(4950, sumOfMultiples(100, [1]));
     }
-    public function testMultiplesOfEmptyList()
+    public function testMultiplesOfEmptyList() : void
     {
         $this->assertEquals(0, sumOfMultiples(1000, [0]));
     }

--- a/exercises/sum-of-multiples/sum-of-multiples_test.php
+++ b/exercises/sum-of-multiples/sum-of-multiples_test.php
@@ -4,7 +4,7 @@ class SumOfMultiplesTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'sum-of-multiples.php';
+        require_once 'sum-of-multiples.php';
     }
 
     public function testSumToOne() : void

--- a/exercises/transpose/transpose_test.php
+++ b/exercises/transpose/transpose_test.php
@@ -7,14 +7,14 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         require 'transpose.php';
     }
 
-    public function testEmptyString()
+    public function testEmptyString() : void
     {
         $input = [""];
         $expected = [""];
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testTwoCharactersInARow()
+    public function testTwoCharactersInARow() : void
     {
         $input = [
             "A1"
@@ -26,7 +26,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testTwoCharactersInAColumn()
+    public function testTwoCharactersInAColumn() : void
     {
         $input = [
             "A",
@@ -38,7 +38,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testSimple()
+    public function testSimple() : void
     {
         $input = [
             "ABC",
@@ -52,7 +52,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testSingleLine()
+    public function testSingleLine() : void
     {
         $input = [
             "Single line."
@@ -74,7 +74,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testFirstLineLongerThanSecondLine()
+    public function testFirstLineLongerThanSecondLine() : void
     {
         $input = [
             "The fourth line.",
@@ -101,7 +101,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testSecondLineLongerThanFirstLine()
+    public function testSecondLineLongerThanFirstLine() : void
     {
         $input = [
             "The first line.",
@@ -128,7 +128,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testSquare()
+    public function testSquare() : void
     {
         $input = [
             "HEART",
@@ -147,7 +147,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testRectangle()
+    public function testRectangle() : void
     {
         $input = [
             "FRACTURE",
@@ -168,7 +168,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testTriangle()
+    public function testTriangle() : void
     {
         $input = [
             "T",
@@ -189,7 +189,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($expected, transpose($input));
     }
 
-    public function testManyLines()
+    public function testManyLines() : void
     {
         $input = [
             "Chor. Two households, both alike in dignity,",

--- a/exercises/transpose/transpose_test.php
+++ b/exercises/transpose/transpose_test.php
@@ -4,7 +4,7 @@ class TransposeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'transpose.php';
+        require_once 'transpose.php';
     }
 
     public function testEmptyString() : void

--- a/exercises/triangle/example.php
+++ b/exercises/triangle/example.php
@@ -13,7 +13,7 @@ class Triangle
         $this->sideC = $sideC;
     }
 
-    public function kind()
+    public function kind() : string
     {
         if (0 == ($this->sideA + $this->sideB + $this->sideC)) {
             throw new Exception("These sides have no values.");

--- a/exercises/triangle/triangle_test.php
+++ b/exercises/triangle/triangle_test.php
@@ -7,7 +7,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         require 'triangle.php';
     }
 
-    public function testEquilateralTrianglesHaveEqualSides()
+    public function testEquilateralTrianglesHaveEqualSides() : void
     {
         $this->assertEquals(
             'equilateral',
@@ -15,7 +15,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testLargerEquilateralTrianglesHaveEqualSides()
+    public function testLargerEquilateralTrianglesHaveEqualSides() : void
     {
         $this->assertEquals(
             'equilateral',
@@ -23,7 +23,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIsoscelesTriangleWhenLastTwoSidesAreEqual()
+    public function testIsoscelesTriangleWhenLastTwoSidesAreEqual() : void
     {
         $this->assertEquals(
             'isosceles',
@@ -31,7 +31,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIsoscelesTriangleWhenFirstAndLastSidesAreEqual()
+    public function testIsoscelesTriangleWhenFirstAndLastSidesAreEqual() : void
     {
         $this->assertEquals(
             'isosceles',
@@ -39,7 +39,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIsoscelesTriangleWhenFirstTwoSidesAreEqual()
+    public function testIsoscelesTriangleWhenFirstTwoSidesAreEqual() : void
     {
         $this->assertEquals(
             'isosceles',
@@ -47,7 +47,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIsoscelesTrianglesWithUnequalSideLargerThanEqualSides()
+    public function testIsoscelesTrianglesWithUnequalSideLargerThanEqualSides() : void
     {
         $this->assertEquals(
             'isosceles',
@@ -55,7 +55,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testScaleneTrianglesHaveNoEqualSides()
+    public function testScaleneTrianglesHaveNoEqualSides() : void
     {
         $this->assertEquals(
             'scalene',
@@ -63,7 +63,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test2aEqualsBPlusCLooksLikeEquilateralButIsNot()
+    public function test2aEqualsBPlusCLooksLikeEquilateralButIsNot() : void
     {
         $this->assertEquals(
             'scalene',
@@ -71,7 +71,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testScaleneTrianglesHaveNoEqualSidesAtLargerScale()
+    public function testScaleneTrianglesHaveNoEqualSidesAtLargerScale() : void
     {
         $this->assertEquals(
             'scalene',
@@ -79,7 +79,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testScaleneTrianglesHaveNoEqualSidesInDescendingOrder()
+    public function testScaleneTrianglesHaveNoEqualSidesInDescendingOrder() : void
     {
         $this->assertEquals(
             'scalene',
@@ -87,7 +87,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testVerySmallTrianglesAreLegal()
+    public function testVerySmallTrianglesAreLegal() : void
     {
         $this->assertEquals(
             'scalene',
@@ -95,28 +95,28 @@ class TriangleTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testTrianglesWithNoSizeAreIllegal()
+    public function testTrianglesWithNoSizeAreIllegal() : void
     {
         $this->expectException(Exception::class);
 
         (new Triangle(0, 0, 0))->kind();
     }
 
-    public function testTrianglesViolatingTriangleInequalityAreIllegal()
+    public function testTrianglesViolatingTriangleInequalityAreIllegal() : void
     {
         $this->expectException(Exception::class);
 
         (new Triangle(1, 1, 3))->kind();
     }
 
-    public function testTrianglesViolatingTriangleInequalityAreIllegal2()
+    public function testTrianglesViolatingTriangleInequalityAreIllegal2() : void
     {
         $this->expectException(Exception::class);
 
         (new Triangle(7, 3, 2))->kind();
     }
 
-    public function testTrianglesViolatingTriangleInequalityAreIllegal3()
+    public function testTrianglesViolatingTriangleInequalityAreIllegal3() : void
     {
         $this->expectException(Exception::class);
 

--- a/exercises/triangle/triangle_test.php
+++ b/exercises/triangle/triangle_test.php
@@ -4,7 +4,7 @@ class TriangleTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'triangle.php';
+        require_once 'triangle.php';
     }
 
     public function testEquilateralTrianglesHaveEqualSides() : void

--- a/exercises/trinary/trinary_test.php
+++ b/exercises/trinary/trinary_test.php
@@ -7,47 +7,47 @@ class TrinaryTest extends PHPUnit\Framework\TestCase
         require 'trinary.php';
     }
 
-    public function test1IsDecimal1()
+    public function test1IsDecimal1() : void
     {
         $this->assertEquals(1, toDecimal('1'));
     }
 
-    public function test2IsDecimal2()
+    public function test2IsDecimal2() : void
     {
         $this->assertEquals(2, toDecimal('2'));
     }
 
-    public function test10IsDecimal3()
+    public function test10IsDecimal3() : void
     {
         $this->assertEquals(3, toDecimal('10'));
     }
 
-    public function test11IsDecimal4()
+    public function test11IsDecimal4() : void
     {
         $this->assertEquals(4, toDecimal('11'));
     }
 
-    public function test100IsDecimal9()
+    public function test100IsDecimal9() : void
     {
         $this->assertEquals(9, toDecimal('100'));
     }
 
-    public function test112IsDecimal14()
+    public function test112IsDecimal14() : void
     {
         $this->assertEquals(14, toDecimal('112'));
     }
 
-    public function test222IsDecimal26()
+    public function test222IsDecimal26() : void
     {
         $this->assertEquals(26, toDecimal('222'));
     }
 
-    public function test1122000120IsDecimal32091()
+    public function test1122000120IsDecimal32091() : void
     {
         $this->assertEquals(32091, toDecimal('1122000120'));
     }
 
-    public function testInvalidTrinaryIsDecimal0()
+    public function testInvalidTrinaryIsDecimal0() : void
     {
         $this->assertSame(0, toDecimal('13201'));
     }

--- a/exercises/trinary/trinary_test.php
+++ b/exercises/trinary/trinary_test.php
@@ -4,7 +4,7 @@ class TrinaryTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'trinary.php';
+        require_once 'trinary.php';
     }
 
     public function test1IsDecimal1() : void

--- a/exercises/two-fer/example.php
+++ b/exercises/two-fer/example.php
@@ -1,6 +1,6 @@
 <?php
 
-function twoFer(string $name = 'you'): string
+function twoFer(string $name = 'you') : string
 {
     return "One for $name, one for me.";
 }

--- a/exercises/two-fer/two-fer_test.php
+++ b/exercises/two-fer/two-fer_test.php
@@ -4,7 +4,7 @@ class TwoFerTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'two-fer.php';
+        require_once 'two-fer.php';
     }
 
     public function testNoNameGiven() : void

--- a/exercises/two-fer/two-fer_test.php
+++ b/exercises/two-fer/two-fer_test.php
@@ -7,17 +7,17 @@ class TwoFerTest extends PHPUnit\Framework\TestCase
         require 'two-fer.php';
     }
 
-    public function testNoNameGiven()
+    public function testNoNameGiven() : void
     {
         $this->assertEquals('One for you, one for me.', twoFer());
     }
 
-    public function testANameGiven()
+    public function testANameGiven() : void
     {
         $this->assertEquals('One for Alice, one for me.', twoFer('Alice'));
     }
 
-    public function testAnotherNameGiven()
+    public function testAnotherNameGiven() : void
     {
         $this->assertEquals('One for Bob, one for me.', twoFer('Bob'));
     }

--- a/exercises/variable-length-quantity/variable-length-quantity_test.php
+++ b/exercises/variable-length-quantity/variable-length-quantity_test.php
@@ -7,35 +7,35 @@ class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
         require 'variable-length-quantity.php';
     }
 
-    public function testItEncodesSingleBytes()
+    public function testItEncodesSingleBytes() : void
     {
         $this->assertEquals([0x00], vlq_encode([0x00]));
         $this->assertEquals([0x40], vlq_encode([0x40]));
         $this->assertEquals([0x7f], vlq_encode([0x7f]));
     }
 
-    public function testItEncodesDoubleBytes()
+    public function testItEncodesDoubleBytes() : void
     {
         $this->assertEquals([0x81, 0x00], vlq_encode([0x80]));
         $this->assertEquals([0xc0, 0x00], vlq_encode([0x2000]));
         $this->assertEquals([0xff, 0x7f], vlq_encode([0x3fff]));
     }
 
-    public function testItEncodesTripleBytes()
+    public function testItEncodesTripleBytes() : void
     {
         $this->assertEquals([0x81, 0x80, 0x00], vlq_encode([0x4000]));
         $this->assertEquals([0xc0, 0x80, 0x00], vlq_encode([0x100000]));
         $this->assertEquals([0xff, 0xff, 0x7f], vlq_encode([0x1fffff]));
     }
 
-    public function testItEncodesQuadrupleBytes()
+    public function testItEncodesQuadrupleBytes() : void
     {
         $this->assertEquals([0x81, 0x80, 0x80, 0x00], vlq_encode([0x200000]));
         $this->assertEquals([0xc0, 0x80, 0x80, 0x00], vlq_encode([0x8000000]));
         $this->assertEquals([0xff, 0xff, 0xff, 0x7f], vlq_encode([0xfffffff]));
     }
 
-    public function testItEncodesMultipleValues()
+    public function testItEncodesMultipleValues() : void
     {
         $this->assertEquals([0x00, 0x00], vlq_encode([0x00, 0x00]));
         $this->assertEquals([0x40, 0x7f], vlq_encode([0x40, 0x7f]));
@@ -49,35 +49,35 @@ class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
         ));
     }
 
-    public function testItDecodesFromSyngleBytes()
+    public function testItDecodesFromSyngleBytes() : void
     {
         $this->assertEquals([0x00], vlq_decode([0x00]));
         $this->assertEquals([0x40], vlq_decode([0x40]));
         $this->assertEquals([0x7f], vlq_decode([0x7f]));
     }
 
-    public function testItDecodesDoubleBytes()
+    public function testItDecodesDoubleBytes() : void
     {
         $this->assertEquals([0x80], vlq_decode([0x81, 0x00]));
         $this->assertEquals([0x2000], vlq_decode([0xc0, 0x00]));
         $this->assertEquals([0x3fff], vlq_decode([0xff, 0x7f]));
     }
 
-    public function testItDecodesTripleBytes()
+    public function testItDecodesTripleBytes() : void
     {
         $this->assertEquals([0x4000], vlq_decode([0x81, 0x80, 0x00]));
         $this->assertEquals([0x100000], vlq_decode([0xc0, 0x80, 0x00]));
         $this->assertEquals([0x1FFFFF], vlq_decode([0xff, 0xff, 0x7f]));
     }
 
-    public function testItDecodesQuadrupleBytes()
+    public function testItDecodesQuadrupleBytes() : void
     {
         $this->assertEquals([0x200000], vlq_decode([0x81, 0x80, 0x80, 0x00]));
         $this->assertEquals([0x8000000], vlq_decode([0xc0, 0x80, 0x80, 0x00]));
         $this->assertEquals([0xFFFFFFF], vlq_decode([0xff, 0xff, 0xff, 0x7f]));
     }
 
-    public function testItDecodesMultipleValues()
+    public function testItDecodesMultipleValues() : void
     {
         $this->assertEquals([0x00, 0x00], vlq_decode([0x00, 0x00]));
         $this->assertEquals([0x40, 0x7f], vlq_decode([0x40, 0x7f]));
@@ -92,21 +92,21 @@ class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIncompleteByteSequence()
+    public function testIncompleteByteSequence() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
         vlq_decode([0xff]);
     }
 
-    public function testOverflow()
+    public function testOverflow() : void
     {
         $this->expectException(OverflowException::class);
 
         vlq_decode([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]);
     }
 
-    public function testChainedDecodeEncodeGivesOriginalBytes()
+    public function testChainedDecodeEncodeGivesOriginalBytes() : void
     {
         $bytes = [
             0xc0, 0x00, 0xc8, 0xe8, 0x56,
@@ -117,7 +117,7 @@ class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($bytes === vlq_encode(vlq_decode($bytes)));
     }
 
-    public function testChainedEncodeDecodeGivesOriginalIntegers()
+    public function testChainedEncodeDecodeGivesOriginalIntegers() : void
     {
         $integers = [0x2000, 0x123456, 0x0fffffff, 0x00, 0x3fff, 0x4000];
 

--- a/exercises/variable-length-quantity/variable-length-quantity_test.php
+++ b/exercises/variable-length-quantity/variable-length-quantity_test.php
@@ -4,7 +4,7 @@ class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'variable-length-quantity.php';
+        require_once 'variable-length-quantity.php';
     }
 
     public function testItEncodesSingleBytes() : void

--- a/exercises/word-count/word-count_test.php
+++ b/exercises/word-count/word-count_test.php
@@ -4,7 +4,7 @@ class WordCountTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'word-count.php';
+        require_once 'word-count.php';
     }
 
     public function testCountOneWord() : void

--- a/exercises/word-count/word-count_test.php
+++ b/exercises/word-count/word-count_test.php
@@ -7,17 +7,17 @@ class WordCountTest extends PHPUnit\Framework\TestCase
         require 'word-count.php';
     }
 
-    public function testCountOneWord()
+    public function testCountOneWord() : void
     {
         $this->assertEquals(['word' => 1], wordCount('word'));
     }
 
-    public function testCountOneOfEachWord()
+    public function testCountOneOfEachWord() : void
     {
         $this->assertEquals(['one' => 1, 'of' => 1, 'each' => 1], wordCount('one of each'));
     }
 
-    public function testMultipleOccurrencesOfAWord()
+    public function testMultipleOccurrencesOfAWord() : void
     {
         $this->assertEquals(
             ['one' => 1, 'fish' => 4, 'two' => 1, 'red' => 1, 'blue' => 1],
@@ -25,7 +25,7 @@ class WordCountTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIgnorePunctuation()
+    public function testIgnorePunctuation() : void
     {
         $this->assertEquals(
             ['car' => 1, 'carpet' => 1, 'as' => 1, 'java' => 1, 'javascript' => 1],
@@ -33,32 +33,32 @@ class WordCountTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIncludeNumbers()
+    public function testIncludeNumbers() : void
     {
         $this->assertEquals(['1' => 1, '2' => 1, 'testing' => 2], wordCount('testing, 1, 2 testing'));
     }
 
-    public function testNormalizeCase()
+    public function testNormalizeCase() : void
     {
         $this->assertEquals(['go' => 3, 'stop' => 2], wordCount('go Go GO Stop stop'));
     }
 
-    public function testCountsMultiline()
+    public function testCountsMultiline() : void
     {
         $this->assertEquals(['hello' => 1, 'world' => 1], wordCount("hello\nworld"));
     }
 
-    public function testCountsTabs()
+    public function testCountsTabs() : void
     {
         $this->assertEquals(['hello' => 1, 'world' => 1], wordCount("hello\tworld"));
     }
 
-    public function testCountsMultipleSpacesAsOne()
+    public function testCountsMultipleSpacesAsOne() : void
     {
         $this->assertEquals(['hello' => 1, 'world' => 1], wordCount('hello  world'));
     }
 
-    public function testDoesNotCountLeadingOrTrailingWhitespace()
+    public function testDoesNotCountLeadingOrTrailingWhitespace() : void
     {
         $this->assertEquals(['introductory' => 1, 'course' => 1], wordCount("\t\tIntroductory Course      "));
     }

--- a/exercises/wordy/wordy_test.php
+++ b/exercises/wordy/wordy_test.php
@@ -4,7 +4,7 @@ class WordProblemTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass() : void
     {
-        require 'wordy.php';
+        require_once 'wordy.php';
     }
 
     public function testAdd1() : void

--- a/exercises/wordy/wordy_test.php
+++ b/exercises/wordy/wordy_test.php
@@ -7,84 +7,84 @@ class WordProblemTest extends PHPUnit\Framework\TestCase
         require 'wordy.php';
     }
 
-    public function testAdd1()
+    public function testAdd1() : void
     {
         $this->assertEquals(2, calculate('What is 1 plus 1?'));
     }
 
-    public function testAdd2()
+    public function testAdd2() : void
     {
         $this->assertEquals(55, calculate('What is 53 plus 2?'));
     }
 
-    public function testAddNegativeNumbers()
+    public function testAddNegativeNumbers() : void
     {
         $this->assertEquals(-11, calculate('What is -1 plus -10?'));
     }
 
-    public function testAddMoreDigits()
+    public function testAddMoreDigits() : void
     {
         $this->assertEquals(45801, calculate('What is 123 plus 45678?'));
     }
 
-    public function testSubtract()
+    public function testSubtract() : void
     {
         $this->assertEquals(16, calculate('What is 4 minus -12?'));
     }
 
-    public function testMultiply()
+    public function testMultiply() : void
     {
         $this->assertEquals(-75, calculate('What is -3 multiplied by 25?'));
     }
 
-    public function testDivide()
+    public function testDivide() : void
     {
         $this->assertEquals(-11, calculate('What is 33 divided by -3?'));
     }
 
-    public function testAddTwice()
+    public function testAddTwice() : void
     {
         $this->assertEquals(3, calculate('What is 1 plus 1 plus 1?'));
     }
 
-    public function testAddThenSubtract()
+    public function testAddThenSubtract() : void
     {
         $this->assertEquals(8, calculate('What is 1 plus 5 minus -2?'));
     }
 
-    public function testSubtractTwice()
+    public function testSubtractTwice() : void
     {
         $this->assertEquals(3, calculate('What is 20 minus 4 minus 13?'));
     }
 
-    public function testSubtractThenAdd()
+    public function testSubtractThenAdd() : void
     {
         $this->assertEquals(14, calculate('What is 17 minus 6 plus 3?'));
     }
 
-    public function testMultiplyTwice()
+    public function testMultiplyTwice() : void
     {
         $this->assertEquals(-12, calculate('What is 2 multiplied by -2 multiplied by 3?'));
     }
 
-    public function testAddThenMultiply()
+    public function testAddThenMultiply() : void
     {
         $this->assertEquals(-8, calculate('What is -3 plus 7 multiplied by -2?'));
     }
 
-    public function testDivideTwice()
+    public function testDivideTwice() : void
     {
         $this->assertEquals(2, calculate('What is -12 divided by 2 divided by -3?'));
     }
 
-    public function testTooAdvanced()
+    public function testTooAdvanced() : void
     {
         $this->expectException('InvalidArgumentException');
 
         calculate('What is 53 cubed?');
     }
 
-    public function testIrrelevant()
+    public function testIrrelevant() : void
     {
         $this->expectException('InvalidArgumentException');
 


### PR DESCRIPTION
This PR replaces #277, where conflicts could not be resolved.

It improves the code base by declaring return types (made available in PHP 7, nullable return types in PHP 7.1).

It also provides some overlooked changes, solving #279.