### PR TITLE
all-your-base: Flip argument order in test assertions to match PHPUnit expectations

### DIFF
--- a/exercises/practice/all-your-base/AllYourBaseTest.php
+++ b/exercises/practice/all-your-base/AllYourBaseTest.php
@@ -13,106 +13,106 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     public function testSingleBitOneToDecimal(): void
     {
-        $this->assertEquals(rebase(2, [1], 10), [1]);
+        $this->assertEquals([1], rebase(2, [1], 10));
     }
 
     public function testBinaryToSingleDecimal(): void
     {
-        $this->assertEquals(rebase(2, [1, 0, 1], 10), [5]);
+        $this->assertEquals([5], rebase(2, [1, 0, 1], 10));
     }
 
     public function testSingleDecimalToBinary(): void
     {
-        $this->assertEquals(rebase(10, [5], 2), [1, 0, 1]);
+        $this->assertEquals([1, 0, 1], rebase(10, [5], 2));
     }
 
     public function testBinaryToMultipleDecimal(): void
     {
-        $this->assertEquals(rebase(2, [1, 0, 1, 0, 1, 0], 10), [4, 2]);
+        $this->assertEquals([4, 2], rebase(2, [1, 0, 1, 0, 1, 0], 10));
     }
 
     public function testDecimalToBinary(): void
     {
-        $this->assertEquals(rebase(10, [4, 2], 2), [1, 0, 1, 0, 1, 0]);
+        $this->assertEquals([1, 0, 1, 0, 1, 0], rebase(10, [4, 2], 2));
     }
 
     public function testTrinaryToHexadecimal(): void
     {
-        $this->assertEquals(rebase(3, [1, 1, 2, 0], 16), [2, 10]);
+        $this->assertEquals([2, 10], rebase(3, [1, 1, 2, 0], 16));
     }
 
     public function testHexadecimalToTrinary(): void
     {
-        $this->assertEquals(rebase(16, [2, 10], 3), [1, 1, 2, 0]);
+        $this->assertEquals([1, 1, 2, 0], rebase(16, [2, 10], 3));
     }
 
     public function test15BitIntegers(): void
     {
-        $this->assertEquals(rebase(97, [3, 46, 60], 73), [6, 10, 45]);
+        $this->assertEquals([6, 10, 45], rebase(97, [3, 46, 60], 73));
     }
 
     public function testEmptyListReturnsNull(): void
     {
-        $this->assertEquals(rebase(10, [], 10), null);
+        $this->assertEquals(null, rebase(10, [], 10));
     }
 
     public function testSingleZeroReturnsNull(): void
     {
-        $this->assertEquals(rebase(10, [0], 2), null);
+        $this->assertEquals(null, rebase(10, [0], 2));
     }
 
     public function testMultipleZerosReturnsNull(): void
     {
-        $this->assertEquals(rebase(10, [0, 0, 0], 2), null);
+        $this->assertEquals(null, rebase(10, [0, 0, 0], 2));
     }
 
     public function testLeadingZerosReturnsNull(): void
     {
-        $this->assertEquals(rebase(10, [0, 6, 0], 2), null);
+        $this->assertEquals(null, rebase(10, [0, 6, 0], 2));
     }
 
     public function testFirstBaseIsOne(): void
     {
-        $this->assertEquals(rebase(1, [6, 0], 2), null);
+        $this->assertEquals(null, rebase(1, [6, 0], 2));
     }
 
     public function testFirstBaseIsZero(): void
     {
-        $this->assertEquals(rebase(0, [6, 0], 2), null);
+        $this->assertEquals(null, rebase(0, [6, 0], 2));
     }
 
     public function testFirstBaseIsNegative(): void
     {
-        $this->assertEquals(rebase(-1, [6, 0], 2), null);
+        $this->assertEquals(null, rebase(-1, [6, 0], 2));
     }
 
     public function testNegativeDigit(): void
     {
-        $this->assertEquals(rebase(10, [1, -1, 0], 2), null);
+        $this->assertEquals(null, rebase(10, [1, -1, 0], 2));
     }
 
     public function testInvalidPositiveDigit(): void
     {
-        $this->assertEquals(rebase(2, [1, 2, 0], 10), null);
+        $this->assertEquals(null, rebase(2, [1, 2, 0], 10));
     }
 
     public function testSecondBaseIsOne(): void
     {
-        $this->assertEquals(rebase(2, [1, 1, 0], 1), null);
+        $this->assertEquals(null, rebase(2, [1, 1, 0], 1));
     }
 
     public function testSecondBaseIsZero(): void
     {
-        $this->assertEquals(rebase(2, [1, 1, 0], 0), null);
+        $this->assertEquals(null, rebase(2, [1, 1, 0], 0));
     }
 
     public function testSecondBaseIsNegative(): void
     {
-        $this->assertEquals(rebase(2, [1, 1, 0], -1), null);
+        $this->assertEquals(null, rebase(2, [1, 1, 0], -1));
     }
 
     public function testBothBasesIsNegative(): void
     {
-        $this->assertEquals(rebase(-3, [1, 1, 0], -1), null);
+        $this->assertEquals(null, rebase(-3, [1, 1, 0], -1));
     }
 }


### PR DESCRIPTION
I just stumbled over the tests telling me unexpected things about what was wrong. It turned out to be caused by the order of `$actual,$expected` in the tests, instead of PHPUnit's `$expected, $actual`. This pull request flips that to PHPUnit's order.