### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,16 +16,16 @@
   },
   "files": {
     "solution": [
-      "path/to/%{kebab_slug}.ext"
+      "%{pascal_slug}.php"
     ],
     "test": [
-      "path/to/%{kebab_slug}.ext"
+      "%{pascal_slug}Test.php"
     ],
     "example": [
-      "path/to/%{kebab_slug}.ext"
+      ".meta/example.php"
     ],
     "exemplar": [
-      "path/to/%{kebab_slug}.ext"
+      ".meta/exemplar.php"
     ]
   },
   "exercises": {

--- a/config.json
+++ b/config.json
@@ -14,6 +14,20 @@
     "indent_style": "space",
     "indent_size": 4
   },
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [],
     "practice": [
@@ -24,7 +38,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["optional_values", "text_formatting"]
+        "topics": [
+          "optional_values",
+          "text_formatting"
+        ]
       },
       {
         "slug": "hamming",
@@ -33,7 +50,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "gigasecond",
@@ -42,7 +62,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["dates"]
+        "topics": [
+          "dates"
+        ]
       },
       {
         "slug": "bob",
@@ -51,7 +73,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["control_flow_if_else_statements", "strings"]
+        "topics": [
+          "control_flow_if_else_statements",
+          "strings"
+        ]
       },
       {
         "slug": "rna-transcription",
@@ -60,7 +85,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "luhn",
@@ -78,7 +106,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "robot-name",
@@ -87,7 +118,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["classes", "randomness", "strings"]
+        "topics": [
+          "classes",
+          "randomness",
+          "strings"
+        ]
       },
       {
         "slug": "difference-of-squares",
@@ -96,7 +131,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["integers", "math"]
+        "topics": [
+          "integers",
+          "math"
+        ]
       },
       {
         "slug": "grade-school",
@@ -105,7 +143,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "robot-simulator",
@@ -114,7 +154,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["oop"]
+        "topics": [
+          "oop"
+        ]
       },
       {
         "slug": "run-length-encoding",
@@ -123,7 +165,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["algorithms", "strings", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "strings",
+          "text_formatting"
+        ]
       },
       {
         "slug": "largest-series-product",
@@ -132,7 +178,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": ["integers", "math", "strings", "transforming"]
+        "topics": [
+          "integers",
+          "math",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "accumulate",
@@ -141,7 +192,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["extension_methods", "sequences", "transforming"]
+        "topics": [
+          "extension_methods",
+          "sequences",
+          "transforming"
+        ]
       },
       {
         "slug": "acronym",
@@ -150,7 +205,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "all-your-base",
@@ -159,7 +217,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "anagram",
@@ -168,7 +228,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["filtering", "strings"]
+        "topics": [
+          "filtering",
+          "strings"
+        ]
       },
       {
         "slug": "atbash-cipher",
@@ -177,7 +240,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "strings", "transforming"]
+        "topics": [
+          "algorithms",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "beer-song",
@@ -186,7 +253,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "text_formatting"
+        ]
       },
       {
         "slug": "binary",
@@ -195,7 +265,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "bowling",
@@ -204,7 +276,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "control_flow_loops"]
+        "topics": [
+          "algorithms",
+          "control_flow_loops"
+        ]
       },
       {
         "slug": "change",
@@ -213,7 +288,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["arrays", "integers"]
+        "topics": [
+          "arrays",
+          "integers"
+        ]
       },
       {
         "slug": "clock",
@@ -222,7 +300,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["structural_equality", "time"]
+        "topics": [
+          "structural_equality",
+          "time"
+        ]
       },
       {
         "slug": "collatz-conjecture",
@@ -264,7 +345,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["lists", "loops", "strings"]
+        "topics": [
+          "lists",
+          "loops",
+          "strings"
+        ]
       },
       {
         "slug": "etl",
@@ -273,7 +358,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["dictionaries", "lists", "transforming"]
+        "topics": [
+          "dictionaries",
+          "lists",
+          "transforming"
+        ]
       },
       {
         "slug": "leap",
@@ -282,7 +371,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["integers"]
+        "topics": [
+          "integers"
+        ]
       },
       {
         "slug": "matching-brackets",
@@ -291,7 +382,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["parsing", "strings"]
+        "topics": [
+          "parsing",
+          "strings"
+        ]
       },
       {
         "slug": "meetup",
@@ -309,7 +403,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["parsing", "transforming"]
+        "topics": [
+          "parsing",
+          "transforming"
+        ]
       },
       {
         "slug": "nucleotide-count",
@@ -318,7 +415,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["dictionaries", "strings"]
+        "topics": [
+          "dictionaries",
+          "strings"
+        ]
       },
       {
         "slug": "perfect-numbers",
@@ -327,7 +427,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "phone-number",
@@ -336,7 +438,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["parsing", "transforming"]
+        "topics": [
+          "parsing",
+          "transforming"
+        ]
       },
       {
         "slug": "rail-fence-cipher",
@@ -345,7 +450,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "cryptography", "lists", "text_formatting"]
+        "topics": [
+          "algorithms",
+          "cryptography",
+          "lists",
+          "text_formatting"
+        ]
       },
       {
         "slug": "series",
@@ -363,7 +473,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["filtering", "math"]
+        "topics": [
+          "filtering",
+          "math"
+        ]
       },
       {
         "slug": "space-age",
@@ -372,7 +485,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["floating_point_numbers"]
+        "topics": [
+          "floating_point_numbers"
+        ]
       },
       {
         "slug": "transpose",
@@ -397,7 +512,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["enumerations", "integers"]
+        "topics": [
+          "enumerations",
+          "integers"
+        ]
       },
       {
         "slug": "trinary",
@@ -406,7 +524,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "two-fer",
@@ -415,7 +535,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["strings"]
+        "topics": [
+          "strings"
+        ]
       },
       {
         "slug": "variable-length-quantity",
@@ -424,7 +546,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["algorithms", "bitwise_operations"]
+        "topics": [
+          "algorithms",
+          "bitwise_operations"
+        ]
       },
       {
         "slug": "word-count",
@@ -433,7 +558,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["dictionaries", "strings", "transforming"]
+        "topics": [
+          "dictionaries",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "wordy",
@@ -442,7 +571,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": ["parsing", "strings", "transforming"]
+        "topics": [
+          "parsing",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "armstrong-numbers",
@@ -451,7 +584,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       },
       {
         "slug": "flatten-array",
@@ -460,7 +596,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["arrays"]
+        "topics": [
+          "arrays"
+        ]
       },
       {
         "slug": "queen-attack",
@@ -469,7 +607,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["integers"]
+        "topics": [
+          "integers"
+        ]
       },
       {
         "slug": "raindrops",
@@ -478,7 +618,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["filtering", "text_formatting"]
+        "topics": [
+          "filtering",
+          "text_formatting"
+        ]
       },
       {
         "slug": "scrabble-score",
@@ -487,7 +630,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["control_flow_loops", "integers", "strings"]
+        "topics": [
+          "control_flow_loops",
+          "integers",
+          "strings"
+        ]
       },
       {
         "slug": "sum-of-multiples",
@@ -496,7 +643,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "affine-cipher",
@@ -505,7 +654,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["cryptography", "math", "strings"]
+        "topics": [
+          "cryptography",
+          "math",
+          "strings"
+        ]
       },
       {
         "slug": "allergies",
@@ -514,7 +667,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["bitwise_operations", "filtering"]
+        "topics": [
+          "bitwise_operations",
+          "filtering"
+        ]
       },
       {
         "slug": "binary-search",
@@ -532,7 +688,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms"]
+        "topics": [
+          "algorithms"
+        ]
       },
       {
         "slug": "grains",
@@ -541,7 +699,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "floating_point_numbers"]
+        "topics": [
+          "algorithms",
+          "floating_point_numbers"
+        ]
       },
       {
         "slug": "markdown",
@@ -550,7 +711,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["refactoring"]
+        "topics": [
+          "refactoring"
+        ]
       },
       {
         "slug": "nth-prime",
@@ -559,7 +722,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "ocr-numbers",
@@ -568,7 +733,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["algorithms", "strings", "transforming"]
+        "topics": [
+          "algorithms",
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "pascals-triangle",
@@ -577,7 +746,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "prime-factors",
@@ -586,7 +757,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": ["math"]
+        "topics": [
+          "math"
+        ]
       },
       {
         "slug": "pangram",
@@ -595,7 +768,9 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["strings"]
+        "topics": [
+          "strings"
+        ]
       },
       {
         "slug": "pig-latin",
@@ -604,7 +779,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["strings", "transforming"]
+        "topics": [
+          "strings",
+          "transforming"
+        ]
       },
       {
         "slug": "roman-numerals",
@@ -613,7 +791,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": ["control_flow_loops", "transforming"]
+        "topics": [
+          "control_flow_loops",
+          "transforming"
+        ]
       },
       {
         "slug": "palindrome-products",
@@ -622,7 +803,10 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": ["algorithms", "math"]
+        "topics": [
+          "algorithms",
+          "math"
+        ]
       }
     ]
   },


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
