### PR TITLE
Update README.md / Add script to download dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,30 @@ Exercism exercises in PHP
 
 ## Running Unit Test Suite
 
+### PHPUnit 8
+
 ```shell
-> ./bin/test.sh
+> PHPUNIT_BIN="./bin/phpunit-8.phar" ./bin/test.sh
+```
+
+### PHPUnit 9
+
+```shell
+> PHPUNIT_BIN="./bin/phpunit-9.phar" ./bin/test.sh
 ```
 
 ## Running Style Checker
 
+### PSR-2 rules
+
 ```shell
-> ./bin/lint.sh
+> PHPCS_BIN="./bin/phpcs.phar" PHPCS_RULES="./phpcs-php.xml" ./bin/lint.sh
+```
+
+### PSR-12 rules
+
+```shell
+> PHPCS_BIN="./bin/phpcs.phar" PHPCS_RULES="./phpcs-php-psr12.xml" ./bin/lint.sh
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PHP
 
 [![Configlet Status](https://github.com/exercism/php/workflows/Configlet%20CI/badge.svg)]
-[![Exercise Test Status](https://github.com/exercism/php/workflows/Exercise%20tests/badge.svg)]
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/68242198cd124a3ebcbdc291d0e0eda4)](https://www.codacy.com/app/borgogelli/php?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=borgogelli/php&amp;utm_campaign=Badge_Grade)
 
 Exercism exercises in PHP
@@ -10,35 +9,21 @@ Exercism exercises in PHP
 
 ### All dependencies
 
-	% make install
-
 ### Only tests dependencies
 
-	% make install-test
-
 ### Only style-check dependencies
-
-	% make install-style
 
 ## Running Unit Test Suite
 
 ### All Assignments
 
-    % make test
-
-### Single Assignment
-
-    % make test-assignment ASSIGNMENT=wordy
+    % ./bin/test.sh
 
 ## Running Style Checker
 
 ### All Assignments
 
-    % make style-check
-
-### Single Assignment
-
-    % make style-check-assignment ASSIGNMENT=wordy
+    % ./bin/lint.sh
 
 ## Help
 If you need command line help for run make commands
@@ -49,11 +34,9 @@ If you need command line help for run make commands
 
 - Follow the [PSR-2] coding style (PHP uses a slightly [modified] version of [PSR-2]).
 - Follow the [contributing guide].
-
-
+- CI is run on all pull requests, it must pass the required checks for merge.
 
 [PSR-2]: http://www.php-fig.org/psr/psr-2
 [contributing guide]: https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data
 [@group annotation]: http://phpunit.de/manual/4.1/en/appendixes.annotations.html#appendixes.annotations.group
 [modified]: phpcs-php.xml
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PHP
 
 [![Configlet Status](https://github.com/exercism/php/workflows/Configlet%20CI/badge.svg)]
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/68242198cd124a3ebcbdc291d0e0eda4)](https://www.codacy.com/app/borgogelli/php?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=borgogelli/php&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/68242198cd124a3ebcbdc291d0e0eda4)](https://www.codacy.com/app/borgogelli/php?utm_source=github.com&utm_medium=referral&utm_content=borgogelli/php&utm_campaign=Badge_Grade)
 
 Exercism exercises in PHP
 
@@ -9,26 +9,34 @@ Exercism exercises in PHP
 
 ### All dependencies
 
+```shell
+> ./bin/install.sh
+```
+
 ### Only tests dependencies
+
+```shell
+> ./bin/install-phpunit-8.sh
+> ./bin/install-phpunit-9.sh
+```
 
 ### Only style-check dependencies
 
+```shell
+> ./bin/install-phpcs.sh
+```
+
 ## Running Unit Test Suite
 
-### All Assignments
-
-    % ./bin/test.sh
+```shell
+> ./bin/test.sh
+```
 
 ## Running Style Checker
 
-### All Assignments
-
-    % ./bin/lint.sh
-
-## Help
-If you need command line help for run make commands
-
-	% make
+```shell
+> ./bin/lint.sh
+```
 
 ## Contributing
 
@@ -36,7 +44,7 @@ If you need command line help for run make commands
 - Follow the [contributing guide].
 - CI is run on all pull requests, it must pass the required checks for merge.
 
-[PSR-2]: http://www.php-fig.org/psr/psr-2
+[psr-2]: http://www.php-fig.org/psr/psr-2
 [contributing guide]: https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data
 [@group annotation]: http://phpunit.de/manual/4.1/en/appendixes.annotations.html#appendixes.annotations.group
 [modified]: phpcs-php.xml

--- a/bin/install-phpcs.sh
+++ b/bin/install-phpcs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl -Lo bin/phpcs.phar https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+chmod +x bin/phpcs.phar

--- a/bin/install-phpunit-8.sh
+++ b/bin/install-phpunit-8.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl -Lo ./bin/phpunit-8.phar https://phar.phpunit.de/phpunit-8.phar
+chmod +x bin/phpunit-8.phar

--- a/bin/install-phpunit-9.sh
+++ b/bin/install-phpunit-9.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl -Lo ./bin/phpunit-9.phar https://phar.phpunit.de/phpunit-9.phar
+chmod +x bin/phpunit-9.phar

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+./bin/install-phpunit-8.sh
+./bin/install-phpunit-9.sh
+./bin/install-phpcs.sh


### PR DESCRIPTION
I think following this PR's merge, bringing the new workflows and preparing for PHPUnit 9 and PSR 12 is mostly complete for now.

@iHiD will need to make the PHPUnit and PSR 12 workflow CI checks optional for now, but they provide a full reference of the work needed to be done to bring things up to spec.  When the repo has met those standards, we can then make them required and/or remove the PHPUnit 8 and PSR 2 workflows.