### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: php
 php:
-- 7.2
 - 7.3
+- 7.4
 script:
 - make install
 - make style-check

--- a/Makefile
+++ b/Makefile
@@ -11,28 +11,20 @@ FILEEXT := "php"
 EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
-default:
-	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
-	chmod +x bin/phpunit.phar
-	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
-	chmod +x bin/phpcs.phar
 
 help: ## Prints this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## install development dependencies
-	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
-	chmod +x bin/phpunit.phar
-
-	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
-	chmod +x bin/phpcs.phar
+	$(MAKE) install-test
+	$(MAKE) install-style
 
 install-test: ## install test dependency: phpunit.phar
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	curl -Lo ./bin/phpunit.phar https://phar.phpunit.de/phpunit.phar
 	chmod +x bin/phpunit.phar
 
 install-style: ## install style checker dependency: phpcs.phar
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpcs.phar
+	curl -Lo bin/phpcs.phar https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 test-assignment: bin/phpunit.phar ## run single test using ASSIGNMENTS: test-assignment ASSIGNMENT=wordy

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: ## install development dependencies
 	$(MAKE) install-style
 
 install-test: ## install test dependency: phpunit.phar
-	curl -Lo ./bin/phpunit.phar https://phar.phpunit.de/phpunit.phar
+	curl -Lo ./bin/phpunit.phar https://phar.phpunit.de/phpunit-8.phar
 	chmod +x bin/phpunit.phar
 
 install-style: ## install style checker dependency: phpcs.phar

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-test: ## install test dependency: phpunit.phar
 	chmod +x bin/phpunit.phar
 
 install-style: ## install style checker dependency: phpcs.phar
-	curl -Lo bin/phpcs.phar https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar
+	curl -Lo bin/phpcs.phar https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
 	chmod +x bin/phpcs.phar
 
 test-assignment: bin/phpunit.phar ## run single test using ASSIGNMENTS: test-assignment ASSIGNMENT=wordy

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # assignments
 ASSIGNMENT ?= ""
-IGNOREDIRS := "^(\.git|bin|docs|exercises)$$"
-ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort | grep -Ev $(IGNOREDIRS))
+ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort )
 
 # output directories
 TMPDIR ?= "/tmp"

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,7 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/


### PR DESCRIPTION
- PHPUnit 9 currently doesn't work with our autoloading/class name strategy - this will need more consideration (so specify PHPUnit 8)
- The codesniffer version we were using is several years out of date and has errors with PHP 7
- Also include PHP 7.4 support, and drop PHP 7.2 support (replaces #304 )