### PR TITLE
Update CI drop PHP 7.2 support add PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: php
 php:
-- 7.2
 - 7.3
+- 7.4
 script:
 - make install
 - make style-check


### PR DESCRIPTION
PHP 7.2 is no longer actively supported, lets encourage users to upgrade to more modern versions to get the best and safest PHP experience possible.

Supported PHP versions: https://www.php.net/supported-versions.php