### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "70e0f03a-58d9-4ef5-a541-8eeeef6fbbbf",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing PHP locally",
+      "blurb": "Learn how to install PHP locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "3fc49161-d224-4a1b-a741-894847232521",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn PHP",
+      "blurb": "An overview of how to get started from scratch with PHP"
+    },
+    {
+      "uuid": "2e799044-c3a1-40a8-833a-6407fe7ec7ce",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the PHP track",
+      "blurb": "Learn how to test your PHP exercises on Exercism"
+    },
+    {
+      "uuid": "6cd7aa02-1632-4ecc-b46d-163c41e47b35",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful PHP resources",
+      "blurb": "A collection of useful resources to help you master PHP"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
