### PR TITLE
Optimise palindrome-products example for speed

### DIFF
--- a/exercises/practice/palindrome-products/.meta/example.php
+++ b/exercises/practice/palindrome-products/.meta/example.php
@@ -1,39 +1,41 @@
 <?php
 
-function generatePalindromeProducts($min, $max)
+function generatePalindromeProducts($range)
 {
     $palindromes = [];
-    foreach (range($min, $max) as $x) {
-        foreach (range($min, $max) as $y) {
+    foreach ($range as $x) {
+        foreach (range($x, array_reverse($range)[0]) as $y) {
             $n = $x * $y;
             if (isPalindrome($n)) {
                 $palindromes[] = $n;
+                if (count($palindromes) > 2) {
+                    ($range[0] > $range[1]) ? rsort($palindromes) : sort($palindromes);
+                    return array_shift($palindromes);
+                }
             }
         }
     }
-    sort($palindromes);
-    return $palindromes;
+
+    return null;
 }
 
 function smallest($min, $max)
 {
     validate($min, $max);
-    $palindromes = generatePalindromeProducts($min, $max);
-    if (empty($palindromes)) {
+    $r = generatePalindromeProducts(range($min, $max));
+    if (empty($r)) {
         throw new Exception();
     }
-    $r = array_shift($palindromes);
     return [$r, factorize($r, range($min, $max))];
 }
 
 function largest($min, $max)
 {
     validate($min, $max);
-    $palindromes = generatePalindromeProducts($min, $max);
-    if (empty($palindromes)) {
+    $r = generatePalindromeProducts(range($max, $min));
+    if (empty($r)) {
         throw new Exception();
     }
-    $r = array_pop($palindromes);
     return [$r, factorize($r, range($min, $max))];
 }
 

--- a/exercises/practice/palindrome-products/.meta/example.php
+++ b/exercises/practice/palindrome-products/.meta/example.php
@@ -1,13 +1,14 @@
 <?php
 
-function generatePalindromeProducts($range)
+function generatePalindromeProduct(array $range): ?int
 {
     $palindromes = [];
+
     foreach ($range as $x) {
         foreach (range($x, array_reverse($range)[0]) as $y) {
-            $n = $x * $y;
-            if (isPalindrome($n)) {
-                $palindromes[] = $n;
+            $product = $x * $y;
+            if (isPalindrome($product)) {
+                $palindromes[] = $product;
                 if (count($palindromes) > 2) {
                     ($range[0] > $range[1]) ? rsort($palindromes) : sort($palindromes);
                     return array_shift($palindromes);
@@ -19,49 +20,51 @@ function generatePalindromeProducts($range)
     return null;
 }
 
-function smallest($min, $max)
+function smallest(int $min, int $max): array
 {
     validate($min, $max);
-    $r = generatePalindromeProducts(range($min, $max));
-    if (empty($r)) {
+    $product = generatePalindromeProduct(range($min, $max));
+    if ($product === null) {
         throw new Exception();
     }
-    return [$r, factorize($r, range($min, $max))];
+    return [$product, factorize($product, range($min, $max))];
 }
 
-function largest($min, $max)
+function largest(int $min, int $max): array
 {
     validate($min, $max);
-    $r = generatePalindromeProducts(range($max, $min));
-    if (empty($r)) {
+    $product = generatePalindromeProduct(range($max, $min));
+    if ($product === null) {
         throw new Exception();
     }
-    return [$r, factorize($r, range($min, $max))];
+    return [$product, factorize($product, range($min, $max))];
 }
 
-function validate($min, $max)
+function validate(int $min, int $max): void
 {
     if ($max <= $min) {
         throw new Exception();
     }
 }
 
-function isPalindrome($n)
+function isPalindrome(int $number): bool
 {
-    return "$n" === strrev("$n");
+    return "$number" === strrev("$number");
 }
 
-function factorize($n, $factorRange)
+function factorize(int $number, array $range): array
 {
     $factors = [];
-    foreach ($factorRange as $x) {
+
+    foreach ($range as $x) {
         if (
-            $n % $x === 0
-            && in_array($n / $x, $factorRange)
-            && !in_array([$n / $x, $x], $factors)
+            $number % $x === 0
+            && in_array($number / $x, $range)
+            && !in_array([$number / $x, $x], $factors)
         ) {
-            $factors[] = [$x, $n / $x];
+            $factors[] = [$x, $number / $x];
         }
     }
+
     return $factors;
 }


### PR DESCRIPTION
The palindrome-products example takes around [75% of the running time](https://github.com/exercism/php/pull/363/checks?check_run_id=2360574137#step:6:374) in the CI test pipeline and a up to several minutes on local machines. With the introduced changes the tests run 1m50s faster in the pipeline.

Changes based on some [exercism solutions](https://exercism.io/tracks/php/exercises/palindrome-products/solutions/09c958495eeb4aad8e1acf1e5c33ab68).