### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 PHP is a server-side language suited towards web development. The acronym is recursive, standing for _PHP: Hypertext Preprocessor_.
 
 Considerably more versatile than CGI scripting, PHP is often used to add interactivity to plain HTML and bolster web frameworks.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ### Which version to chose?
 
 We encourage to use a stable PHP release with active support. Currently this is **PHP 7.3 and 7.4**. Details on current releases and their timelines can be found at [php.net/supported-versions](https://www.php.net/supported-versions.php).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,16 +1,16 @@
 # Installation
 
-### Which version to chose?
+## Which version to chose?
 
 We encourage to use a stable PHP release with active support. Currently this is **PHP 7.3 and 7.4**. Details on current releases and their timelines can be found at [php.net/supported-versions](https://www.php.net/supported-versions.php).
 
-### Install PHP
+## Install PHP
 
 PHP can be downloaded and built from source, available at [php.net/downloads.php](http://php.net/downloads.php) or [windows.php.net/download](https://windows.php.net/download).
 
 > Note: A web server such as nginx or Apache HTTP server is not required to complete the exercises.
 
-#### Linux
+### Linux
 
 Different distributions have different methods. You should be able to
 
@@ -28,13 +28,13 @@ depending on your repository manager.
 
 For further instructions, read the manual on [Installation on Unix systems](https://www.php.net/manual/en/install.unix.php).
 
-#### macOS
+### macOS
 
 Normally macOS comes with PHP installed, but it is often an outdated version. There are other pre-built options available, including [MAMP](http://www.mamp.info/en/) and [php-osx.liip.ch](https://php-osx.liip.ch/).
 
 For further instructions, read the manual on [Installation on macOS](https://www.php.net/manual/en/install.macosx.php).
 
-#### Windows
+### Windows
 
 Official PHP binaries for Windows can be downloaded from [windows.php.net/download](https://windows.php.net/download).
 
@@ -42,7 +42,7 @@ There are pre-built stacks including [WAMP](http://www.wampserver.com/en/) - (Wi
 
 For further instructions, read the manual on [Installation on Windows systems](https://www.php.net/manual/en/install.windows.php).
 
-#### Other
+### Other
 
 If you want to use a different OS, see instruction on [php.net/manual/en/install](https://www.php.net/manual/en/install.php).
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 ## Recommended Learning Resources
 
 - [PHP The Right Way](http://www.phptherightway.com/)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Execute the tests with:
 
 ```shell

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,1 +1,3 @@
+# Instructions append
+
 The skipped tests near the bottom of the anagram_test.php are **Stretch Goals**, they are optional. They require the usage of `mb_string` functions, which aren't installed by default with every version of PHP.

--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -1,2 +1,4 @@
+# Instructions append
+
 The commented tests at the bottom of the bob_test.php are **Stretch Goals**, they are optional. They may be easier to
  solve if you are using the `mb_string` functions, which aren't installed by default with every version of PHP.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
