### PR TITLE
Anagram: Skip tests which require `mb_string` functions

### DIFF
--- a/exercises/anagram/.meta/hints.md
+++ b/exercises/anagram/.meta/hints.md
@@ -1,0 +1,1 @@
+The skipped tests near the bottom of the anagram_test.php are **Stretch Goals**, they are optional. They require the usage of `mb_string` functions, which aren't installed by default with every version of PHP.

--- a/exercises/anagram/anagram_test.php
+++ b/exercises/anagram/anagram_test.php
@@ -92,11 +92,13 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     public function testDetectsUnicodeAnagrams() : void
     {
+        $this->markTestSkipped('This requires `mbstring` to be installed and thus is optional.');
         $this->assertEquals(['ΒΓΑ', 'γβα'], detectAnagrams('ΑΒΓ', ['ΒΓΑ', 'ΒΓΔ', 'γβα']));
     }
 
     public function testEliminatesMisleadingUnicodeAnagrams() : void
     {
+        $this->markTestSkipped('This requires `mbstring` to be installed and thus is optional.');
         $this->assertEquals([], detectAnagrams('ΑΒΓ', ['ABΓ']));
     }
 


### PR DESCRIPTION
This PR provides changes discussed in #81.