### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [
-    "pmatseykanets"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["pmatseykanets"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Accumulate.php"
-    ],
-    "test": [
-      "AccumulateTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Accumulate.php"],
+    "test": ["AccumulateTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [],
+  "authors": [
+    "pmatseykanets"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Accumulate.php"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [],
+  "authors": [
+    "pmatseykanets"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Acronym.php"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [
-    "pmatseykanets"
-  ],
+  "authors": ["pmatseykanets"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "Acronym.php"
-    ],
-    "test": [
-      "AcronymTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Acronym.php"],
+    "test": ["AcronymTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "AffineCipher.php"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "mk-mxp",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "AllYourBase.php"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,27 +1,18 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [
-    "mikeSimonson"
-  ],
+  "authors": ["mikeSimonson"],
   "contributors": [
     "arueckauer",
     "DerTee",
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Allergies.php"
-    ],
-    "test": [
-      "AllergiesTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Allergies.php"],
+    "test": ["AllergiesTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [],
+  "authors": [
+    "mikeSimonson"
+  ],
+  "contributors": [
+    "arueckauer",
+    "DerTee",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Allergies.php"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [],
+  "authors": [
+    "ecrmnn"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Anagram.php"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [
-    "ecrmnn"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["ecrmnn"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Anagram.php"
-    ],
-    "test": [
-      "AnagramTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Anagram.php"],
+    "test": ["AnagramTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [],
+  "authors": [
+    "amscotti"
+  ],
+  "contributors": [
+    "arueckauer",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "ArmstrongNumbers.php"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [
-    "nhoag"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["nhoag"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "AtbashCipher.php"
-    ],
-    "test": [
-      "AtbashCipherTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["AtbashCipher.php"],
+    "test": ["AtbashCipherTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [],
+  "authors": [
+    "nhoag"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "AtbashCipher.php"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": [
-    "nhoag"
-  ],
+  "authors": ["nhoag"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "BeerSong.php"
-    ],
-    "test": [
-      "BeerSongTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["BeerSong.php"],
+    "test": ["BeerSongTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": [],
+  "authors": [
+    "nhoag"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "BeerSong.php"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [
-    "arthurchipdean"
-  ],
+  "authors": ["arthurchipdean"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "BinarySearch.php"
-    ],
-    "test": [
-      "BinarySearchTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["BinarySearch.php"],
+    "test": ["BinarySearchTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [],
+  "authors": [
+    "arthurchipdean"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "BinarySearch.php"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [
-    "pmatseykanets"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["pmatseykanets"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Binary.php"
-    ],
-    "test": [
-      "BinaryTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Binary.php"],
+    "test": ["BinaryTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [],
+  "authors": [
+    "pmatseykanets"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Binary.php"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [
-    "brettsantore"
-  ],
+  "authors": ["brettsantore"],
   "contributors": [
     "arueckauer",
     "DerTee",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Bob.php"
-    ],
-    "test": [
-      "BobTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Bob.php"],
+    "test": ["BobTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [],
+  "authors": [
+    "brettsantore"
+  ],
+  "contributors": [
+    "arueckauer",
+    "DerTee",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Bob.php"

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
-  "authors": [],
+  "authors": [
+    "Hrumpa"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "BookStore.php"

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
-  "authors": [
-    "Hrumpa"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["Hrumpa"],
+  "contributors": ["arueckauer", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "BookStore.php"
-    ],
-    "test": [
-      "BookStoreTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["BookStore.php"],
+    "test": ["BookStoreTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",
   "source_url": "http://cyber-dojo.org"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -8,19 +8,12 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Bowling.php"
-    ],
-    "test": [
-      "BowlingTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Bowling.php"],
+    "test": ["BowlingTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Score a bowling game",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "DerTee",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Bowling.php"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": [],
+  "authors": [
+    "petemcfarlane"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "leNEKO",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "Change.php"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [],
+  "authors": [
+    "jrdnull"
+  ],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Clock.php"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,27 +1,18 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [
-    "jrdnull"
-  ],
+  "authors": ["jrdnull"],
   "contributors": [
     "arueckauer",
     "dkinzer",
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Clock.php"
-    ],
-    "test": [
-      "ClockTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Clock.php"],
+    "test": ["ClockTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
-  "authors": [],
+  "authors": [
+    "kk-r"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "CollatzConjecture.php"

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,8 +1,6 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": [
-    "pminten"
-  ],
+  "authors": ["pminten"],
   "contributors": [
     "arueckauer",
     "dkinzer",
@@ -10,19 +8,12 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "Connect.php"
-    ],
-    "test": [
-      "ConnectTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Connect.php"],
+    "test": ["ConnectTest.php"],
+    "example": [".meta/example.php"]
   }
 }

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": [],
+  "authors": [
+    "pminten"
+  ],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "karptonite",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Connect.php"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "dstockto",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "CryptoSquare.php"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": [
-    "camilopayan"
-  ],
+  "authors": ["camilopayan"],
   "contributors": [
     "arueckauer",
     "dstockto",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "CryptoSquare.php"
-    ],
-    "test": [
-      "CryptoSquareTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["CryptoSquare.php"],
+    "test": ["CryptoSquareTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "neenjaw",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Diamond.php"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
-  "authors": [
-    "camilopayan"
-  ],
-  "contributors": [
-    "arueckauer",
-    "neenjaw",
-    "yisraeldov"
-  ],
+  "authors": ["camilopayan"],
+  "contributors": ["arueckauer", "yisraeldov"],
   "files": {
-    "solution": [
-      "Diamond.php"
-    ],
-    "test": [
-      "DiamondTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Diamond.php"],
+    "test": ["DiamondTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -7,20 +7,13 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane",
     "Scientifica96"
   ],
   "files": {
-    "solution": [
-      "DifferenceOfSquares.php"
-    ],
-    "test": [
-      "DifferenceOfSquaresTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["DifferenceOfSquares.php"],
+    "test": ["DifferenceOfSquaresTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane",
+    "Scientifica96"
+  ],
   "files": {
     "solution": [
       "DifferenceOfSquares.php"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [
-    "camilopayan"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["camilopayan"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Etl.php"
-    ],
-    "test": [
-      "EtlTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Etl.php"],
+    "test": ["EtlTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Etl.php"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": [],
+  "authors": [
+    "kk-r"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "FlattenArray.php"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -9,7 +9,6 @@
     "kytrinyx",
     "lafent",
     "MatheusNaldi",
-    "neenjaw",
     "petemcfarlane",
     "peteraba",
     "TFarla",
@@ -17,15 +16,9 @@
     "zembrowski"
   ],
   "files": {
-    "solution": [
-      "Gigasecond.php"
-    ],
-    "test": [
-      "GigasecondTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Gigasecond.php"],
+    "test": ["GigasecondTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "Dog",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "MatheusNaldi",
+    "neenjaw",
+    "petemcfarlane",
+    "peteraba",
+    "TFarla",
+    "tstirrat15",
+    "zembrowski"
+  ],
   "files": {
     "solution": [
       "Gigasecond.php"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -7,20 +7,13 @@
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "rossbearman"
   ],
   "files": {
-    "solution": [
-      "GradeSchool.php"
-    ],
-    "test": [
-      "GradeSchoolTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["GradeSchool.php"],
+    "test": ["GradeSchoolTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "DerTee",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "rossbearman"
+  ],
   "files": {
     "solution": [
       "GradeSchool.php"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [
-    "Hrumpa"
-  ],
-  "contributors": [
-    "arueckauer",
-    "G-Rath",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["Hrumpa"],
+  "contributors": ["arueckauer", "G-Rath", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Grains.php"
-    ],
-    "test": [
-      "GrainsTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Grains.php"],
+    "test": ["GrainsTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [],
+  "authors": [
+    "Hrumpa"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Grains.php"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "Dog",
+    "kip-13",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "marvinrabe",
+    "neenjaw",
+    "petemcfarlane",
+    "rossbearman"
+  ],
   "files": {
     "solution": [
       "Hamming.php"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -10,20 +10,13 @@
     "kytrinyx",
     "lafent",
     "marvinrabe",
-    "neenjaw",
     "petemcfarlane",
     "rossbearman"
   ],
   "files": {
-    "solution": [
-      "Hamming.php"
-    ],
-    "test": [
-      "HammingTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Hamming.php"],
+    "test": ["HammingTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [],
+  "authors": [
+    "duffn"
+  ],
+  "contributors": [
+    "arueckauer",
+    "joseph-walker",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "HelloWorld.php"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [
-    "duffn"
-  ],
-  "contributors": [
-    "arueckauer",
-    "joseph-walker",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["duffn"],
+  "contributors": ["arueckauer", "joseph-walker", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "HelloWorld.php"
-    ],
-    "test": [
-      "HelloWorldTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["HelloWorld.php"],
+    "test": ["HelloWorldTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
-  "authors": [
-    "ecrmnn"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["ecrmnn"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Isogram.php"
-    ],
-    "test": [
-      "IsogramTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Isogram.php"],
+    "test": ["IsogramTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
-  "authors": [],
+  "authors": [
+    "ecrmnn"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Isogram.php"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [],
+  "authors": [
+    "brettsantore"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "LargestSeriesProduct.php"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,27 +1,18 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [
-    "brettsantore"
-  ],
+  "authors": ["brettsantore"],
   "contributors": [
     "arueckauer",
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "LargestSeriesProduct.php"
-    ],
-    "test": [
-      "LargestSeriesProductTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["LargestSeriesProduct.php"],
+    "test": ["LargestSeriesProductTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -7,19 +7,12 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Leap.php"
-    ],
-    "test": [
-      "LeapTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Leap.php"],
+    "test": ["LeapTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Leap.php"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [],
+  "authors": [
+    "Pierre-Vdsp"
+  ],
+  "contributors": [
+    "arueckauer",
+    "dstockto",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Luhn.php"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [
-    "Pierre-Vdsp"
-  ],
+  "authors": ["Pierre-Vdsp"],
   "contributors": [
     "arueckauer",
     "dstockto",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "Luhn.php"
-    ],
-    "test": [
-      "LuhnTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Luhn.php"],
+    "test": ["LuhnTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -1,23 +1,10 @@
 {
   "blurb": "Refactor a Markdown parser",
-  "authors": [
-    "petemcfarlane"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kytrinyx",
-    "neenjaw",
-    "yisraeldov"
-  ],
+  "authors": ["petemcfarlane"],
+  "contributors": ["arueckauer", "kytrinyx", "yisraeldov"],
   "files": {
-    "solution": [
-      "Markdown.php"
-    ],
-    "test": [
-      "MarkdownTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Markdown.php"],
+    "test": ["MarkdownTest.php"],
+    "example": [".meta/example.php"]
   }
 }

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Refactor a Markdown parser",
-  "authors": [],
+  "authors": [
+    "petemcfarlane"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kytrinyx",
+    "neenjaw",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Markdown.php"

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [],
+  "authors": [
+    "petemcfarlane"
+  ],
+  "contributors": [
+    "amscotti",
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "MatchingBrackets.php"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Calculate the date of meetups.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "Meetup.php"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": [],
+  "authors": [
+    "petemcfarlane"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "Minesweeper.php"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": [
-    "arthurchipdean"
-  ],
+  "authors": ["arthurchipdean"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "NthPrime.php"
-    ],
-    "test": [
-      "NthPrimeTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["NthPrime.php"],
+    "test": ["NthPrimeTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": [],
+  "authors": [
+    "arthurchipdean"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "NthPrime.php"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [],
+  "authors": [
+    "mikeSimonson"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "NucleotideCount.php"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,24 +1,11 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [
-    "mikeSimonson"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["mikeSimonson"],
+  "contributors": ["arueckauer", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "NucleotideCount.php"
-    ],
-    "test": [
-      "NucleotideCountTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["NucleotideCount.php"],
+    "test": ["NucleotideCountTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": [
-    "Hrumpa"
-  ],
-  "contributors": [
-    "arueckauer",
-    "G-Rath",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["Hrumpa"],
+  "contributors": ["arueckauer", "G-Rath", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "OcrNumbers.php"
-    ],
-    "test": [
-      "OcrNumbersTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["OcrNumbers.php"],
+    "test": ["OcrNumbersTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": [],
+  "authors": [
+    "Hrumpa"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "OcrNumbers.php"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,23 +1,11 @@
 {
   "blurb": "Detect palindrome products in a given range.",
-  "authors": [
-    "camilopayan"
-  ],
-  "contributors": [
-    "arueckauer",
-    "neenjaw",
-    "yisraeldov"
-  ],
+  "authors": ["camilopayan"],
+  "contributors": ["arueckauer", "yisraeldov"],
   "files": {
-    "solution": [
-      "PalindromeProducts.php"
-    ],
-    "test": [
-      "PalindromeProductsTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["PalindromeProducts.php"],
+    "test": ["PalindromeProductsTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Detect palindrome products in a given range.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "neenjaw",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "PalindromeProducts.php"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [],
+  "authors": [
+    "ecrmnn"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "rossbearman"
+  ],
   "files": {
     "solution": [
       "Pangram.php"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [
-    "ecrmnn"
-  ],
+  "authors": ["ecrmnn"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "rossbearman"
   ],
   "files": {
-    "solution": [
-      "Pangram.php"
-    ],
-    "test": [
-      "PangramTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Pangram.php"],
+    "test": ["PangramTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [],
+  "authors": [
+    "arthurchipdean"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "PascalsTriangle.php"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [
-    "arthurchipdean"
-  ],
+  "authors": ["arthurchipdean"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "PascalsTriangle.php"
-    ],
-    "test": [
-      "PascalsTriangleTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["PascalsTriangle.php"],
+    "test": ["PascalsTriangleTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": [],
+  "authors": [
+    "Pierre-Vdsp"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "PerfectNumbers.php"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [],
+  "authors": [
+    "nhoag"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "PhoneNumber.php"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [
-    "nhoag"
-  ],
+  "authors": ["nhoag"],
   "contributors": [
     "arueckauer",
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "PhoneNumber.php"
-    ],
-    "test": [
-      "PhoneNumberTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["PhoneNumber.php"],
+    "test": ["PhoneNumberTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": [],
+  "authors": [
+    "brettsantore"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "woylie"
+  ],
   "files": {
     "solution": [
       "PigLatin.php"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": [
-    "brettsantore"
-  ],
+  "authors": ["brettsantore"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "woylie"
   ],
   "files": {
-    "solution": [
-      "PigLatin.php"
-    ],
-    "test": [
-      "PigLatinTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["PigLatin.php"],
+    "test": ["PigLatinTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": [
-    "arthurchipdean"
-  ],
+  "authors": ["arthurchipdean"],
   "contributors": [
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "PrimeFactors.php"
-    ],
-    "test": [
-      "PrimeFactorsTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["PrimeFactors.php"],
+    "test": ["PrimeFactorsTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": [],
+  "authors": [
+    "arthurchipdean"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "PrimeFactors.php"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": [],
+  "authors": [
+    "MichaelBunker"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "QueenAttack.php"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": [
-    "MichaelBunker"
-  ],
+  "authors": ["MichaelBunker"],
   "contributors": [
     "arueckauer",
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "QueenAttack.php"
-    ],
-    "test": [
-      "QueenAttackTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["QueenAttack.php"],
+    "test": ["QueenAttackTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Implement encoding and decoding for the rail fence cipher.",
-  "authors": [
-    "kk-r"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "yisraeldov"
-  ],
+  "authors": ["kk-r"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "yisraeldov"],
   "files": {
-    "solution": [
-      "RailFenceCipher.php"
-    ],
-    "test": [
-      "RailFenceCipherTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["RailFenceCipher.php"],
+    "test": ["RailFenceCipherTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Implement encoding and decoding for the rail fence cipher.",
-  "authors": [],
+  "authors": [
+    "kk-r"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "RailFenceCipher.php"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -8,19 +8,12 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Raindrops.php"
-    ],
-    "test": [
-      "RaindropsTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Raindrops.php"],
+    "test": ["RaindropsTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kenden",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Raindrops.php"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -7,19 +7,12 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "RnaTranscription.php"
-    ],
-    "test": [
-      "RnaTranscriptionTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["RnaTranscription.php"],
+    "test": ["RnaTranscriptionTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "RnaTranscription.php"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Manage robot factory settings.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "DerTee",
+    "dkinzer",
+    "Dog",
+    "Hrumpa",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "masters3d",
+    "neenjaw",
+    "petemcfarlane",
+    "schorsch3000"
+  ],
   "files": {
     "solution": [
       "RobotName.php"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -11,20 +11,13 @@
     "kytrinyx",
     "lafent",
     "masters3d",
-    "neenjaw",
     "petemcfarlane",
     "schorsch3000"
   ],
   "files": {
-    "solution": [
-      "RobotName.php"
-    ],
-    "test": [
-      "RobotNameTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["RobotName.php"],
+    "test": ["RobotNameTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [],
+  "authors": [
+    "Hrumpa"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "RobotSimulator.php"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [
-    "Hrumpa"
-  ],
-  "contributors": [
-    "arueckauer",
-    "G-Rath",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["Hrumpa"],
+  "contributors": ["arueckauer", "G-Rath", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "RobotSimulator.php"
-    ],
-    "test": [
-      "RobotSimulatorTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["RobotSimulator.php"],
+    "test": ["RobotSimulatorTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "Dog",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane",
+    "zembrowski"
+  ],
   "files": {
     "solution": [
       "RomanNumerals.php"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -8,20 +8,13 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane",
     "zembrowski"
   ],
   "files": {
-    "solution": [
-      "RomanNumerals.php"
-    ],
-    "test": [
-      "RomanNumeralsTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["RomanNumerals.php"],
+    "test": ["RomanNumeralsTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": [],
+  "authors": [
+    "Leprechaunz"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "RunLengthEncoding.php"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [],
+  "authors": [
+    "MichaelBunker"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "ScrabbleScore.php"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [
-    "MichaelBunker"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["MichaelBunker"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "ScrabbleScore.php"
-    ],
-    "test": [
-      "ScrabbleScoreTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["ScrabbleScore.php"],
+    "test": ["ScrabbleScoreTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "dstockto",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "Series.php"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [
-    "jeslopcru"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["jeslopcru"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Sieve.php"
-    ],
-    "test": [
-      "SieveTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Sieve.php"],
+    "test": ["SieveTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [],
+  "authors": [
+    "jeslopcru"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Sieve.php"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "SpaceAge.php"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [
-    "camilopayan"
-  ],
+  "authors": ["camilopayan"],
   "contributors": [
     "arueckauer",
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "SpaceAge.php"
-    ],
-    "test": [
-      "SpaceAgeTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["SpaceAge.php"],
+    "test": ["SpaceAgeTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [],
+  "authors": [
+    "arthurchipdean"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kytrinyx",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "SumOfMultiples.php"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [],
+  "authors": [
+    "kk-r"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Transpose.php"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [
-    "kk-r"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["kk-r"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "Transpose.php"
-    ],
-    "test": [
-      "TransposeTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Transpose.php"],
+    "test": ["TransposeTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [
-    "camilopayan"
-  ],
+  "authors": ["camilopayan"],
   "contributors": [
     "arueckauer",
     "G-Rath",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "Triangle.php"
-    ],
-    "test": [
-      "TriangleTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Triangle.php"],
+    "test": ["TriangleTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [],
+  "authors": [
+    "camilopayan"
+  ],
+  "contributors": [
+    "arueckauer",
+    "G-Rath",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "Triangle.php"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -8,20 +8,13 @@
     "kytrinyx",
     "lafent",
     "LucasThompson",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "Trinary.php"
-    ],
-    "test": [
-      "TrinaryTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Trinary.php"],
+    "test": ["TrinaryTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "All of Computer Science",
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "LucasThompson",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Trinary.php"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [],
+  "authors": [
+    "rossbearman"
+  ],
+  "contributors": [
+    "arueckauer",
+    "neenjaw"
+  ],
   "files": {
     "solution": [
       "TwoFer.php"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": [],
+  "authors": [
+    "pmatseykanets"
+  ],
+  "contributors": [
+    "arueckauer",
+    "Hrumpa",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "VariableLengthQuantity.php"

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -1,26 +1,17 @@
 {
   "blurb": "Implement variable length quantity encoding and decoding.",
-  "authors": [
-    "pmatseykanets"
-  ],
+  "authors": ["pmatseykanets"],
   "contributors": [
     "arueckauer",
     "Hrumpa",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw",
     "petemcfarlane"
   ],
   "files": {
-    "solution": [
-      "VariableLengthQuantity.php"
-    ],
-    "test": [
-      "VariableLengthQuantityTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["VariableLengthQuantity.php"],
+    "test": ["VariableLengthQuantityTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,25 +1,11 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [
-    "ecrmnn"
-  ],
-  "contributors": [
-    "arueckauer",
-    "kunicmarko20",
-    "kytrinyx",
-    "neenjaw",
-    "petemcfarlane"
-  ],
+  "authors": ["ecrmnn"],
+  "contributors": ["arueckauer", "kunicmarko20", "kytrinyx", "petemcfarlane"],
   "files": {
-    "solution": [
-      "WordCount.php"
-    ],
-    "test": [
-      "WordCountTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["WordCount.php"],
+    "test": ["WordCountTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [],
+  "authors": [
+    "ecrmnn"
+  ],
+  "contributors": [
+    "arueckauer",
+    "kunicmarko20",
+    "kytrinyx",
+    "neenjaw",
+    "petemcfarlane"
+  ],
   "files": {
     "solution": [
       "WordCount.php"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "authors": [],
+  "contributors": [
+    "arueckauer",
+    "dkinzer",
+    "kunicmarko20",
+    "kytrinyx",
+    "lafent",
+    "neenjaw",
+    "petemcfarlane",
+    "yisraeldov"
+  ],
   "files": {
     "solution": [
       "Wordy.php"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -7,20 +7,13 @@
     "kunicmarko20",
     "kytrinyx",
     "lafent",
-    "neenjaw",
     "petemcfarlane",
     "yisraeldov"
   ],
   "files": {
-    "solution": [
-      "Wordy.php"
-    ],
-    "test": [
-      "WordyTest.php"
-    ],
-    "example": [
-      ".meta/example.php"
-    ]
+    "solution": ["Wordy.php"],
+    "test": ["WordyTest.php"],
+    "example": [".meta/example.php"]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"


### PR DESCRIPTION
_If you got tagged in this PR, it is because you are being credited for work you've done in the past on Exercism here, and we want to ensure you don't miss out on the recognition you deserve 🙂_

---

With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercises' `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, already contain authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Maintainer TODO list

These are the things you, the maintainers, should do:

- [ ] Check the authors and contributors, adding/removing users where the data is missing or incorrect
- [ ] Double-check any renamed Practice Exercises
- [ ] Check for Practice Exercises with missing authors, which are most likely due to the author not being on GitHub anymore 
- [ ] Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

**For clarity, authors should be the people who originally created the exercise on this track. Contributors should be people who have substantially contributed to that exercise. PRs for typos or multiple-exercise PRs do not automatically mean someone should be considered a contributor to that exercise. Those non-exercise-specific contributions will get recognition through Exercism's reputation system in v3.**

If you find something needs updating, just push a new commit to this PR.

## Automatic Merging

We will automatically merge this PR before we launch v3, but will give the maximum time we can to maintainers to review it first.

---

_The rest of this issue explains how this PR has been generated. You do not **need** to read it._

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits touched that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Any commit that we can associate with a Practice Exercise is used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise.
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors and any co-authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author and any co-authors of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors and any co-authors of those commits
3. Add the GitHub usernames of the Git commit authors and any co-authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author and any co-authors. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There are a small number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Tracking

https://github.com/exercism/v3-launch/issues/24

---

cc @amscotti, @arthurchipdean, @arueckauer, @brettsantore, @camilopayan, @codedge, @DerTee, @dkinzer, @Dog, @dstockto, @duffn, @ecrmnn, @ErikSchierboom, @G-Rath, @Hrumpa, @jeslopcru, @joseph-walker, @jrdnull, @karptonite, @kenden, @kip-13, @kk-r, @kunicmarko20, @kytrinyx, @lafent, @leNEKO, @Leprechaunz, @LucasThompson, @marvinrabe, @masters3d, @MatheusNaldi, @MichaelBunker, @mikeSimonson, @mk-mxp, @neenjaw, @nhoag, @petemcfarlane, @peteraba, @Pierre-Vdsp, @pmatseykanets, @pminten, @rossbearman, @schorsch3000, @Scientifica96, @TFarla, @tstirrat15, @woylie, @yisraeldov, @zembrowski as you are referenced in this PR
