### PR TITLE
Add blurb

### DIFF
--- a/exercises/practice/ordinal-number/.meta/config.json
+++ b/exercises/practice/ordinal-number/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "Convert numbers to ordinal numerals.",
   "authors": [
     "codedge"
   ],


### PR DESCRIPTION
Ordinal number meta config misses the "blurb" key and therefore the Configlet CI is failing.