### PR TITLE
Fix deprecated string indexing

### DIFF
--- a/exercises/practice/luhn/example.php
+++ b/exercises/practice/luhn/example.php
@@ -12,14 +12,14 @@ function isValid($candidate)
     $sum = 0 ;
 
     for ($i = 1; $i < strlen($reversseCandidate); $i += 2) {
-        $digit = 2 * intval($reversseCandidate{$i}) ;
+        $digit = 2 * intval($reversseCandidate[$i]) ;
 
         if ($digit > 9) {
             $digit -= 9 ;
         }
 
         $sum += $digit ;
-        $sum += intval($reversseCandidate{$i - 1}) ;
+        $sum += intval($reversseCandidate[$i - 1]) ;
     }
 
     return $sum % 10 == 0 ;


### PR DESCRIPTION
While the CI was passing before, it seems to break if we update the setup-php action as recommended by dependabot because of a deprecated string indexing syntax. This fixes it in the exercise example that was raising the error.