### PR TITLE
Add maskify exercise

### DIFF
--- a/exercises/practice/mask-credit-card/.docs/instructions.md
+++ b/exercises/practice/mask-credit-card/.docs/instructions.md
@@ -1,0 +1,15 @@
+# Instructions
+
+Create a function `maskify` to mask digits of a credit card number with `#`.
+
+**Requirements:**
+
+- Do not mask the first digit and the last four digits
+- Do not mask non-digit chars
+- Do not mask if the input is less than 6
+- Return '' when input is empty
+
+**Examples:**
+
+- `1234-5678-9012` converts to `1###-####-9012`
+- `123456789012` converts to `1#######9012`

--- a/exercises/practice/mask-credit-card/.meta/config.json
+++ b/exercises/practice/mask-credit-card/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "authors": [
+    {
+      "github_username": "codedge",
+      "exercism_username": "codedge"
+    }
+  ],
+  "contributors": [
+    {
+      "github_username": "neenjaw",
+      "exercism_username": "neenjaw"
+    }
+  ],
+  "files": {
+    "solution": [
+      "MaskCreditCard.php"
+    ],
+    "test": [
+      "MaskCreditCardTest.php"
+    ],
+    "example": [
+      ".meta/example.php"
+    ]
+  },
+  "source": "",
+  "source_url": ""
+}

--- a/exercises/practice/mask-credit-card/.meta/example.php
+++ b/exercises/practice/mask-credit-card/.meta/example.php
@@ -1,0 +1,33 @@
+<?php
+
+function maskify(string $cc): string
+{
+    // Do no mask if cc less than 6 or empty string
+    if (strlen($cc) < 6) {
+        return $cc;
+    }
+
+    $masked = [];
+    $ccArr = str_split($cc);
+    $length = count($ccArr);
+
+    foreach ($ccArr as $idx => $item) {
+        // Exclude first and last four items
+        if (0 === $idx || $idx >= $length - 4) {
+            $masked[] = $item;
+            continue;
+        }
+
+        // All non digits
+        preg_match('/[^0-9]/', $item, $matches);
+
+        if (count($matches) > 0) {
+            $masked[] = $item;
+            continue;
+        }
+
+        array_push($masked, '#');
+    }
+
+    return implode('', $masked);
+}

--- a/exercises/practice/mask-credit-card/MaskCreditCard.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCard.php
@@ -1,0 +1,5 @@
+<?php
+
+function maskify(string $cc): string {
+    throw new \BadFunctionCallException("Implement the maskify function");
+}

--- a/exercises/practice/mask-credit-card/MaskCreditCard.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCard.php
@@ -1,5 +1,6 @@
 <?php
 
-function maskify(string $cc): string {
+function maskify(string $cc): string
+{
     throw new \BadFunctionCallException("Implement the maskify function");
 }

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -1,0 +1,24 @@
+<?php
+
+class MaskCreditCardTest extends PHPUnit\Framework\TestCase
+{
+    public function testDoNotMaskShorterThan6Chars()
+    {
+        $this->assertSame('12345', maskify('12345'));
+    }
+
+    public function testReturnEmptyStringWhenEmpty()
+    {
+        $this->assertSame('', maskify(''));
+    }
+
+    public function testMaskCcWithDashes()
+    {
+        $this->assertSame('1###-####-9012', maskify('1234-5678-9012'));
+    }
+
+    public function testMaskCcWithoutDashes()
+    {
+        $this->assertSame('1#######9012', maskify('123456789012'));
+    }
+}

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -2,6 +2,11 @@
 
 class MaskCreditCardTest extends PHPUnit\Framework\TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        require_once 'MaskCreditCard.php';
+    }
+
     public function testDoNotMaskShorterThan6Chars()
     {
         $this->assertSame('12345', maskify('12345'));


### PR DESCRIPTION
This adds an exercise to maskify a credit card number with `#`.

**Examples:**

- `1234-5678-9012` converts to `1###-####-9012`
- `123456789012` converts to `1#######9012`