### PR TITLE
Add strict types for all php files

### DIFF
--- a/.github/workflows/exercise-lint-phpcs-psr-12.yml
+++ b/.github/workflows/exercise-lint-phpcs-psr-12.yml
@@ -31,12 +31,16 @@ jobs:
         with:
           version: ${{ matrix.php-version }}
           extensions: gmp
+          tools: composer
 
       - name: Install dependencies
         shell: bash
         run: |
           curl -Lo bin/phpcs.phar https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
           chmod +x bin/phpcs.phar
+
+      - name: Install composer packages
+        run: composer install
 
       - name: Lint exercises
         shell: bash

--- a/.github/workflows/exercise-lint-phpcs-psr-12.yml
+++ b/.github/workflows/exercise-lint-phpcs-psr-12.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: shivammathur/setup-php@46fc8a2fd7cba50512858026dc8f0947c8a7a0e8
         with:
-          version: ${{ matrix.php-version }}
+          php-version: ${{ matrix.php-version }}
           extensions: gmp
           tools: composer
 
@@ -44,7 +44,4 @@ jobs:
 
       - name: Lint exercises
         shell: bash
-        env:
-          PHPCS_BIN: 'bin/phpcs.phar'
-          PHPCS_RULES: 'phpcs-php.xml'
-        run: bin/lint.sh
+        run: composer lint:check

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tmp
 .phpunit.result.cache
 bin/configlet
 bin/configlet.exe
+
+/vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "exercism/php",
+    "require-dev": {
+        "slevomat/coding-standard": "^7.0"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,15 @@
 {
-    "name": "exercism/php",
-    "require-dev": {
-        "slevomat/coding-standard": "^7.0"
-    }
+  "name": "exercism/php",
+  "autoload": {
+    "Exercism\\": "src",
+    "Exercism\\Exercises\\": "exercises"
+  },
+  "require-dev": {
+    "slevomat/coding-standard": "^7.0",
+    "squizlabs/php_codesniffer": "^3.6"
+  },
+  "scripts": {
+    "lint:check": "./vendor/bin/phpcs --standard=phpcs-php.xml ./exercises",
+    "lint:fix": "./vendor/bin/phpcbf --standard=phpcs-php.xml ./exercises"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "Exercism\\Exercises\\": "exercises"
   },
   "require-dev": {
+    "php": "^7.4|^8.0",
     "slevomat/coding-standard": "^7.0",
     "squizlabs/php_codesniffer": "^3.6"
   },

--- a/exercises/practice/accumulate/.meta/example.php
+++ b/exercises/practice/accumulate/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/accumulate/.meta/example.php
+++ b/exercises/practice/accumulate/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/accumulate/.meta/example.php
+++ b/exercises/practice/accumulate/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Given the input array and operation returns an array
  * containing the result of applying that operation

--- a/exercises/practice/accumulate/.meta/example.php
+++ b/exercises/practice/accumulate/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/accumulate/Accumulate.php
+++ b/exercises/practice/accumulate/Accumulate.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/accumulate/Accumulate.php
+++ b/exercises/practice/accumulate/Accumulate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function accumulate(array $input, callable $accumulator): array
 {
     throw new \BadFunctionCallException("Implement the accumulate function");

--- a/exercises/practice/accumulate/Accumulate.php
+++ b/exercises/practice/accumulate/Accumulate.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function accumulate(array $input, callable $accumulator): array

--- a/exercises/practice/accumulate/Accumulate.php
+++ b/exercises/practice/accumulate/Accumulate.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/accumulate/AccumulateTest.php
+++ b/exercises/practice/accumulate/AccumulateTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class AccumulateTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/accumulate/AccumulateTest.php
+++ b/exercises/practice/accumulate/AccumulateTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/accumulate/AccumulateTest.php
+++ b/exercises/practice/accumulate/AccumulateTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/accumulate/AccumulateTest.php
+++ b/exercises/practice/accumulate/AccumulateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AccumulateTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/acronym/.meta/example.php
+++ b/exercises/practice/acronym/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/acronym/.meta/example.php
+++ b/exercises/practice/acronym/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Abbreviates a phrase.
  *

--- a/exercises/practice/acronym/.meta/example.php
+++ b/exercises/practice/acronym/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/acronym/.meta/example.php
+++ b/exercises/practice/acronym/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/acronym/Acronym.php
+++ b/exercises/practice/acronym/Acronym.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/acronym/Acronym.php
+++ b/exercises/practice/acronym/Acronym.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function acronym(string $text): string
 {
     throw new \BadFunctionCallException("Implement the acronym function");

--- a/exercises/practice/acronym/Acronym.php
+++ b/exercises/practice/acronym/Acronym.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/acronym/Acronym.php
+++ b/exercises/practice/acronym/Acronym.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function acronym(string $text): string

--- a/exercises/practice/acronym/AcronymTest.php
+++ b/exercises/practice/acronym/AcronymTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/acronym/AcronymTest.php
+++ b/exercises/practice/acronym/AcronymTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class AcronymTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/acronym/AcronymTest.php
+++ b/exercises/practice/acronym/AcronymTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AcronymTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/acronym/AcronymTest.php
+++ b/exercises/practice/acronym/AcronymTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/affine-cipher/.meta/example.php
+++ b/exercises/practice/affine-cipher/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/affine-cipher/.meta/example.php
+++ b/exercises/practice/affine-cipher/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode($text, $a, $b)
 {
     $alphabet = range('a', 'z');

--- a/exercises/practice/affine-cipher/.meta/example.php
+++ b/exercises/practice/affine-cipher/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/affine-cipher/.meta/example.php
+++ b/exercises/practice/affine-cipher/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode($text, $a, $b)

--- a/exercises/practice/affine-cipher/AffineCipher.php
+++ b/exercises/practice/affine-cipher/AffineCipher.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode(string $text, int $num1, int $num2): string

--- a/exercises/practice/affine-cipher/AffineCipher.php
+++ b/exercises/practice/affine-cipher/AffineCipher.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/affine-cipher/AffineCipher.php
+++ b/exercises/practice/affine-cipher/AffineCipher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode(string $text, int $num1, int $num2): string
 {
     throw new \BadFunctionCallException("Implement the encode function");

--- a/exercises/practice/affine-cipher/AffineCipher.php
+++ b/exercises/practice/affine-cipher/AffineCipher.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/affine-cipher/AffineCipherTest.php
+++ b/exercises/practice/affine-cipher/AffineCipherTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/affine-cipher/AffineCipherTest.php
+++ b/exercises/practice/affine-cipher/AffineCipherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * The test are divided into two groups:
  *

--- a/exercises/practice/affine-cipher/AffineCipherTest.php
+++ b/exercises/practice/affine-cipher/AffineCipherTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/affine-cipher/AffineCipherTest.php
+++ b/exercises/practice/affine-cipher/AffineCipherTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/all-your-base/.meta/example.php
+++ b/exercises/practice/all-your-base/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/all-your-base/.meta/example.php
+++ b/exercises/practice/all-your-base/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/all-your-base/.meta/example.php
+++ b/exercises/practice/all-your-base/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function rebase(int $fromBase, array $digits, int $toBase)
 {
     if (empty($digits) || $digits[0] == 0 || $fromBase <= 1 || $toBase <= 1) {

--- a/exercises/practice/all-your-base/.meta/example.php
+++ b/exercises/practice/all-your-base/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function rebase(int $fromBase, array $digits, int $toBase)

--- a/exercises/practice/all-your-base/AllYourBase.php
+++ b/exercises/practice/all-your-base/AllYourBase.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/all-your-base/AllYourBase.php
+++ b/exercises/practice/all-your-base/AllYourBase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function rebase(int $number, array $sequence, int $base)
 {
     throw new \BadFunctionCallException("Implement the rebase function");

--- a/exercises/practice/all-your-base/AllYourBase.php
+++ b/exercises/practice/all-your-base/AllYourBase.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function rebase(int $number, array $sequence, int $base)

--- a/exercises/practice/all-your-base/AllYourBase.php
+++ b/exercises/practice/all-your-base/AllYourBase.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/all-your-base/AllYourBaseTest.php
+++ b/exercises/practice/all-your-base/AllYourBaseTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/all-your-base/AllYourBaseTest.php
+++ b/exercises/practice/all-your-base/AllYourBaseTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/all-your-base/AllYourBaseTest.php
+++ b/exercises/practice/all-your-base/AllYourBaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * These tests are adapted from the canonical data in the
  * `problem-specifications` repository.

--- a/exercises/practice/all-your-base/AllYourBaseTest.php
+++ b/exercises/practice/all-your-base/AllYourBaseTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/allergies/.meta/example.php
+++ b/exercises/practice/allergies/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/allergies/.meta/example.php
+++ b/exercises/practice/allergies/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Allergies

--- a/exercises/practice/allergies/.meta/example.php
+++ b/exercises/practice/allergies/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/allergies/.meta/example.php
+++ b/exercises/practice/allergies/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Allergies
 {
     private $score;

--- a/exercises/practice/allergies/Allergies.php
+++ b/exercises/practice/allergies/Allergies.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/allergies/Allergies.php
+++ b/exercises/practice/allergies/Allergies.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Allergies
 {
     public function __construct(int $score)

--- a/exercises/practice/allergies/Allergies.php
+++ b/exercises/practice/allergies/Allergies.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Allergies

--- a/exercises/practice/allergies/Allergies.php
+++ b/exercises/practice/allergies/Allergies.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AllergiesTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class AllergiesTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/anagram/.meta/example.php
+++ b/exercises/practice/anagram/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/anagram/.meta/example.php
+++ b/exercises/practice/anagram/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/anagram/.meta/example.php
+++ b/exercises/practice/anagram/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function detectAnagrams($anagram, array $possibleMatches)
 {
     $matches = [];

--- a/exercises/practice/anagram/.meta/example.php
+++ b/exercises/practice/anagram/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function detectAnagrams($anagram, array $possibleMatches)

--- a/exercises/practice/anagram/Anagram.php
+++ b/exercises/practice/anagram/Anagram.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/anagram/Anagram.php
+++ b/exercises/practice/anagram/Anagram.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/anagram/Anagram.php
+++ b/exercises/practice/anagram/Anagram.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function detectAnagrams(string $word, array $anagrams): array

--- a/exercises/practice/anagram/Anagram.php
+++ b/exercises/practice/anagram/Anagram.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function detectAnagrams(string $word, array $anagrams): array
 {
     throw new \BadFunctionCallException("Implement the detectAnagrams function");

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class AnagramTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AnagramTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/armstrong-numbers/.meta/example.php
+++ b/exercises/practice/armstrong-numbers/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/armstrong-numbers/.meta/example.php
+++ b/exercises/practice/armstrong-numbers/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isArmstrongNumber(int $number): bool

--- a/exercises/practice/armstrong-numbers/.meta/example.php
+++ b/exercises/practice/armstrong-numbers/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/armstrong-numbers/.meta/example.php
+++ b/exercises/practice/armstrong-numbers/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isArmstrongNumber(int $number): bool
 {
     $total = 0;

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isArmstrongNumber(int $number): bool

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isArmstrongNumber(int $number): bool
 {
     throw new \BadFunctionCallException("Implement the isArmstrongNumber function");

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/atbash-cipher/.meta/example.php
+++ b/exercises/practice/atbash-cipher/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/atbash-cipher/.meta/example.php
+++ b/exercises/practice/atbash-cipher/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode($string)

--- a/exercises/practice/atbash-cipher/.meta/example.php
+++ b/exercises/practice/atbash-cipher/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/atbash-cipher/.meta/example.php
+++ b/exercises/practice/atbash-cipher/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode($string)
 {
     $a_z = range('a', 'z');

--- a/exercises/practice/atbash-cipher/AtbashCipher.php
+++ b/exercises/practice/atbash-cipher/AtbashCipher.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/atbash-cipher/AtbashCipher.php
+++ b/exercises/practice/atbash-cipher/AtbashCipher.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/atbash-cipher/AtbashCipher.php
+++ b/exercises/practice/atbash-cipher/AtbashCipher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode(string $text): string
 {
     throw new \BadFunctionCallException("Implement the encode function");

--- a/exercises/practice/atbash-cipher/AtbashCipher.php
+++ b/exercises/practice/atbash-cipher/AtbashCipher.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode(string $text): string

--- a/exercises/practice/atbash-cipher/AtbashCipherTest.php
+++ b/exercises/practice/atbash-cipher/AtbashCipherTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/atbash-cipher/AtbashCipherTest.php
+++ b/exercises/practice/atbash-cipher/AtbashCipherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AtbashCipherTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/atbash-cipher/AtbashCipherTest.php
+++ b/exercises/practice/atbash-cipher/AtbashCipherTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class AtbashCipherTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/atbash-cipher/AtbashCipherTest.php
+++ b/exercises/practice/atbash-cipher/AtbashCipherTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/beer-song/.meta/example.php
+++ b/exercises/practice/beer-song/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class BeerSong
 {
     public function verse($number): string

--- a/exercises/practice/beer-song/.meta/example.php
+++ b/exercises/practice/beer-song/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class BeerSong

--- a/exercises/practice/beer-song/.meta/example.php
+++ b/exercises/practice/beer-song/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/beer-song/.meta/example.php
+++ b/exercises/practice/beer-song/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/beer-song/BeerSong.php
+++ b/exercises/practice/beer-song/BeerSong.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class BeerSong

--- a/exercises/practice/beer-song/BeerSong.php
+++ b/exercises/practice/beer-song/BeerSong.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/beer-song/BeerSong.php
+++ b/exercises/practice/beer-song/BeerSong.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/beer-song/BeerSong.php
+++ b/exercises/practice/beer-song/BeerSong.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class BeerSong
 {
     public function verse(int $number): string

--- a/exercises/practice/beer-song/BeerSongTest.php
+++ b/exercises/practice/beer-song/BeerSongTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/beer-song/BeerSongTest.php
+++ b/exercises/practice/beer-song/BeerSongTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/beer-song/BeerSongTest.php
+++ b/exercises/practice/beer-song/BeerSongTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class BeerSongTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/beer-song/BeerSongTest.php
+++ b/exercises/practice/beer-song/BeerSongTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class BeerSongTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/binary-search/.meta/example.php
+++ b/exercises/practice/binary-search/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/binary-search/.meta/example.php
+++ b/exercises/practice/binary-search/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function find($needle, $haystack)

--- a/exercises/practice/binary-search/.meta/example.php
+++ b/exercises/practice/binary-search/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/binary-search/.meta/example.php
+++ b/exercises/practice/binary-search/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function find($needle, $haystack)
 {
     $left = 0;

--- a/exercises/practice/binary-search/BinarySearch.php
+++ b/exercises/practice/binary-search/BinarySearch.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/binary-search/BinarySearch.php
+++ b/exercises/practice/binary-search/BinarySearch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function find(int $needle, array $haystack): int
 {
     throw new \BadFunctionCallException("Implement the find function");

--- a/exercises/practice/binary-search/BinarySearch.php
+++ b/exercises/practice/binary-search/BinarySearch.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/binary-search/BinarySearch.php
+++ b/exercises/practice/binary-search/BinarySearch.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function find(int $needle, array $haystack): int

--- a/exercises/practice/binary-search/BinarySearchTest.php
+++ b/exercises/practice/binary-search/BinarySearchTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class BinarySearchTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/binary-search/BinarySearchTest.php
+++ b/exercises/practice/binary-search/BinarySearchTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/binary-search/BinarySearchTest.php
+++ b/exercises/practice/binary-search/BinarySearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class BinarySearchTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/binary-search/BinarySearchTest.php
+++ b/exercises/practice/binary-search/BinarySearchTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/binary/.meta/example.php
+++ b/exercises/practice/binary/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/binary/.meta/example.php
+++ b/exercises/practice/binary/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Converts binary value to a decimal.
  *

--- a/exercises/practice/binary/.meta/example.php
+++ b/exercises/practice/binary/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/binary/.meta/example.php
+++ b/exercises/practice/binary/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/binary/Binary.php
+++ b/exercises/practice/binary/Binary.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/binary/Binary.php
+++ b/exercises/practice/binary/Binary.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function parse_binary(string $binary): int

--- a/exercises/practice/binary/Binary.php
+++ b/exercises/practice/binary/Binary.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/binary/Binary.php
+++ b/exercises/practice/binary/Binary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function parse_binary(string $binary): int
 {
     throw new \BadFunctionCallException("Implement the parse_binary function");

--- a/exercises/practice/binary/BinaryTest.php
+++ b/exercises/practice/binary/BinaryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class BinaryTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/binary/BinaryTest.php
+++ b/exercises/practice/binary/BinaryTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/binary/BinaryTest.php
+++ b/exercises/practice/binary/BinaryTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class BinaryTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/binary/BinaryTest.php
+++ b/exercises/practice/binary/BinaryTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bob/.meta/example.php
+++ b/exercises/practice/bob/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/bob/.meta/example.php
+++ b/exercises/practice/bob/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bob/.meta/example.php
+++ b/exercises/practice/bob/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Bob

--- a/exercises/practice/bob/.meta/example.php
+++ b/exercises/practice/bob/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Bob
 {
     /**

--- a/exercises/practice/bob/Bob.php
+++ b/exercises/practice/bob/Bob.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/bob/Bob.php
+++ b/exercises/practice/bob/Bob.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bob/Bob.php
+++ b/exercises/practice/bob/Bob.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Bob

--- a/exercises/practice/bob/Bob.php
+++ b/exercises/practice/bob/Bob.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Bob
 {
     public function respondTo(string $str): string

--- a/exercises/practice/bob/BobTest.php
+++ b/exercises/practice/bob/BobTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/bob/BobTest.php
+++ b/exercises/practice/bob/BobTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class BobTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/bob/BobTest.php
+++ b/exercises/practice/bob/BobTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bob/BobTest.php
+++ b/exercises/practice/bob/BobTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class BobTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/book-store/.meta/example.php
+++ b/exercises/practice/book-store/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function total($items)
 {
     return calculate($items, 0);

--- a/exercises/practice/book-store/.meta/example.php
+++ b/exercises/practice/book-store/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function total($items)

--- a/exercises/practice/book-store/.meta/example.php
+++ b/exercises/practice/book-store/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/book-store/.meta/example.php
+++ b/exercises/practice/book-store/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/book-store/BookStore.php
+++ b/exercises/practice/book-store/BookStore.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function total(array $items): float

--- a/exercises/practice/book-store/BookStore.php
+++ b/exercises/practice/book-store/BookStore.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/book-store/BookStore.php
+++ b/exercises/practice/book-store/BookStore.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/book-store/BookStore.php
+++ b/exercises/practice/book-store/BookStore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function total(array $items): float
 {
     throw new \BadFunctionCallException("Implement the total function");

--- a/exercises/practice/book-store/BookStoreTest.php
+++ b/exercises/practice/book-store/BookStoreTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/book-store/BookStoreTest.php
+++ b/exercises/practice/book-store/BookStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Calculate lowest price for shopping basket only
  * containing books from a single series. There is no

--- a/exercises/practice/book-store/BookStoreTest.php
+++ b/exercises/practice/book-store/BookStoreTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/book-store/BookStoreTest.php
+++ b/exercises/practice/book-store/BookStoreTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/bowling/.meta/example.php
+++ b/exercises/practice/bowling/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/bowling/.meta/example.php
+++ b/exercises/practice/bowling/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Translated from original source:
  * http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata

--- a/exercises/practice/bowling/.meta/example.php
+++ b/exercises/practice/bowling/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bowling/.meta/example.php
+++ b/exercises/practice/bowling/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/bowling/Bowling.php
+++ b/exercises/practice/bowling/Bowling.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/bowling/Bowling.php
+++ b/exercises/practice/bowling/Bowling.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Game

--- a/exercises/practice/bowling/Bowling.php
+++ b/exercises/practice/bowling/Bowling.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bowling/Bowling.php
+++ b/exercises/practice/bowling/Bowling.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Game
 {
     public function score(): int

--- a/exercises/practice/bowling/BowlingTest.php
+++ b/exercises/practice/bowling/BowlingTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/bowling/BowlingTest.php
+++ b/exercises/practice/bowling/BowlingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Translated from original source:
  * http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata

--- a/exercises/practice/bowling/BowlingTest.php
+++ b/exercises/practice/bowling/BowlingTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/bowling/BowlingTest.php
+++ b/exercises/practice/bowling/BowlingTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/change/.meta/example.php
+++ b/exercises/practice/change/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 // adapted from the python example

--- a/exercises/practice/change/.meta/example.php
+++ b/exercises/practice/change/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/change/.meta/example.php
+++ b/exercises/practice/change/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // adapted from the python example
 function findFewestCoins(array $coins, int $total_change): array
 {

--- a/exercises/practice/change/.meta/example.php
+++ b/exercises/practice/change/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/change/Change.php
+++ b/exercises/practice/change/Change.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/change/Change.php
+++ b/exercises/practice/change/Change.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function findFewestCoins(array $coins, int $amount): array

--- a/exercises/practice/change/Change.php
+++ b/exercises/practice/change/Change.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/change/Change.php
+++ b/exercises/practice/change/Change.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function findFewestCoins(array $coins, int $amount): array
 {
     throw new \BadFunctionCallException("Implement the findFewestCoins function");

--- a/exercises/practice/change/ChangeTest.php
+++ b/exercises/practice/change/ChangeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ChangeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/change/ChangeTest.php
+++ b/exercises/practice/change/ChangeTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/change/ChangeTest.php
+++ b/exercises/practice/change/ChangeTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class ChangeTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/change/ChangeTest.php
+++ b/exercises/practice/change/ChangeTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/clock/.meta/example.php
+++ b/exercises/practice/clock/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Clock

--- a/exercises/practice/clock/.meta/example.php
+++ b/exercises/practice/clock/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/clock/.meta/example.php
+++ b/exercises/practice/clock/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/clock/.meta/example.php
+++ b/exercises/practice/clock/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Clock
 {
     /**

--- a/exercises/practice/clock/Clock.php
+++ b/exercises/practice/clock/Clock.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Clock

--- a/exercises/practice/clock/Clock.php
+++ b/exercises/practice/clock/Clock.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/clock/Clock.php
+++ b/exercises/practice/clock/Clock.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/clock/Clock.php
+++ b/exercises/practice/clock/Clock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Clock
 {
     public function __toString(): string

--- a/exercises/practice/clock/ClockTest.php
+++ b/exercises/practice/clock/ClockTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/clock/ClockTest.php
+++ b/exercises/practice/clock/ClockTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/clock/ClockTest.php
+++ b/exercises/practice/clock/ClockTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ClockTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/clock/ClockTest.php
+++ b/exercises/practice/clock/ClockTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class ClockTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/collatz-conjecture/.meta/example.php
+++ b/exercises/practice/collatz-conjecture/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/collatz-conjecture/.meta/example.php
+++ b/exercises/practice/collatz-conjecture/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function steps($number)

--- a/exercises/practice/collatz-conjecture/.meta/example.php
+++ b/exercises/practice/collatz-conjecture/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function steps($number)
 {
     $stepCount = 0;

--- a/exercises/practice/collatz-conjecture/.meta/example.php
+++ b/exercises/practice/collatz-conjecture/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function steps(int $number): int
 {
     throw new \BadFunctionCallException("Implement the steps function");

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function steps(int $number): int

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class CollatzConjectureTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/connect/.meta/example.php
+++ b/exercises/practice/connect/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/connect/.meta/example.php
+++ b/exercises/practice/connect/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 const NOTHING = 0;

--- a/exercises/practice/connect/.meta/example.php
+++ b/exercises/practice/connect/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/connect/.meta/example.php
+++ b/exercises/practice/connect/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 const NOTHING = 0;
 const WHITE = 1;
 const BLACK = 2;

--- a/exercises/practice/connect/Connect.php
+++ b/exercises/practice/connect/Connect.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function resultFor(array $lines)

--- a/exercises/practice/connect/Connect.php
+++ b/exercises/practice/connect/Connect.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/connect/Connect.php
+++ b/exercises/practice/connect/Connect.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function resultFor(array $lines)
 {
     throw new \BadFunctionCallException("Implement the resultFor method");

--- a/exercises/practice/connect/Connect.php
+++ b/exercises/practice/connect/Connect.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/connect/ConnectTest.php
+++ b/exercises/practice/connect/ConnectTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/connect/ConnectTest.php
+++ b/exercises/practice/connect/ConnectTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/connect/ConnectTest.php
+++ b/exercises/practice/connect/ConnectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ConnectTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/connect/ConnectTest.php
+++ b/exercises/practice/connect/ConnectTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class ConnectTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/crypto-square/.meta/example.php
+++ b/exercises/practice/crypto-square/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/crypto-square/.meta/example.php
+++ b/exercises/practice/crypto-square/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function crypto_square($plaintext)

--- a/exercises/practice/crypto-square/.meta/example.php
+++ b/exercises/practice/crypto-square/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function crypto_square($plaintext)
 {
     $normalized = preg_replace('/\W*/', '', strtolower($plaintext));

--- a/exercises/practice/crypto-square/.meta/example.php
+++ b/exercises/practice/crypto-square/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/crypto-square/CryptoSquare.php
+++ b/exercises/practice/crypto-square/CryptoSquare.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/crypto-square/CryptoSquare.php
+++ b/exercises/practice/crypto-square/CryptoSquare.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function crypto_square(string $plaintext): string

--- a/exercises/practice/crypto-square/CryptoSquare.php
+++ b/exercises/practice/crypto-square/CryptoSquare.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function crypto_square(string $plaintext): string
 {
     throw new \BadFunctionCallException("Implement the crypto_square function");

--- a/exercises/practice/crypto-square/CryptoSquare.php
+++ b/exercises/practice/crypto-square/CryptoSquare.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/crypto-square/CryptoSquareTest.php
+++ b/exercises/practice/crypto-square/CryptoSquareTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class CryptoSquareTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/crypto-square/CryptoSquareTest.php
+++ b/exercises/practice/crypto-square/CryptoSquareTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/crypto-square/CryptoSquareTest.php
+++ b/exercises/practice/crypto-square/CryptoSquareTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/crypto-square/CryptoSquareTest.php
+++ b/exercises/practice/crypto-square/CryptoSquareTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class CryptoSquareTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/diamond/.meta/example.php
+++ b/exercises/practice/diamond/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/diamond/.meta/example.php
+++ b/exercises/practice/diamond/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/diamond/.meta/example.php
+++ b/exercises/practice/diamond/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function diamond($limit)
 {
     $alphabet = range('A', $limit);

--- a/exercises/practice/diamond/.meta/example.php
+++ b/exercises/practice/diamond/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function diamond($limit)

--- a/exercises/practice/diamond/Diamond.php
+++ b/exercises/practice/diamond/Diamond.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/diamond/Diamond.php
+++ b/exercises/practice/diamond/Diamond.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function diamond(string $letter): array

--- a/exercises/practice/diamond/Diamond.php
+++ b/exercises/practice/diamond/Diamond.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function diamond(string $letter): array
 {
     throw new \BadFunctionCallException("Implement the diamond function");

--- a/exercises/practice/diamond/Diamond.php
+++ b/exercises/practice/diamond/Diamond.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/diamond/DiamondTest.php
+++ b/exercises/practice/diamond/DiamondTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/diamond/DiamondTest.php
+++ b/exercises/practice/diamond/DiamondTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class DiamondTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/diamond/DiamondTest.php
+++ b/exercises/practice/diamond/DiamondTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/diamond/DiamondTest.php
+++ b/exercises/practice/diamond/DiamondTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class DiamondTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/difference-of-squares/.meta/example.php
+++ b/exercises/practice/difference-of-squares/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/difference-of-squares/.meta/example.php
+++ b/exercises/practice/difference-of-squares/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/difference-of-squares/.meta/example.php
+++ b/exercises/practice/difference-of-squares/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function squareOfSum($max)

--- a/exercises/practice/difference-of-squares/.meta/example.php
+++ b/exercises/practice/difference-of-squares/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function squareOfSum($max)
 {
     $sum = 0;

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function squareOfSum(int $max): int

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function squareOfSum(int $max): int
 {
     throw new \BadFunctionCallException("Implement the squareOfSum function");

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/etl/.meta/example.php
+++ b/exercises/practice/etl/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/etl/.meta/example.php
+++ b/exercises/practice/etl/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function transform($old)

--- a/exercises/practice/etl/.meta/example.php
+++ b/exercises/practice/etl/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/etl/.meta/example.php
+++ b/exercises/practice/etl/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function transform($old)
 {
     $new = [];

--- a/exercises/practice/etl/Etl.php
+++ b/exercises/practice/etl/Etl.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/etl/Etl.php
+++ b/exercises/practice/etl/Etl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function transform(array $input): array
 {
     throw new \BadFunctionCallException("Implement the transform function");

--- a/exercises/practice/etl/Etl.php
+++ b/exercises/practice/etl/Etl.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function transform(array $input): array

--- a/exercises/practice/etl/Etl.php
+++ b/exercises/practice/etl/Etl.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/etl/EtlTest.php
+++ b/exercises/practice/etl/EtlTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/etl/EtlTest.php
+++ b/exercises/practice/etl/EtlTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class EtlTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/etl/EtlTest.php
+++ b/exercises/practice/etl/EtlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class EtlTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/etl/EtlTest.php
+++ b/exercises/practice/etl/EtlTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/flatten-array/.meta/example.php
+++ b/exercises/practice/flatten-array/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/flatten-array/.meta/example.php
+++ b/exercises/practice/flatten-array/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function flatten($array = [])

--- a/exercises/practice/flatten-array/.meta/example.php
+++ b/exercises/practice/flatten-array/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/flatten-array/.meta/example.php
+++ b/exercises/practice/flatten-array/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function flatten($array = [])
 {
     $return = [];

--- a/exercises/practice/flatten-array/FlattenArray.php
+++ b/exercises/practice/flatten-array/FlattenArray.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/flatten-array/FlattenArray.php
+++ b/exercises/practice/flatten-array/FlattenArray.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/flatten-array/FlattenArray.php
+++ b/exercises/practice/flatten-array/FlattenArray.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function flatten(array $input): array

--- a/exercises/practice/flatten-array/FlattenArray.php
+++ b/exercises/practice/flatten-array/FlattenArray.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function flatten(array $input): array
 {
     throw new \BadFunctionCallException("Implement the flatten function");

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class FlattenArrayTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class FlattenArrayTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/gigasecond/.meta/example.php
+++ b/exercises/practice/gigasecond/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function from(DateTimeImmutable $from): DateTimeImmutable
 {
     $interval = new DateInterval('PT1000000000S');

--- a/exercises/practice/gigasecond/.meta/example.php
+++ b/exercises/practice/gigasecond/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/gigasecond/.meta/example.php
+++ b/exercises/practice/gigasecond/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/gigasecond/.meta/example.php
+++ b/exercises/practice/gigasecond/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function from(DateTimeImmutable $from): DateTimeImmutable

--- a/exercises/practice/gigasecond/Gigasecond.php
+++ b/exercises/practice/gigasecond/Gigasecond.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/gigasecond/Gigasecond.php
+++ b/exercises/practice/gigasecond/Gigasecond.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/gigasecond/Gigasecond.php
+++ b/exercises/practice/gigasecond/Gigasecond.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function from(DateTimeImmutable $date): DateTimeImmutable

--- a/exercises/practice/gigasecond/Gigasecond.php
+++ b/exercises/practice/gigasecond/Gigasecond.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function from(DateTimeImmutable $date): DateTimeImmutable
 {
     throw new \BadFunctionCallException("Implement the from function");

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class GigasecondTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class GigasecondTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/grade-school/.meta/example.php
+++ b/exercises/practice/grade-school/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/grade-school/.meta/example.php
+++ b/exercises/practice/grade-school/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/grade-school/.meta/example.php
+++ b/exercises/practice/grade-school/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class School

--- a/exercises/practice/grade-school/.meta/example.php
+++ b/exercises/practice/grade-school/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class School
 {
     private $students = [];

--- a/exercises/practice/grade-school/GradeSchool.php
+++ b/exercises/practice/grade-school/GradeSchool.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/grade-school/GradeSchool.php
+++ b/exercises/practice/grade-school/GradeSchool.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/grade-school/GradeSchool.php
+++ b/exercises/practice/grade-school/GradeSchool.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class School

--- a/exercises/practice/grade-school/GradeSchool.php
+++ b/exercises/practice/grade-school/GradeSchool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class School
 {
     public function add(string $name, int $grade): void

--- a/exercises/practice/grade-school/GradeSchoolTest.php
+++ b/exercises/practice/grade-school/GradeSchoolTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/grade-school/GradeSchoolTest.php
+++ b/exercises/practice/grade-school/GradeSchoolTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
 class GradeSchoolTest extends TestCase

--- a/exercises/practice/grade-school/GradeSchoolTest.php
+++ b/exercises/practice/grade-school/GradeSchoolTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;

--- a/exercises/practice/grade-school/GradeSchoolTest.php
+++ b/exercises/practice/grade-school/GradeSchoolTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/grains/.meta/example.php
+++ b/exercises/practice/grains/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/grains/.meta/example.php
+++ b/exercises/practice/grains/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  *
 Here is the simplest solution. But King hates floats.

--- a/exercises/practice/grains/.meta/example.php
+++ b/exercises/practice/grains/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/grains/.meta/example.php
+++ b/exercises/practice/grains/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/grains/Grains.php
+++ b/exercises/practice/grains/Grains.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/grains/Grains.php
+++ b/exercises/practice/grains/Grains.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function square(int $number): string

--- a/exercises/practice/grains/Grains.php
+++ b/exercises/practice/grains/Grains.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function square(int $number): string
 {
     throw new \BadFunctionCallException("Implement the square function");

--- a/exercises/practice/grains/Grains.php
+++ b/exercises/practice/grains/Grains.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/grains/GrainsTest.php
+++ b/exercises/practice/grains/GrainsTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/grains/GrainsTest.php
+++ b/exercises/practice/grains/GrainsTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/grains/GrainsTest.php
+++ b/exercises/practice/grains/GrainsTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class GrainsTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/grains/GrainsTest.php
+++ b/exercises/practice/grains/GrainsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class GrainsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/hamming/.meta/example.php
+++ b/exercises/practice/hamming/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/hamming/.meta/example.php
+++ b/exercises/practice/hamming/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/hamming/.meta/example.php
+++ b/exercises/practice/hamming/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @param string $a
  * @param string $b

--- a/exercises/practice/hamming/.meta/example.php
+++ b/exercises/practice/hamming/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/hamming/Hamming.php
+++ b/exercises/practice/hamming/Hamming.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function distance(string $strandA, string $strandB): int
 {
     throw new \BadFunctionCallException("Implement the distance function");

--- a/exercises/practice/hamming/Hamming.php
+++ b/exercises/practice/hamming/Hamming.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/hamming/Hamming.php
+++ b/exercises/practice/hamming/Hamming.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function distance(string $strandA, string $strandB): int

--- a/exercises/practice/hamming/Hamming.php
+++ b/exercises/practice/hamming/Hamming.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/hamming/HammingTest.php
+++ b/exercises/practice/hamming/HammingTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/hamming/HammingTest.php
+++ b/exercises/practice/hamming/HammingTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class HammingTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/hamming/HammingTest.php
+++ b/exercises/practice/hamming/HammingTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/hamming/HammingTest.php
+++ b/exercises/practice/hamming/HammingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class HammingTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/hello-world/.meta/example.php
+++ b/exercises/practice/hello-world/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/hello-world/.meta/example.php
+++ b/exercises/practice/hello-world/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function helloWorld($name = 'World')
 {
     return "Hello, $name!";

--- a/exercises/practice/hello-world/.meta/example.php
+++ b/exercises/practice/hello-world/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function helloWorld($name = 'World')

--- a/exercises/practice/hello-world/.meta/example.php
+++ b/exercises/practice/hello-world/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/hello-world/HelloWorld.php
+++ b/exercises/practice/hello-world/HelloWorld.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/hello-world/HelloWorld.php
+++ b/exercises/practice/hello-world/HelloWorld.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 //

--- a/exercises/practice/hello-world/HelloWorld.php
+++ b/exercises/practice/hello-world/HelloWorld.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/hello-world/HelloWorld.php
+++ b/exercises/practice/hello-world/HelloWorld.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 //
 // This is only a SKELETON file for the "Hello World" exercise.
 // It's been provided as a convenience to get you started writing code faster.

--- a/exercises/practice/hello-world/HelloWorldTest.php
+++ b/exercises/practice/hello-world/HelloWorldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class HelloWorldTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/hello-world/HelloWorldTest.php
+++ b/exercises/practice/hello-world/HelloWorldTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/hello-world/HelloWorldTest.php
+++ b/exercises/practice/hello-world/HelloWorldTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class HelloWorldTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/hello-world/HelloWorldTest.php
+++ b/exercises/practice/hello-world/HelloWorldTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/isogram/.meta/example.php
+++ b/exercises/practice/isogram/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/isogram/.meta/example.php
+++ b/exercises/practice/isogram/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isIsogram($string)

--- a/exercises/practice/isogram/.meta/example.php
+++ b/exercises/practice/isogram/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isIsogram($string)
 {
     $string = str_replace(['-', ' '], '', mb_strtolower($string));

--- a/exercises/practice/isogram/.meta/example.php
+++ b/exercises/practice/isogram/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/isogram/Isogram.php
+++ b/exercises/practice/isogram/Isogram.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/isogram/Isogram.php
+++ b/exercises/practice/isogram/Isogram.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isogram(string $word): bool
 {
     throw new \BadFunctionCallException("Implement the isogram function");

--- a/exercises/practice/isogram/Isogram.php
+++ b/exercises/practice/isogram/Isogram.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/isogram/Isogram.php
+++ b/exercises/practice/isogram/Isogram.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isogram(string $word): bool

--- a/exercises/practice/isogram/IsogramTest.php
+++ b/exercises/practice/isogram/IsogramTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/isogram/IsogramTest.php
+++ b/exercises/practice/isogram/IsogramTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/isogram/IsogramTest.php
+++ b/exercises/practice/isogram/IsogramTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class IsogramTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/isogram/IsogramTest.php
+++ b/exercises/practice/isogram/IsogramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class IsogramTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/largest-series-product/.meta/example.php
+++ b/exercises/practice/largest-series-product/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Series
 {
     /**

--- a/exercises/practice/largest-series-product/.meta/example.php
+++ b/exercises/practice/largest-series-product/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/largest-series-product/.meta/example.php
+++ b/exercises/practice/largest-series-product/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/largest-series-product/.meta/example.php
+++ b/exercises/practice/largest-series-product/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Series

--- a/exercises/practice/largest-series-product/LargestSeriesProduct.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProduct.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/largest-series-product/LargestSeriesProduct.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProduct.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Series
 {
     public function largestProduct(int $span): int

--- a/exercises/practice/largest-series-product/LargestSeriesProduct.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProduct.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/largest-series-product/LargestSeriesProduct.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProduct.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Series

--- a/exercises/practice/largest-series-product/LargestSeriesProductTest.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProductTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/largest-series-product/LargestSeriesProductTest.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProductTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/largest-series-product/LargestSeriesProductTest.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProductTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void
@@ -22,25 +24,25 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     public function testCanFindTheLargestProductOf2(): void
     {
-        $series = new Series(576802143);
+        $series = new Series("576802143");
         $this->assertEquals(48, $series->largestProduct(2));
     }
 
     public function testFindsTheLargestProductIfSpanEqualsLength(): void
     {
-        $series = new Series(29);
+        $series = new Series("29");
         $this->assertEquals(18, $series->largestProduct(2));
     }
 
     public function testCanFindTheLargestProductOf3WithNumbersInOrder(): void
     {
-        $series = new Series(123456789);
+        $series = new Series("123456789");
         $this->assertEquals(504, $series->largestProduct(3));
     }
 
     public function testCanFindTheLargestProductOf3(): void
     {
-        $series = new Series(1027839564);
+        $series = new Series("1027839564");
         $this->assertEquals(270, $series->largestProduct(3));
     }
 
@@ -82,7 +84,7 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     public function testReportsZeroIfAllSpansIncludeZero(): void
     {
-        $series = new Series(99099);
+        $series = new Series("99099");
         $this->assertEquals(0, $series->largestProduct(3));
     }
 
@@ -90,7 +92,7 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $series = new Series(123);
+        $series = new Series("123");
         $series->largestProduct(4);
     }
 

--- a/exercises/practice/largest-series-product/LargestSeriesProductTest.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProductTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class LargestSeriesProductTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/leap/.meta/example.php
+++ b/exercises/practice/leap/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/leap/.meta/example.php
+++ b/exercises/practice/leap/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @return bool
  */

--- a/exercises/practice/leap/.meta/example.php
+++ b/exercises/practice/leap/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/leap/.meta/example.php
+++ b/exercises/practice/leap/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/leap/Leap.php
+++ b/exercises/practice/leap/Leap.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/leap/Leap.php
+++ b/exercises/practice/leap/Leap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isLeap(int $year): bool
 {
     throw new \BadFunctionCallException("Implement the isLeap function");

--- a/exercises/practice/leap/Leap.php
+++ b/exercises/practice/leap/Leap.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/leap/Leap.php
+++ b/exercises/practice/leap/Leap.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isLeap(int $year): bool

--- a/exercises/practice/leap/LeapTest.php
+++ b/exercises/practice/leap/LeapTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class LeapTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/leap/LeapTest.php
+++ b/exercises/practice/leap/LeapTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/leap/LeapTest.php
+++ b/exercises/practice/leap/LeapTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/leap/LeapTest.php
+++ b/exercises/practice/leap/LeapTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class LeapTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/luhn/.meta/example.php
+++ b/exercises/practice/luhn/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/luhn/.meta/example.php
+++ b/exercises/practice/luhn/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isValid($candidate)

--- a/exercises/practice/luhn/.meta/example.php
+++ b/exercises/practice/luhn/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isValid($candidate)
 {
     $sanitizedCandidate = str_replace(" ", "", $candidate) ;

--- a/exercises/practice/luhn/.meta/example.php
+++ b/exercises/practice/luhn/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/luhn/Luhn.php
+++ b/exercises/practice/luhn/Luhn.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/luhn/Luhn.php
+++ b/exercises/practice/luhn/Luhn.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/luhn/Luhn.php
+++ b/exercises/practice/luhn/Luhn.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isValid(string $number): bool

--- a/exercises/practice/luhn/Luhn.php
+++ b/exercises/practice/luhn/Luhn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isValid(string $number): bool
 {
     throw new \BadFunctionCallException("Implement the isValid function");

--- a/exercises/practice/luhn/LuhnTest.php
+++ b/exercises/practice/luhn/LuhnTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/luhn/LuhnTest.php
+++ b/exercises/practice/luhn/LuhnTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/luhn/LuhnTest.php
+++ b/exercises/practice/luhn/LuhnTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class LuhnTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/luhn/LuhnTest.php
+++ b/exercises/practice/luhn/LuhnTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class LuhnTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/markdown/.meta/example.php
+++ b/exercises/practice/markdown/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/markdown/.meta/example.php
+++ b/exercises/practice/markdown/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function parseMarkdown($markdown)
 {
     $lines = explode("\n", $markdown);

--- a/exercises/practice/markdown/.meta/example.php
+++ b/exercises/practice/markdown/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/markdown/.meta/example.php
+++ b/exercises/practice/markdown/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function parseMarkdown($markdown)

--- a/exercises/practice/markdown/Markdown.php
+++ b/exercises/practice/markdown/Markdown.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/markdown/Markdown.php
+++ b/exercises/practice/markdown/Markdown.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function parseMarkdown($markdown)
 {
     $lines = explode("\n", $markdown);

--- a/exercises/practice/markdown/Markdown.php
+++ b/exercises/practice/markdown/Markdown.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/markdown/Markdown.php
+++ b/exercises/practice/markdown/Markdown.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function parseMarkdown($markdown)

--- a/exercises/practice/markdown/MarkdownTest.php
+++ b/exercises/practice/markdown/MarkdownTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/markdown/MarkdownTest.php
+++ b/exercises/practice/markdown/MarkdownTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/markdown/MarkdownTest.php
+++ b/exercises/practice/markdown/MarkdownTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class MarkdownTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/markdown/MarkdownTest.php
+++ b/exercises/practice/markdown/MarkdownTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class MarkdownTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/mask-credit-card/.meta/example.php
+++ b/exercises/practice/mask-credit-card/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/mask-credit-card/.meta/example.php
+++ b/exercises/practice/mask-credit-card/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/mask-credit-card/.meta/example.php
+++ b/exercises/practice/mask-credit-card/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function maskify(string $cc): string

--- a/exercises/practice/mask-credit-card/.meta/example.php
+++ b/exercises/practice/mask-credit-card/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function maskify(string $cc): string
 {
     // Do no mask if cc less than 6 or empty string

--- a/exercises/practice/mask-credit-card/MaskCreditCard.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCard.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/mask-credit-card/MaskCreditCard.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function maskify(string $cc): string
 {
     throw new \BadFunctionCallException("Implement the maskify function");

--- a/exercises/practice/mask-credit-card/MaskCreditCard.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCard.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/mask-credit-card/MaskCreditCard.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCard.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function maskify(string $cc): string

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class MaskCreditCardTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class MaskCreditCardTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/matching-brackets/.meta/example.php
+++ b/exercises/practice/matching-brackets/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function brackets_match(string $input): bool

--- a/exercises/practice/matching-brackets/.meta/example.php
+++ b/exercises/practice/matching-brackets/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/matching-brackets/.meta/example.php
+++ b/exercises/practice/matching-brackets/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/matching-brackets/.meta/example.php
+++ b/exercises/practice/matching-brackets/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function brackets_match(string $input): bool
 {
     $characters = str_split($input);

--- a/exercises/practice/matching-brackets/MatchingBrackets.php
+++ b/exercises/practice/matching-brackets/MatchingBrackets.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function brackets_match(string $input): bool

--- a/exercises/practice/matching-brackets/MatchingBrackets.php
+++ b/exercises/practice/matching-brackets/MatchingBrackets.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/matching-brackets/MatchingBrackets.php
+++ b/exercises/practice/matching-brackets/MatchingBrackets.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function brackets_match(string $input): bool
 {
     throw new \BadFunctionCallException("Implement the brackets_match function");

--- a/exercises/practice/matching-brackets/MatchingBrackets.php
+++ b/exercises/practice/matching-brackets/MatchingBrackets.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/matching-brackets/MatchingBracketsTest.php
+++ b/exercises/practice/matching-brackets/MatchingBracketsTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class MatchingBracketsTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/matching-brackets/MatchingBracketsTest.php
+++ b/exercises/practice/matching-brackets/MatchingBracketsTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/matching-brackets/MatchingBracketsTest.php
+++ b/exercises/practice/matching-brackets/MatchingBracketsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/matching-brackets/MatchingBracketsTest.php
+++ b/exercises/practice/matching-brackets/MatchingBracketsTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/meetup/.meta/example.php
+++ b/exercises/practice/meetup/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/meetup/.meta/example.php
+++ b/exercises/practice/meetup/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function meetup_day($year, $month, $which, $weekday)

--- a/exercises/practice/meetup/.meta/example.php
+++ b/exercises/practice/meetup/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function meetup_day($year, $month, $which, $weekday)
 {
     $monthName = DateTimeImmutable::createFromFormat("!m", $month)->format('F');

--- a/exercises/practice/meetup/.meta/example.php
+++ b/exercises/practice/meetup/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/meetup/Meetup.php
+++ b/exercises/practice/meetup/Meetup.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function meetup_day(int $year, int $month, string $which, string $weekday): DateTimeImmutable

--- a/exercises/practice/meetup/Meetup.php
+++ b/exercises/practice/meetup/Meetup.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/meetup/Meetup.php
+++ b/exercises/practice/meetup/Meetup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function meetup_day(int $year, int $month, string $which, string $weekday): DateTimeImmutable
 {
     throw new \BadFunctionCallException("Implement the meetup_day function");

--- a/exercises/practice/meetup/Meetup.php
+++ b/exercises/practice/meetup/Meetup.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/meetup/MeetupTest.php
+++ b/exercises/practice/meetup/MeetupTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/meetup/MeetupTest.php
+++ b/exercises/practice/meetup/MeetupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class MeetupTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/meetup/MeetupTest.php
+++ b/exercises/practice/meetup/MeetupTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class MeetupTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/meetup/MeetupTest.php
+++ b/exercises/practice/meetup/MeetupTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/meetup/MeetupTest.php
+++ b/exercises/practice/meetup/MeetupTest.php
@@ -9,476 +9,476 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     public function testMonteenthOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/13"), meetup_day(2013, 5, "teenth", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/13"), meetup_day(2013, "5", "teenth", "Monday"));
     }
 
     public function testMonteenthOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/19"), meetup_day(2013, 8, "teenth", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/19"), meetup_day(2013, "8", "teenth", "Monday"));
     }
 
     public function testMonteenthOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/16"), meetup_day(2013, 9, "teenth", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/16"), meetup_day(2013, "9", "teenth", "Monday"));
     }
 
     public function testTuesteenthOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/19"), meetup_day(2013, 3, "teenth", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/19"), meetup_day(2013, "3", "teenth", "Tuesday"));
     }
 
     public function testTuesteenthOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/16"), meetup_day(2013, 4, "teenth", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/16"), meetup_day(2013, "4", "teenth", "Tuesday"));
     }
 
     public function testTuesteenthOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/13"), meetup_day(2013, 8, "teenth", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/13"), meetup_day(2013, "8", "teenth", "Tuesday"));
     }
 
     public function testWednesteenthOfJanuary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/1/16"), meetup_day(2013, 1, "teenth", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/1/16"), meetup_day(2013, "1", "teenth", "Wednesday"));
     }
 
     public function testWednesteenthOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/13"), meetup_day(2013, 2, "teenth", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/13"), meetup_day(2013, "2", "teenth", "Wednesday"));
     }
 
     public function testWednesteenthOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/19"), meetup_day(2013, 6, "teenth", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/19"), meetup_day(2013, "6", "teenth", "Wednesday"));
     }
 
     public function testThursteenthOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/16"), meetup_day(2013, 5, "teenth", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/16"), meetup_day(2013, "5", "teenth", "Thursday"));
     }
 
     public function testThursteenthOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/13"), meetup_day(2013, 6, "teenth", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/13"), meetup_day(2013, "6", "teenth", "Thursday"));
     }
 
     public function testThursteenthOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/19"), meetup_day(2013, 9, "teenth", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/19"), meetup_day(2013, "9", "teenth", "Thursday"));
     }
 
     public function testFriteenthOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/19"), meetup_day(2013, 4, "teenth", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/19"), meetup_day(2013, "4", "teenth", "Friday"));
     }
 
     public function testFriteenthOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/16"), meetup_day(2013, 8, "teenth", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/16"), meetup_day(2013, "8", "teenth", "Friday"));
     }
 
     public function testFriteenthOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/13"), meetup_day(2013, 9, "teenth", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/13"), meetup_day(2013, "9", "teenth", "Friday"));
     }
 
     public function testSaturteenthOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/16"), meetup_day(2013, 2, "teenth", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/16"), meetup_day(2013, "2", "teenth", "Saturday"));
     }
 
     public function testSaturteenthOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/13"), meetup_day(2013, 4, "teenth", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/13"), meetup_day(2013, "4", "teenth", "Saturday"));
     }
 
     public function testSaturteenthOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/19"), meetup_day(2013, 10, "teenth", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/19"), meetup_day(2013, "10", "teenth", "Saturday"));
     }
 
     public function testSunteenthOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/19"), meetup_day(2013, 5, "teenth", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/19"), meetup_day(2013, "5", "teenth", "Sunday"));
     }
 
     public function testSunteenthOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/16"), meetup_day(2013, 6, "teenth", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/16"), meetup_day(2013, "6", "teenth", "Sunday"));
     }
 
     public function testSunteenthOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/13"), meetup_day(2013, 10, "teenth", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/13"), meetup_day(2013, "10", "teenth", "Sunday"));
     }
 
     public function testFirstMondayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/4"), meetup_day(2013, 3, "first", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/4"), meetup_day(2013, "3", "first", "Monday"));
     }
 
     public function testFirstMondayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/1"), meetup_day(2013, 4, "first", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/1"), meetup_day(2013, "4", "first", "Monday"));
     }
 
     public function testFirstTuesdayOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/7"), meetup_day(2013, 5, "first", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/7"), meetup_day(2013, "5", "first", "Tuesday"));
     }
 
     public function testFirstTuesdayOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/4"), meetup_day(2013, 6, "first", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/4"), meetup_day(2013, "6", "first", "Tuesday"));
     }
 
     public function testFirstWednesdayOfJuly2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/7/3"), meetup_day(2013, 7, "first", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/7/3"), meetup_day(2013, "7", "first", "Wednesday"));
     }
 
     public function testFirstWednesdayOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/7"), meetup_day(2013, 8, "first", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/7"), meetup_day(2013, "8", "first", "Wednesday"));
     }
 
     public function testFirstThursdayOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/5"), meetup_day(2013, 9, "first", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/5"), meetup_day(2013, "9", "first", "Thursday"));
     }
 
     public function testFirstThursdayOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/3"), meetup_day(2013, 10, "first", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/3"), meetup_day(2013, "10", "first", "Thursday"));
     }
 
     public function testFirstFridayOfNovember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/11/1"), meetup_day(2013, 11, "first", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/11/1"), meetup_day(2013, "11", "first", "Friday"));
     }
 
     public function testFirstFridayOfDecember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/12/6"), meetup_day(2013, 12, "first", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/12/6"), meetup_day(2013, "12", "first", "Friday"));
     }
 
     public function testFirstSaturdayOfJanuary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/1/5"), meetup_day(2013, 1, "first", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/1/5"), meetup_day(2013, "1", "first", "Saturday"));
     }
 
     public function testFirstSaturdayOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/2"), meetup_day(2013, 2, "first", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/2"), meetup_day(2013, "2", "first", "Saturday"));
     }
 
     public function testFirstSundayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/3"), meetup_day(2013, 3, "first", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/3"), meetup_day(2013, "3", "first", "Sunday"));
     }
 
     public function testFirstSundayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/7"), meetup_day(2013, 4, "first", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/7"), meetup_day(2013, "4", "first", "Sunday"));
     }
 
     public function testSecondMondayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/11"), meetup_day(2013, 3, "second", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/11"), meetup_day(2013, "3", "second", "Monday"));
     }
 
     public function testSecondMondayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/8"), meetup_day(2013, 4, "second", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/8"), meetup_day(2013, "4", "second", "Monday"));
     }
 
     public function testSecondTuesdayOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/14"), meetup_day(2013, 5, "second", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/14"), meetup_day(2013, "5", "second", "Tuesday"));
     }
 
     public function testSecondTuesdayOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/11"), meetup_day(2013, 6, "second", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/11"), meetup_day(2013, "6", "second", "Tuesday"));
     }
 
     public function testSecondWednesdayOfJuly2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/7/10"), meetup_day(2013, 7, "second", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/7/10"), meetup_day(2013, "7", "second", "Wednesday"));
     }
 
     public function testSecondWednesdayOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/14"), meetup_day(2013, 8, "second", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/14"), meetup_day(2013, "8", "second", "Wednesday"));
     }
 
     public function testSecondThursdayOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/12"), meetup_day(2013, 9, "second", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/12"), meetup_day(2013, "9", "second", "Thursday"));
     }
 
     public function testSecondThursdayOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/10"), meetup_day(2013, 10, "second", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/10"), meetup_day(2013, "10", "second", "Thursday"));
     }
 
     public function testSecondFridayOfNovember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/11/8"), meetup_day(2013, 11, "second", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/11/8"), meetup_day(2013, "11", "second", "Friday"));
     }
 
     public function testSecondFridayOfDecember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/12/13"), meetup_day(2013, 12, "second", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/12/13"), meetup_day(2013, "12", "second", "Friday"));
     }
 
     public function testSecondSaturdayOfJanuary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/1/12"), meetup_day(2013, 1, "second", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/1/12"), meetup_day(2013, "1", "second", "Saturday"));
     }
 
     public function testSecondSaturdayOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/9"), meetup_day(2013, 2, "second", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/9"), meetup_day(2013, "2", "second", "Saturday"));
     }
 
     public function testSecondSundayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/10"), meetup_day(2013, 3, "second", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/10"), meetup_day(2013, "3", "second", "Sunday"));
     }
 
     public function testSecondSundayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/14"), meetup_day(2013, 4, "second", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/14"), meetup_day(2013, "4", "second", "Sunday"));
     }
 
     public function testThirdMondayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/18"), meetup_day(2013, 3, "third", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/18"), meetup_day(2013, "3", "third", "Monday"));
     }
 
     public function testThirdMondayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/15"), meetup_day(2013, 4, "third", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/15"), meetup_day(2013, "4", "third", "Monday"));
     }
 
     public function testThirdTuesdayOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/21"), meetup_day(2013, 5, "third", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/21"), meetup_day(2013, "5", "third", "Tuesday"));
     }
 
     public function testThirdTuesdayOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/18"), meetup_day(2013, 6, "third", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/18"), meetup_day(2013, "6", "third", "Tuesday"));
     }
 
     public function testThirdWednesdayOfJuly2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/7/17"), meetup_day(2013, 7, "third", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/7/17"), meetup_day(2013, "7", "third", "Wednesday"));
     }
 
     public function testThirdWednesdayOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/21"), meetup_day(2013, 8, "third", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/21"), meetup_day(2013, "8", "third", "Wednesday"));
     }
 
     public function testThirdThursdayOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/19"), meetup_day(2013, 9, "third", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/19"), meetup_day(2013, "9", "third", "Thursday"));
     }
 
     public function testThirdThursdayOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/17"), meetup_day(2013, 10, "third", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/17"), meetup_day(2013, "10", "third", "Thursday"));
     }
 
     public function testThirdFridayOfNovember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/11/15"), meetup_day(2013, 11, "third", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/11/15"), meetup_day(2013, "11", "third", "Friday"));
     }
 
     public function testThirdFridayOfDecember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/12/20"), meetup_day(2013, 12, "third", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/12/20"), meetup_day(2013, "12", "third", "Friday"));
     }
 
     public function testThirdSaturdayOfJanuary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/1/19"), meetup_day(2013, 1, "third", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/1/19"), meetup_day(2013, "1", "third", "Saturday"));
     }
 
     public function testThirdSaturdayOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/16"), meetup_day(2013, 2, "third", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/16"), meetup_day(2013, "2", "third", "Saturday"));
     }
 
     public function testThirdSundayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/17"), meetup_day(2013, 3, "third", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/17"), meetup_day(2013, "3", "third", "Sunday"));
     }
 
     public function testThirdSundayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/21"), meetup_day(2013, 4, "third", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/21"), meetup_day(2013, "4", "third", "Sunday"));
     }
 
     public function testFourthMondayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/25"), meetup_day(2013, 3, "fourth", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/25"), meetup_day(2013, "3", "fourth", "Monday"));
     }
 
     public function testFourthMondayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/22"), meetup_day(2013, 4, "fourth", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/22"), meetup_day(2013, "4", "fourth", "Monday"));
     }
 
     public function testFourthTuesdayOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/28"), meetup_day(2013, 5, "fourth", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/28"), meetup_day(2013, "5", "fourth", "Tuesday"));
     }
 
     public function testFourthTuesdayOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/25"), meetup_day(2013, 6, "fourth", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/25"), meetup_day(2013, "6", "fourth", "Tuesday"));
     }
 
     public function testFourthWednesdayOfJuly2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/7/24"), meetup_day(2013, 7, "fourth", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/7/24"), meetup_day(2013, "7", "fourth", "Wednesday"));
     }
 
     public function testFourthWednesdayOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/28"), meetup_day(2013, 8, "fourth", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/28"), meetup_day(2013, "8", "fourth", "Wednesday"));
     }
 
     public function testFourthThursdayOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/26"), meetup_day(2013, 9, "fourth", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/26"), meetup_day(2013, "9", "fourth", "Thursday"));
     }
 
     public function testFourthThursdayOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/24"), meetup_day(2013, 10, "fourth", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/24"), meetup_day(2013, "10", "fourth", "Thursday"));
     }
 
     public function testFourthFridayOfNovember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/11/22"), meetup_day(2013, 11, "fourth", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/11/22"), meetup_day(2013, "11", "fourth", "Friday"));
     }
 
     public function testFourthFridayOfDecember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/12/27"), meetup_day(2013, 12, "fourth", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/12/27"), meetup_day(2013, "12", "fourth", "Friday"));
     }
 
     public function testFourthSaturdayOfJanuary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/1/26"), meetup_day(2013, 1, "fourth", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/1/26"), meetup_day(2013, "1", "fourth", "Saturday"));
     }
 
     public function testFourthSaturdayOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/23"), meetup_day(2013, 2, "fourth", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/23"), meetup_day(2013, "2", "fourth", "Saturday"));
     }
 
     public function testFourthSundayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/24"), meetup_day(2013, 3, "fourth", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/24"), meetup_day(2013, "3", "fourth", "Sunday"));
     }
 
     public function testFourthSundayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/28"), meetup_day(2013, 4, "fourth", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/28"), meetup_day(2013, "4", "fourth", "Sunday"));
     }
 
     public function testLastMondayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/25"), meetup_day(2013, 3, "last", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/25"), meetup_day(2013, "3", "last", "Monday"));
     }
 
     public function testLastMondayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/29"), meetup_day(2013, 4, "last", "Monday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/29"), meetup_day(2013, "4", "last", "Monday"));
     }
 
     public function testLastTuesdayOfMay2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/5/28"), meetup_day(2013, 5, "last", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/5/28"), meetup_day(2013, "5", "last", "Tuesday"));
     }
 
     public function testLastTuesdayOfJune2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/6/25"), meetup_day(2013, 6, "last", "Tuesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/6/25"), meetup_day(2013, "6", "last", "Tuesday"));
     }
 
     public function testLastWednesdayOfJuly2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/7/31"), meetup_day(2013, 7, "last", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/7/31"), meetup_day(2013, "7", "last", "Wednesday"));
     }
 
     public function testLastWednesdayOfAugust2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/8/28"), meetup_day(2013, 8, "last", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2013/8/28"), meetup_day(2013, "8", "last", "Wednesday"));
     }
 
     public function testLastThursdayOfSeptember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/9/26"), meetup_day(2013, 9, "last", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/9/26"), meetup_day(2013, "9", "last", "Thursday"));
     }
 
     public function testLastThursdayOfOctober2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/10/31"), meetup_day(2013, 10, "last", "Thursday"));
+        $this->assertEquals(new DateTimeImmutable("2013/10/31"), meetup_day(2013, "10", "last", "Thursday"));
     }
 
     public function testLastFridayOfNovember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/11/29"), meetup_day(2013, 11, "last", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/11/29"), meetup_day(2013, "11", "last", "Friday"));
     }
 
     public function testLastFridayOfDecember2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/12/27"), meetup_day(2013, 12, "last", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2013/12/27"), meetup_day(2013, "12", "last", "Friday"));
     }
 
     public function testLastSaturdayOfJanuary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/1/26"), meetup_day(2013, 1, "last", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/1/26"), meetup_day(2013, "1", "last", "Saturday"));
     }
 
     public function testLastSaturdayOfFebruary2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/2/23"), meetup_day(2013, 2, "last", "Saturday"));
+        $this->assertEquals(new DateTimeImmutable("2013/2/23"), meetup_day(2013, "2", "last", "Saturday"));
     }
 
     public function testLastSundayOfMarch2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/3/31"), meetup_day(2013, 3, "last", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/3/31"), meetup_day(2013, "3", "last", "Sunday"));
     }
 
     public function testLastSundayOfApril2013(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2013/4/28"), meetup_day(2013, 4, "last", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2013/4/28"), meetup_day(2013, "4", "last", "Sunday"));
     }
 
     public function testLastWednesdayOfFebruary2012(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2012/2/29"), meetup_day(2012, 2, "last", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2012/2/29"), meetup_day(2012, "2", "last", "Wednesday"));
     }
 
     public function testLastWednesdayOfDecember2014(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2014/12/31"), meetup_day(2014, 12, "last", "Wednesday"));
+        $this->assertEquals(new DateTimeImmutable("2014/12/31"), meetup_day(2014, "12", "last", "Wednesday"));
     }
 
     public function testLastSundayOfFebruary2015(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2015/2/22"), meetup_day(2015, 2, "last", "Sunday"));
+        $this->assertEquals(new DateTimeImmutable("2015/2/22"), meetup_day(2015, "2", "last", "Sunday"));
     }
 
     public function testFirstFridayOfDecember2012(): void
     {
-        $this->assertEquals(new DateTimeImmutable("2012/12/7"), meetup_day(2012, 12, "first", "Friday"));
+        $this->assertEquals(new DateTimeImmutable("2012/12/7"), meetup_day(2012, "12", "first", "Friday"));
     }
 }

--- a/exercises/practice/minesweeper/.meta/example.php
+++ b/exercises/practice/minesweeper/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/minesweeper/.meta/example.php
+++ b/exercises/practice/minesweeper/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function solve($minesweeperBoard)
 {
     $minesweeperBoard = makeBoardFromString($minesweeperBoard);

--- a/exercises/practice/minesweeper/.meta/example.php
+++ b/exercises/practice/minesweeper/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function solve($minesweeperBoard)

--- a/exercises/practice/minesweeper/.meta/example.php
+++ b/exercises/practice/minesweeper/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/minesweeper/Minesweeper.php
+++ b/exercises/practice/minesweeper/Minesweeper.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/minesweeper/Minesweeper.php
+++ b/exercises/practice/minesweeper/Minesweeper.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/minesweeper/Minesweeper.php
+++ b/exercises/practice/minesweeper/Minesweeper.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function solve(string $minesweeperBoard): string

--- a/exercises/practice/minesweeper/Minesweeper.php
+++ b/exercises/practice/minesweeper/Minesweeper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function solve(string $minesweeperBoard): string
 {
     throw new \BadFunctionCallException("Implement the solve function");

--- a/exercises/practice/minesweeper/MinesweeperTest.php
+++ b/exercises/practice/minesweeper/MinesweeperTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/minesweeper/MinesweeperTest.php
+++ b/exercises/practice/minesweeper/MinesweeperTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/minesweeper/MinesweeperTest.php
+++ b/exercises/practice/minesweeper/MinesweeperTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class MinesweeperTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/minesweeper/MinesweeperTest.php
+++ b/exercises/practice/minesweeper/MinesweeperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class MinesweeperTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/nth-prime/.meta/example.php
+++ b/exercises/practice/nth-prime/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/nth-prime/.meta/example.php
+++ b/exercises/practice/nth-prime/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function prime($count)

--- a/exercises/practice/nth-prime/.meta/example.php
+++ b/exercises/practice/nth-prime/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function prime($count)
 {
     if ($count < 1) {

--- a/exercises/practice/nth-prime/.meta/example.php
+++ b/exercises/practice/nth-prime/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/nth-prime/NthPrime.php
+++ b/exercises/practice/nth-prime/NthPrime.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/nth-prime/NthPrime.php
+++ b/exercises/practice/nth-prime/NthPrime.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/nth-prime/NthPrime.php
+++ b/exercises/practice/nth-prime/NthPrime.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function prime(int $number)

--- a/exercises/practice/nth-prime/NthPrime.php
+++ b/exercises/practice/nth-prime/NthPrime.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function prime(int $number)
 {
     throw new \BadFunctionCallException("Implement the prime function");

--- a/exercises/practice/nth-prime/NthPrimeTest.php
+++ b/exercises/practice/nth-prime/NthPrimeTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/nth-prime/NthPrimeTest.php
+++ b/exercises/practice/nth-prime/NthPrimeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class NthPrimeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/nth-prime/NthPrimeTest.php
+++ b/exercises/practice/nth-prime/NthPrimeTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/nth-prime/NthPrimeTest.php
+++ b/exercises/practice/nth-prime/NthPrimeTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class NthPrimeTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/nucleotide-count/.meta/example.php
+++ b/exercises/practice/nucleotide-count/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function nucleotideCount($dna)

--- a/exercises/practice/nucleotide-count/.meta/example.php
+++ b/exercises/practice/nucleotide-count/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/nucleotide-count/.meta/example.php
+++ b/exercises/practice/nucleotide-count/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function nucleotideCount($dna)
 {
     $nucleotides = [];

--- a/exercises/practice/nucleotide-count/.meta/example.php
+++ b/exercises/practice/nucleotide-count/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/nucleotide-count/NucleotideCount.php
+++ b/exercises/practice/nucleotide-count/NucleotideCount.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/nucleotide-count/NucleotideCount.php
+++ b/exercises/practice/nucleotide-count/NucleotideCount.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/nucleotide-count/NucleotideCount.php
+++ b/exercises/practice/nucleotide-count/NucleotideCount.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function nucleotideCount(string $input): array

--- a/exercises/practice/nucleotide-count/NucleotideCount.php
+++ b/exercises/practice/nucleotide-count/NucleotideCount.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function nucleotideCount(string $input): array
 {
     throw new \BadFunctionCallException("Implement the nucleotideCount function");

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class NucleotideCountTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class NucleotideCountTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ocr-numbers/.meta/example.php
+++ b/exercises/practice/ocr-numbers/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/ocr-numbers/.meta/example.php
+++ b/exercises/practice/ocr-numbers/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function recognize($ocr)

--- a/exercises/practice/ocr-numbers/.meta/example.php
+++ b/exercises/practice/ocr-numbers/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ocr-numbers/.meta/example.php
+++ b/exercises/practice/ocr-numbers/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function recognize($ocr)
 {
     return (new OcrBlock($ocr))->recognize();

--- a/exercises/practice/ocr-numbers/OcrNumbers.php
+++ b/exercises/practice/ocr-numbers/OcrNumbers.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function recognize(array $input): string

--- a/exercises/practice/ocr-numbers/OcrNumbers.php
+++ b/exercises/practice/ocr-numbers/OcrNumbers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function recognize(array $input): string
 {
     throw new \BadFunctionCallException("Implement the recognize function");

--- a/exercises/practice/ocr-numbers/OcrNumbers.php
+++ b/exercises/practice/ocr-numbers/OcrNumbers.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/ocr-numbers/OcrNumbers.php
+++ b/exercises/practice/ocr-numbers/OcrNumbers.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ocr-numbers/OcrNumbersTest.php
+++ b/exercises/practice/ocr-numbers/OcrNumbersTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/ocr-numbers/OcrNumbersTest.php
+++ b/exercises/practice/ocr-numbers/OcrNumbersTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class OcrNumbersTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/ocr-numbers/OcrNumbersTest.php
+++ b/exercises/practice/ocr-numbers/OcrNumbersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class OcrNumbersTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/ocr-numbers/OcrNumbersTest.php
+++ b/exercises/practice/ocr-numbers/OcrNumbersTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ordinal-number/.meta/example.php
+++ b/exercises/practice/ordinal-number/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toOrdinal(int $number): string

--- a/exercises/practice/ordinal-number/.meta/example.php
+++ b/exercises/practice/ordinal-number/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/ordinal-number/.meta/example.php
+++ b/exercises/practice/ordinal-number/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toOrdinal(int $number): string
 {
     if (0 === $number) {

--- a/exercises/practice/ordinal-number/.meta/example.php
+++ b/exercises/practice/ordinal-number/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ordinal-number/OrdinalNumber.php
+++ b/exercises/practice/ordinal-number/OrdinalNumber.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toOrdinal(int $number): string

--- a/exercises/practice/ordinal-number/OrdinalNumber.php
+++ b/exercises/practice/ordinal-number/OrdinalNumber.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/ordinal-number/OrdinalNumber.php
+++ b/exercises/practice/ordinal-number/OrdinalNumber.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ordinal-number/OrdinalNumber.php
+++ b/exercises/practice/ordinal-number/OrdinalNumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toOrdinal(int $number): string
 {
     throw new \BadFunctionCallException("Implement the toOrdinal function");

--- a/exercises/practice/ordinal-number/OrdinalNumberTest.php
+++ b/exercises/practice/ordinal-number/OrdinalNumberTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/ordinal-number/OrdinalNumberTest.php
+++ b/exercises/practice/ordinal-number/OrdinalNumberTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class OrdinalNumberTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/ordinal-number/OrdinalNumberTest.php
+++ b/exercises/practice/ordinal-number/OrdinalNumberTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/ordinal-number/OrdinalNumberTest.php
+++ b/exercises/practice/ordinal-number/OrdinalNumberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class OrdinalNumberTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/palindrome-products/.meta/example.php
+++ b/exercises/practice/palindrome-products/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function generatePalindromeProduct(array $range): ?int
 {
     $palindromes = [];

--- a/exercises/practice/palindrome-products/.meta/example.php
+++ b/exercises/practice/palindrome-products/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/palindrome-products/.meta/example.php
+++ b/exercises/practice/palindrome-products/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function generatePalindromeProduct(array $range): ?int

--- a/exercises/practice/palindrome-products/.meta/example.php
+++ b/exercises/practice/palindrome-products/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/palindrome-products/PalindromeProducts.php
+++ b/exercises/practice/palindrome-products/PalindromeProducts.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/palindrome-products/PalindromeProducts.php
+++ b/exercises/practice/palindrome-products/PalindromeProducts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function smallest(int $min, int $max): array
 {
     throw new \BadFunctionCallException("Implement the smallest function");

--- a/exercises/practice/palindrome-products/PalindromeProducts.php
+++ b/exercises/practice/palindrome-products/PalindromeProducts.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/palindrome-products/PalindromeProducts.php
+++ b/exercises/practice/palindrome-products/PalindromeProducts.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function smallest(int $min, int $max): array

--- a/exercises/practice/palindrome-products/PalindromeProductsTest.php
+++ b/exercises/practice/palindrome-products/PalindromeProductsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PalindromeProductsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/palindrome-products/PalindromeProductsTest.php
+++ b/exercises/practice/palindrome-products/PalindromeProductsTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PalindromeProductsTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/palindrome-products/PalindromeProductsTest.php
+++ b/exercises/practice/palindrome-products/PalindromeProductsTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/palindrome-products/PalindromeProductsTest.php
+++ b/exercises/practice/palindrome-products/PalindromeProductsTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pangram/.meta/example.php
+++ b/exercises/practice/pangram/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isPangram($string)

--- a/exercises/practice/pangram/.meta/example.php
+++ b/exercises/practice/pangram/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pangram/.meta/example.php
+++ b/exercises/practice/pangram/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pangram/.meta/example.php
+++ b/exercises/practice/pangram/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isPangram($string)
 {
     $string = str_replace(['-', ' '], '', mb_strtolower($string));

--- a/exercises/practice/pangram/Pangram.php
+++ b/exercises/practice/pangram/Pangram.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pangram/Pangram.php
+++ b/exercises/practice/pangram/Pangram.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function isPangram(string $string): bool
 {
     throw new \BadFunctionCallException("Implement the isPangram function");

--- a/exercises/practice/pangram/Pangram.php
+++ b/exercises/practice/pangram/Pangram.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function isPangram(string $string): bool

--- a/exercises/practice/pangram/Pangram.php
+++ b/exercises/practice/pangram/Pangram.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PangramTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PangramTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/pascals-triangle/.meta/example.php
+++ b/exercises/practice/pascals-triangle/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pascals-triangle/.meta/example.php
+++ b/exercises/practice/pascals-triangle/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function pascalsTriangleRows($rowCount)
 {
     if ($rowCount < 0 || $rowCount === null) {

--- a/exercises/practice/pascals-triangle/.meta/example.php
+++ b/exercises/practice/pascals-triangle/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function pascalsTriangleRows($rowCount)

--- a/exercises/practice/pascals-triangle/.meta/example.php
+++ b/exercises/practice/pascals-triangle/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pascals-triangle/PascalsTriangle.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangle.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pascals-triangle/PascalsTriangle.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function pascalsTriangleRows(int $rowCount)
 {
     throw new \BadFunctionCallException("Implement the pascalsTriangleRows function");

--- a/exercises/practice/pascals-triangle/PascalsTriangle.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangle.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pascals-triangle/PascalsTriangle.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangle.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function pascalsTriangleRows(int $rowCount)

--- a/exercises/practice/pascals-triangle/PascalsTriangleTest.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangleTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pascals-triangle/PascalsTriangleTest.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangleTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PascalsTriangleTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/pascals-triangle/PascalsTriangleTest.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangleTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pascals-triangle/PascalsTriangleTest.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/perfect-numbers/.meta/example.php
+++ b/exercises/practice/perfect-numbers/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/perfect-numbers/.meta/example.php
+++ b/exercises/practice/perfect-numbers/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/perfect-numbers/.meta/example.php
+++ b/exercises/practice/perfect-numbers/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function getClassification($number)

--- a/exercises/practice/perfect-numbers/.meta/example.php
+++ b/exercises/practice/perfect-numbers/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function getClassification($number)
 {
     if ($number <= 0) {

--- a/exercises/practice/perfect-numbers/PerfectNumbers.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/perfect-numbers/PerfectNumbers.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/perfect-numbers/PerfectNumbers.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function getClassification(int $number): string
 {
     throw new \BadFunctionCallException("Implement the getClassification function");

--- a/exercises/practice/perfect-numbers/PerfectNumbers.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function getClassification(int $number): string

--- a/exercises/practice/perfect-numbers/PerfectNumbersTest.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbersTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/perfect-numbers/PerfectNumbersTest.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbersTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PerfectNumbersTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/perfect-numbers/PerfectNumbersTest.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbersTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PerfectNumbersTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/perfect-numbers/PerfectNumbersTest.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbersTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/phone-number/.meta/example.php
+++ b/exercises/practice/phone-number/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/phone-number/.meta/example.php
+++ b/exercises/practice/phone-number/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/phone-number/.meta/example.php
+++ b/exercises/practice/phone-number/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PhoneNumber

--- a/exercises/practice/phone-number/.meta/example.php
+++ b/exercises/practice/phone-number/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PhoneNumber
 {
     private $number;

--- a/exercises/practice/phone-number/PhoneNumber.php
+++ b/exercises/practice/phone-number/PhoneNumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PhoneNumber
 {
     public function number(): string

--- a/exercises/practice/phone-number/PhoneNumber.php
+++ b/exercises/practice/phone-number/PhoneNumber.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/phone-number/PhoneNumber.php
+++ b/exercises/practice/phone-number/PhoneNumber.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/phone-number/PhoneNumber.php
+++ b/exercises/practice/phone-number/PhoneNumber.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PhoneNumber

--- a/exercises/practice/phone-number/PhoneNumberTest.php
+++ b/exercises/practice/phone-number/PhoneNumberTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/phone-number/PhoneNumberTest.php
+++ b/exercises/practice/phone-number/PhoneNumberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PhoneNumberTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/phone-number/PhoneNumberTest.php
+++ b/exercises/practice/phone-number/PhoneNumberTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/phone-number/PhoneNumberTest.php
+++ b/exercises/practice/phone-number/PhoneNumberTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PhoneNumberTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/pig-latin/.meta/example.php
+++ b/exercises/practice/pig-latin/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pig-latin/.meta/example.php
+++ b/exercises/practice/pig-latin/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Translates a string into Pig Latin
  *

--- a/exercises/practice/pig-latin/.meta/example.php
+++ b/exercises/practice/pig-latin/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pig-latin/.meta/example.php
+++ b/exercises/practice/pig-latin/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/pig-latin/PigLatin.php
+++ b/exercises/practice/pig-latin/PigLatin.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pig-latin/PigLatin.php
+++ b/exercises/practice/pig-latin/PigLatin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function translate(string $text): string
 {
     throw new \BadFunctionCallException("Implement the translate function");

--- a/exercises/practice/pig-latin/PigLatin.php
+++ b/exercises/practice/pig-latin/PigLatin.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function translate(string $text): string

--- a/exercises/practice/pig-latin/PigLatin.php
+++ b/exercises/practice/pig-latin/PigLatin.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/pig-latin/PigLatinTest.php
+++ b/exercises/practice/pig-latin/PigLatinTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PigLatinTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/pig-latin/PigLatinTest.php
+++ b/exercises/practice/pig-latin/PigLatinTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/pig-latin/PigLatinTest.php
+++ b/exercises/practice/pig-latin/PigLatinTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PigLatinTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/pig-latin/PigLatinTest.php
+++ b/exercises/practice/pig-latin/PigLatinTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/prime-factors/.meta/example.php
+++ b/exercises/practice/prime-factors/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/prime-factors/.meta/example.php
+++ b/exercises/practice/prime-factors/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function factors($n)
 {
     $factorList = [];

--- a/exercises/practice/prime-factors/.meta/example.php
+++ b/exercises/practice/prime-factors/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/prime-factors/.meta/example.php
+++ b/exercises/practice/prime-factors/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function factors($n)

--- a/exercises/practice/prime-factors/PrimeFactors.php
+++ b/exercises/practice/prime-factors/PrimeFactors.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/prime-factors/PrimeFactors.php
+++ b/exercises/practice/prime-factors/PrimeFactors.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function factors(int $number): array

--- a/exercises/practice/prime-factors/PrimeFactors.php
+++ b/exercises/practice/prime-factors/PrimeFactors.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/prime-factors/PrimeFactors.php
+++ b/exercises/practice/prime-factors/PrimeFactors.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function factors(int $number): array
 {
     throw new \BadFunctionCallException("Implement the factors function");

--- a/exercises/practice/prime-factors/PrimeFactorsTest.php
+++ b/exercises/practice/prime-factors/PrimeFactorsTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/prime-factors/PrimeFactorsTest.php
+++ b/exercises/practice/prime-factors/PrimeFactorsTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class PrimeFactorsTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/prime-factors/PrimeFactorsTest.php
+++ b/exercises/practice/prime-factors/PrimeFactorsTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/prime-factors/PrimeFactorsTest.php
+++ b/exercises/practice/prime-factors/PrimeFactorsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class PrimeFactorsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/queen-attack/.meta/example.php
+++ b/exercises/practice/queen-attack/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/queen-attack/.meta/example.php
+++ b/exercises/practice/queen-attack/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/queen-attack/.meta/example.php
+++ b/exercises/practice/queen-attack/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Check if the queen is placed on a valid square.
  *

--- a/exercises/practice/queen-attack/.meta/example.php
+++ b/exercises/practice/queen-attack/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/queen-attack/QueenAttack.php
+++ b/exercises/practice/queen-attack/QueenAttack.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/queen-attack/QueenAttack.php
+++ b/exercises/practice/queen-attack/QueenAttack.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function placeQueen(int $xCoordinate, int $yCoordinate): bool

--- a/exercises/practice/queen-attack/QueenAttack.php
+++ b/exercises/practice/queen-attack/QueenAttack.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/queen-attack/QueenAttack.php
+++ b/exercises/practice/queen-attack/QueenAttack.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function placeQueen(int $xCoordinate, int $yCoordinate): bool
 {
     throw new \BadFunctionCallException("Implement the placeQueen function");

--- a/exercises/practice/queen-attack/QueenAttackTest.php
+++ b/exercises/practice/queen-attack/QueenAttackTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/queen-attack/QueenAttackTest.php
+++ b/exercises/practice/queen-attack/QueenAttackTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class QueenAttackTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/queen-attack/QueenAttackTest.php
+++ b/exercises/practice/queen-attack/QueenAttackTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/queen-attack/QueenAttackTest.php
+++ b/exercises/practice/queen-attack/QueenAttackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class QueenAttackTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/rail-fence-cipher/.meta/example.php
+++ b/exercises/practice/rail-fence-cipher/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/rail-fence-cipher/.meta/example.php
+++ b/exercises/practice/rail-fence-cipher/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode($plainMessage, $rails)
 {
     $cipherMessage = [];
@@ -24,7 +26,7 @@ function decode($cipherMessage, $rails)
     $position = ($rails * 2) - 2;
     $textLength = strlen($cipherMessage);
 
-    $minLength = floor($textLength / $position);
+    $minLength = (int) floor($textLength / $position);
     $balance = $textLength % $position;
     $lengths = [];
     $strings = [];

--- a/exercises/practice/rail-fence-cipher/.meta/example.php
+++ b/exercises/practice/rail-fence-cipher/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode($plainMessage, $rails)

--- a/exercises/practice/rail-fence-cipher/.meta/example.php
+++ b/exercises/practice/rail-fence-cipher/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/rail-fence-cipher/RailFenceCipher.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipher.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/rail-fence-cipher/RailFenceCipher.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipher.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/rail-fence-cipher/RailFenceCipher.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipher.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode(string $plainMessage, int $rails): string

--- a/exercises/practice/rail-fence-cipher/RailFenceCipher.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode(string $plainMessage, int $rails): string
 {
     throw new \BadFunctionCallException("Implement the encode function");

--- a/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RailFenceCipherTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RailFenceCipherTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/raindrops/.meta/example.php
+++ b/exercises/practice/raindrops/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/raindrops/.meta/example.php
+++ b/exercises/practice/raindrops/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function raindrops($num)
 {
     $sound =

--- a/exercises/practice/raindrops/.meta/example.php
+++ b/exercises/practice/raindrops/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/raindrops/.meta/example.php
+++ b/exercises/practice/raindrops/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function raindrops($num)

--- a/exercises/practice/raindrops/Raindrops.php
+++ b/exercises/practice/raindrops/Raindrops.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function raindrops(int $number): string

--- a/exercises/practice/raindrops/Raindrops.php
+++ b/exercises/practice/raindrops/Raindrops.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/raindrops/Raindrops.php
+++ b/exercises/practice/raindrops/Raindrops.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function raindrops(int $number): string
 {
     throw new \BadFunctionCallException("Implement the raindrops function");

--- a/exercises/practice/raindrops/Raindrops.php
+++ b/exercises/practice/raindrops/Raindrops.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/raindrops/RaindropsTest.php
+++ b/exercises/practice/raindrops/RaindropsTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/raindrops/RaindropsTest.php
+++ b/exercises/practice/raindrops/RaindropsTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RaindropsTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/raindrops/RaindropsTest.php
+++ b/exercises/practice/raindrops/RaindropsTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/raindrops/RaindropsTest.php
+++ b/exercises/practice/raindrops/RaindropsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RaindropsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/rna-transcription/.meta/example.php
+++ b/exercises/practice/rna-transcription/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toRna($strand)

--- a/exercises/practice/rna-transcription/.meta/example.php
+++ b/exercises/practice/rna-transcription/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/rna-transcription/.meta/example.php
+++ b/exercises/practice/rna-transcription/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/rna-transcription/.meta/example.php
+++ b/exercises/practice/rna-transcription/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toRna($strand)
 {
     return strtr($strand, 'CGTA', 'GCAU');

--- a/exercises/practice/rna-transcription/RnaTranscription.php
+++ b/exercises/practice/rna-transcription/RnaTranscription.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/rna-transcription/RnaTranscription.php
+++ b/exercises/practice/rna-transcription/RnaTranscription.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toRna(string $dna): string

--- a/exercises/practice/rna-transcription/RnaTranscription.php
+++ b/exercises/practice/rna-transcription/RnaTranscription.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/rna-transcription/RnaTranscription.php
+++ b/exercises/practice/rna-transcription/RnaTranscription.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toRna(string $dna): string
 {
     throw new \BadFunctionCallException("Implement the toRna function");

--- a/exercises/practice/rna-transcription/RnaTranscriptionTest.php
+++ b/exercises/practice/rna-transcription/RnaTranscriptionTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/rna-transcription/RnaTranscriptionTest.php
+++ b/exercises/practice/rna-transcription/RnaTranscriptionTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RnaTranscriptionTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/rna-transcription/RnaTranscriptionTest.php
+++ b/exercises/practice/rna-transcription/RnaTranscriptionTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/rna-transcription/RnaTranscriptionTest.php
+++ b/exercises/practice/rna-transcription/RnaTranscriptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/robot-name/.meta/example.php
+++ b/exercises/practice/robot-name/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Robot
 {
     private $name;

--- a/exercises/practice/robot-name/.meta/example.php
+++ b/exercises/practice/robot-name/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/robot-name/.meta/example.php
+++ b/exercises/practice/robot-name/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/robot-name/.meta/example.php
+++ b/exercises/practice/robot-name/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Robot

--- a/exercises/practice/robot-name/RobotName.php
+++ b/exercises/practice/robot-name/RobotName.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/robot-name/RobotName.php
+++ b/exercises/practice/robot-name/RobotName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Robot
 {
     public function getName(): string

--- a/exercises/practice/robot-name/RobotName.php
+++ b/exercises/practice/robot-name/RobotName.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/robot-name/RobotName.php
+++ b/exercises/practice/robot-name/RobotName.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Robot

--- a/exercises/practice/robot-name/RobotNameTest.php
+++ b/exercises/practice/robot-name/RobotNameTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/robot-name/RobotNameTest.php
+++ b/exercises/practice/robot-name/RobotNameTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/robot-name/RobotNameTest.php
+++ b/exercises/practice/robot-name/RobotNameTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RobotNameTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/robot-name/RobotNameTest.php
+++ b/exercises/practice/robot-name/RobotNameTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RobotNameTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Robot
 {
     public const DIRECTION_NORTH = 'north';

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Robot

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Robot
 {
     /**

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Robot

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RobotSimulatorTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/roman-numerals/.meta/example.php
+++ b/exercises/practice/roman-numerals/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/roman-numerals/.meta/example.php
+++ b/exercises/practice/roman-numerals/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/roman-numerals/.meta/example.php
+++ b/exercises/practice/roman-numerals/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toRoman($number)

--- a/exercises/practice/roman-numerals/.meta/example.php
+++ b/exercises/practice/roman-numerals/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toRoman($number)
 {
     $mapping = [

--- a/exercises/practice/roman-numerals/RomanNumerals.php
+++ b/exercises/practice/roman-numerals/RomanNumerals.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/roman-numerals/RomanNumerals.php
+++ b/exercises/practice/roman-numerals/RomanNumerals.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toRoman(int $number): string

--- a/exercises/practice/roman-numerals/RomanNumerals.php
+++ b/exercises/practice/roman-numerals/RomanNumerals.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/roman-numerals/RomanNumerals.php
+++ b/exercises/practice/roman-numerals/RomanNumerals.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toRoman(int $number): string
 {
     throw new \BadFunctionCallException("Implement the toRoman function");

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RomanNumeralsTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/run-length-encoding/.meta/example.php
+++ b/exercises/practice/run-length-encoding/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/run-length-encoding/.meta/example.php
+++ b/exercises/practice/run-length-encoding/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/run-length-encoding/.meta/example.php
+++ b/exercises/practice/run-length-encoding/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @param string $input
  * @return string

--- a/exercises/practice/run-length-encoding/.meta/example.php
+++ b/exercises/practice/run-length-encoding/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/run-length-encoding/RunLengthEncoding.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncoding.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function encode(string $input): string
 {
     throw new \BadFunctionCallException("Implement the encode function");

--- a/exercises/practice/run-length-encoding/RunLengthEncoding.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncoding.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/run-length-encoding/RunLengthEncoding.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncoding.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function encode(string $input): string

--- a/exercises/practice/run-length-encoding/RunLengthEncoding.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncoding.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class RunLengthEncodingTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/scrabble-score/.meta/example.php
+++ b/exercises/practice/scrabble-score/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/scrabble-score/.meta/example.php
+++ b/exercises/practice/scrabble-score/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function score($word)

--- a/exercises/practice/scrabble-score/.meta/example.php
+++ b/exercises/practice/scrabble-score/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/scrabble-score/.meta/example.php
+++ b/exercises/practice/scrabble-score/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function score($word)
 {
     if (strlen($word) === 0 || $word === ' ') {

--- a/exercises/practice/scrabble-score/ScrabbleScore.php
+++ b/exercises/practice/scrabble-score/ScrabbleScore.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/scrabble-score/ScrabbleScore.php
+++ b/exercises/practice/scrabble-score/ScrabbleScore.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function score(string $word): int

--- a/exercises/practice/scrabble-score/ScrabbleScore.php
+++ b/exercises/practice/scrabble-score/ScrabbleScore.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/scrabble-score/ScrabbleScore.php
+++ b/exercises/practice/scrabble-score/ScrabbleScore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function score(string $word): int
 {
     throw new \BadFunctionCallException("Implement the score function");

--- a/exercises/practice/scrabble-score/ScrabbleScoreTest.php
+++ b/exercises/practice/scrabble-score/ScrabbleScoreTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/scrabble-score/ScrabbleScoreTest.php
+++ b/exercises/practice/scrabble-score/ScrabbleScoreTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/scrabble-score/ScrabbleScoreTest.php
+++ b/exercises/practice/scrabble-score/ScrabbleScoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Calculate the value of scrabble score for a given word.
  */

--- a/exercises/practice/scrabble-score/ScrabbleScoreTest.php
+++ b/exercises/practice/scrabble-score/ScrabbleScoreTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/series/.meta/example.php
+++ b/exercises/practice/series/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/series/.meta/example.php
+++ b/exercises/practice/series/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function slices($series, $size)

--- a/exercises/practice/series/.meta/example.php
+++ b/exercises/practice/series/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function slices($series, $size)
 {
     if ($size > strlen($series) || $size < 1) {

--- a/exercises/practice/series/.meta/example.php
+++ b/exercises/practice/series/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/series/Series.php
+++ b/exercises/practice/series/Series.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/series/Series.php
+++ b/exercises/practice/series/Series.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/series/Series.php
+++ b/exercises/practice/series/Series.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function slices(string $digits, int $series): array
 {
     throw new \BadFunctionCallException("Implement the slices function");

--- a/exercises/practice/series/Series.php
+++ b/exercises/practice/series/Series.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function slices(string $digits, int $series): array

--- a/exercises/practice/series/SeriesTest.php
+++ b/exercises/practice/series/SeriesTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/series/SeriesTest.php
+++ b/exercises/practice/series/SeriesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SeriesTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/series/SeriesTest.php
+++ b/exercises/practice/series/SeriesTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/series/SeriesTest.php
+++ b/exercises/practice/series/SeriesTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class SeriesTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/sieve/.meta/example.php
+++ b/exercises/practice/sieve/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/sieve/.meta/example.php
+++ b/exercises/practice/sieve/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function sieve($number)

--- a/exercises/practice/sieve/.meta/example.php
+++ b/exercises/practice/sieve/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/sieve/.meta/example.php
+++ b/exercises/practice/sieve/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function sieve($number)
 {
     if ($number == 1) {

--- a/exercises/practice/sieve/Sieve.php
+++ b/exercises/practice/sieve/Sieve.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function sieve(int $number): array
 {
     throw new \BadFunctionCallException("Implement the sieve function");

--- a/exercises/practice/sieve/Sieve.php
+++ b/exercises/practice/sieve/Sieve.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/sieve/Sieve.php
+++ b/exercises/practice/sieve/Sieve.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/sieve/Sieve.php
+++ b/exercises/practice/sieve/Sieve.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function sieve(int $number): array

--- a/exercises/practice/sieve/SieveTest.php
+++ b/exercises/practice/sieve/SieveTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/sieve/SieveTest.php
+++ b/exercises/practice/sieve/SieveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SieveTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/sieve/SieveTest.php
+++ b/exercises/practice/sieve/SieveTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/sieve/SieveTest.php
+++ b/exercises/practice/sieve/SieveTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class SieveTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/space-age/.meta/example.php
+++ b/exercises/practice/space-age/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SpaceAge
 {
     public $seconds;

--- a/exercises/practice/space-age/.meta/example.php
+++ b/exercises/practice/space-age/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/space-age/.meta/example.php
+++ b/exercises/practice/space-age/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class SpaceAge

--- a/exercises/practice/space-age/.meta/example.php
+++ b/exercises/practice/space-age/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/space-age/SpaceAge.php
+++ b/exercises/practice/space-age/SpaceAge.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/space-age/SpaceAge.php
+++ b/exercises/practice/space-age/SpaceAge.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class SpaceAge

--- a/exercises/practice/space-age/SpaceAge.php
+++ b/exercises/practice/space-age/SpaceAge.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/space-age/SpaceAge.php
+++ b/exercises/practice/space-age/SpaceAge.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SpaceAge
 {
     public function __construct(int $seconds)

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class SpaceAgeTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SpaceAgeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/sum-of-multiples/.meta/example.php
+++ b/exercises/practice/sum-of-multiples/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/sum-of-multiples/.meta/example.php
+++ b/exercises/practice/sum-of-multiples/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function sumOfMultiples($number, $multiples)
 {
     $numbers = [];

--- a/exercises/practice/sum-of-multiples/.meta/example.php
+++ b/exercises/practice/sum-of-multiples/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function sumOfMultiples($number, $multiples)

--- a/exercises/practice/sum-of-multiples/.meta/example.php
+++ b/exercises/practice/sum-of-multiples/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function sumOfMultiples(int $number, array $multiples): int

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function sumOfMultiples(int $number, array $multiples): int
 {
     throw new \BadFunctionCallException("Implement the sumOfMultiples function");

--- a/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SumOfMultiplesTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class SumOfMultiplesTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/transpose/.meta/example.php
+++ b/exercises/practice/transpose/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/transpose/.meta/example.php
+++ b/exercises/practice/transpose/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Transpose multi line text into Rows become columns and columns become rows.
  * Eg: http://en.wikipedia.org/wiki/Transpose

--- a/exercises/practice/transpose/.meta/example.php
+++ b/exercises/practice/transpose/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/transpose/.meta/example.php
+++ b/exercises/practice/transpose/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/transpose/Transpose.php
+++ b/exercises/practice/transpose/Transpose.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/transpose/Transpose.php
+++ b/exercises/practice/transpose/Transpose.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function transpose(array $input): array
 {
     throw new \BadFunctionCallException("Implement the transpose function");

--- a/exercises/practice/transpose/Transpose.php
+++ b/exercises/practice/transpose/Transpose.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function transpose(array $input): array

--- a/exercises/practice/transpose/Transpose.php
+++ b/exercises/practice/transpose/Transpose.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/transpose/TransposeTest.php
+++ b/exercises/practice/transpose/TransposeTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/transpose/TransposeTest.php
+++ b/exercises/practice/transpose/TransposeTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class TransposeTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/transpose/TransposeTest.php
+++ b/exercises/practice/transpose/TransposeTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/transpose/TransposeTest.php
+++ b/exercises/practice/transpose/TransposeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TransposeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/triangle/.meta/example.php
+++ b/exercises/practice/triangle/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/triangle/.meta/example.php
+++ b/exercises/practice/triangle/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/triangle/.meta/example.php
+++ b/exercises/practice/triangle/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Triangle
 {
     protected $sideA;

--- a/exercises/practice/triangle/.meta/example.php
+++ b/exercises/practice/triangle/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Triangle

--- a/exercises/practice/triangle/Triangle.php
+++ b/exercises/practice/triangle/Triangle.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/triangle/Triangle.php
+++ b/exercises/practice/triangle/Triangle.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/triangle/Triangle.php
+++ b/exercises/practice/triangle/Triangle.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class Triangle

--- a/exercises/practice/triangle/Triangle.php
+++ b/exercises/practice/triangle/Triangle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Triangle
 {
     public function __construct(int $a, int $b, int $c)

--- a/exercises/practice/triangle/TriangleTest.php
+++ b/exercises/practice/triangle/TriangleTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/triangle/TriangleTest.php
+++ b/exercises/practice/triangle/TriangleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TriangleTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/triangle/TriangleTest.php
+++ b/exercises/practice/triangle/TriangleTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class TriangleTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/triangle/TriangleTest.php
+++ b/exercises/practice/triangle/TriangleTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/trinary/.meta/example.php
+++ b/exercises/practice/trinary/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/trinary/.meta/example.php
+++ b/exercises/practice/trinary/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toDecimal($ternaryString, $base = 3)
 {
     if (!preg_match('/^[0-2]+$/', $ternaryString)) {

--- a/exercises/practice/trinary/.meta/example.php
+++ b/exercises/practice/trinary/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/trinary/.meta/example.php
+++ b/exercises/practice/trinary/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toDecimal($ternaryString, $base = 3)

--- a/exercises/practice/trinary/Trinary.php
+++ b/exercises/practice/trinary/Trinary.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/trinary/Trinary.php
+++ b/exercises/practice/trinary/Trinary.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/trinary/Trinary.php
+++ b/exercises/practice/trinary/Trinary.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function toDecimal(string $number): int

--- a/exercises/practice/trinary/Trinary.php
+++ b/exercises/practice/trinary/Trinary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function toDecimal(string $number): int
 {
     throw new \BadFunctionCallException("Implement the toDecimal function");

--- a/exercises/practice/trinary/TrinaryTest.php
+++ b/exercises/practice/trinary/TrinaryTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class TrinaryTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/trinary/TrinaryTest.php
+++ b/exercises/practice/trinary/TrinaryTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/trinary/TrinaryTest.php
+++ b/exercises/practice/trinary/TrinaryTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/trinary/TrinaryTest.php
+++ b/exercises/practice/trinary/TrinaryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TrinaryTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/two-fer/.meta/example.php
+++ b/exercises/practice/two-fer/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/two-fer/.meta/example.php
+++ b/exercises/practice/two-fer/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/two-fer/.meta/example.php
+++ b/exercises/practice/two-fer/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function twoFer(string $name = 'you'): string
 {
     return "One for $name, one for me.";

--- a/exercises/practice/two-fer/.meta/example.php
+++ b/exercises/practice/two-fer/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function twoFer(string $name = 'you'): string

--- a/exercises/practice/two-fer/TwoFer.php
+++ b/exercises/practice/two-fer/TwoFer.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function twoFer(string $name): string

--- a/exercises/practice/two-fer/TwoFer.php
+++ b/exercises/practice/two-fer/TwoFer.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/two-fer/TwoFer.php
+++ b/exercises/practice/two-fer/TwoFer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function twoFer(string $name): string
 {
     throw new \BadFunctionCallException("Implement the twoFer function");

--- a/exercises/practice/two-fer/TwoFer.php
+++ b/exercises/practice/two-fer/TwoFer.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/two-fer/TwoFerTest.php
+++ b/exercises/practice/two-fer/TwoFerTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/two-fer/TwoFerTest.php
+++ b/exercises/practice/two-fer/TwoFerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TwoFerTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/two-fer/TwoFerTest.php
+++ b/exercises/practice/two-fer/TwoFerTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/two-fer/TwoFerTest.php
+++ b/exercises/practice/two-fer/TwoFerTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class TwoFerTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/variable-length-quantity/.meta/example.php
+++ b/exercises/practice/variable-length-quantity/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/variable-length-quantity/.meta/example.php
+++ b/exercises/practice/variable-length-quantity/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/variable-length-quantity/.meta/example.php
+++ b/exercises/practice/variable-length-quantity/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/variable-length-quantity/.meta/example.php
+++ b/exercises/practice/variable-length-quantity/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @param array $integers
  * @return array

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function vlq_encode(array $input): array

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function vlq_encode(array $input): array
 {
     throw new \BadFunctionCallException("Implement the vlq_encode function");

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/word-count/.meta/example.php
+++ b/exercises/practice/word-count/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/word-count/.meta/example.php
+++ b/exercises/practice/word-count/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function wordCount($phrase)
 {
     $count = [];

--- a/exercises/practice/word-count/.meta/example.php
+++ b/exercises/practice/word-count/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function wordCount($phrase)

--- a/exercises/practice/word-count/.meta/example.php
+++ b/exercises/practice/word-count/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/word-count/WordCount.php
+++ b/exercises/practice/word-count/WordCount.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/word-count/WordCount.php
+++ b/exercises/practice/word-count/WordCount.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function wordCount(string $words): array

--- a/exercises/practice/word-count/WordCount.php
+++ b/exercises/practice/word-count/WordCount.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function wordCount(string $words): array
 {
     throw new \BadFunctionCallException("Implement the wordCount function");

--- a/exercises/practice/word-count/WordCount.php
+++ b/exercises/practice/word-count/WordCount.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/word-count/WordCountTest.php
+++ b/exercises/practice/word-count/WordCountTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class WordCountTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/word-count/WordCountTest.php
+++ b/exercises/practice/word-count/WordCountTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/word-count/WordCountTest.php
+++ b/exercises/practice/word-count/WordCountTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class WordCountTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/word-count/WordCountTest.php
+++ b/exercises/practice/word-count/WordCountTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/wordy/.meta/example.php
+++ b/exercises/practice/wordy/.meta/example.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/wordy/.meta/example.php
+++ b/exercises/practice/wordy/.meta/example.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function calculate($question = "")

--- a/exercises/practice/wordy/.meta/example.php
+++ b/exercises/practice/wordy/.meta/example.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function calculate($question = "")
 {
     preg_match(

--- a/exercises/practice/wordy/.meta/example.php
+++ b/exercises/practice/wordy/.meta/example.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/wordy/Wordy.php
+++ b/exercises/practice/wordy/Wordy.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/wordy/Wordy.php
+++ b/exercises/practice/wordy/Wordy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 function calculate(string $input): int
 {
     throw new \BadFunctionCallException("Implement the calculate function");

--- a/exercises/practice/wordy/Wordy.php
+++ b/exercises/practice/wordy/Wordy.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/wordy/Wordy.php
+++ b/exercises/practice/wordy/Wordy.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 function calculate(string $input): int

--- a/exercises/practice/wordy/WordyTest.php
+++ b/exercises/practice/wordy/WordyTest.php
@@ -3,13 +3,14 @@
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/exercises/practice/wordy/WordyTest.php
+++ b/exercises/practice/wordy/WordyTest.php
@@ -1,18 +1,24 @@
 <?php
 
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 

--- a/exercises/practice/wordy/WordyTest.php
+++ b/exercises/practice/wordy/WordyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class WordyTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/wordy/WordyTest.php
+++ b/exercises/practice/wordy/WordyTest.php
@@ -1,5 +1,20 @@
 <?php
 
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+
 declare(strict_types=1);
 
 class WordyTest extends PHPUnit\Framework\TestCase

--- a/phpcs-php.xml
+++ b/phpcs-php.xml
@@ -8,4 +8,5 @@
     <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
     <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
   </rule>
+  <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php" />
 </ruleset>

--- a/phpcs-php.xml
+++ b/phpcs-php.xml
@@ -10,8 +10,9 @@
   </rule>
   <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php">
     <properties>
-      <property name="newlinesCountBetweenOpenTagAndDeclare" type="int" value="2" />
+      <property name="newlinesCountBetweenOpenTagAndDeclare" type="int" value="1" />
       <property name="spacesCountAroundEqualsSign" type="int" value="0" />
     </properties>
   </rule>
+  <rule ref="src/Sniffs/ExplainStrictTypesSniff.php"/>
 </ruleset>

--- a/phpcs-php.xml
+++ b/phpcs-php.xml
@@ -8,5 +8,10 @@
     <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
     <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
   </rule>
-  <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php" />
+  <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php">
+    <properties>
+      <property name="newlinesCountBetweenOpenTagAndDeclare" type="int" value="2" />
+      <property name="spacesCountAroundEqualsSign" type="int" value="0" />
+    </properties>
+  </rule>
 </ruleset>

--- a/src/Sniffs/ExplainStrictTypesSniff.php
+++ b/src/Sniffs/ExplainStrictTypesSniff.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Exercism\Php\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Fixer;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ExplainStrictTypesSniff implements Sniff
+{
+    private static string $explanation = <<<EOT
+/*
+ * By adding type hints and enabling strict type checking, code can become easier to read,
+ * self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict,
+ * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ * To enable strict mode, a single declare directive must be placed at the top of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To disable strict typing, comment out the directive below.
+ */
+EOT;
+
+    private ?Fixer $fixer = null;
+    private int $position = 0;
+
+    private array $tokens = [
+        T_COMMENT,
+    ];
+
+    public function register(): array
+    {
+        return [
+            T_DECLARE,
+        ];
+    }
+
+    public function process(File $file, $stackPtr)
+    {
+        $this->fixer = $file->fixer;
+        $this->position = $stackPtr;
+
+        if (!$file->findPrevious($this->tokens, $stackPtr)) {
+            $file->addFixableError(
+                'Missing explanation of declaration of strict types.',
+                $stackPtr - 1,
+                self::class
+            );
+            $this->fix();
+        }
+    }
+
+    private function fix(): void
+    {
+        $this->fixer->addContent($this->position - 1, self::$explanation);
+    }
+}

--- a/src/Sniffs/ExplainStrictTypesSniff.php
+++ b/src/Sniffs/ExplainStrictTypesSniff.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Exercism\Php\Sniffs;
+namespace Exercism\Sniffs;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Fixer;
@@ -14,13 +14,14 @@ class ExplainStrictTypesSniff implements Sniff
 /*
  * By adding type hints and enabling strict type checking, code can become easier to read,
  * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict,
- * which means they will attempt to change the original type to match the type specified by the type-declaration.
+ * By default, type declarations are non-strict, which means they will attempt to
+ * change the original type to match the type specified by the type-declaration.
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
  * To enable strict mode, a single declare directive must be placed at the top of the file.
  * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's return type.
+ * This directive not only affects the type declarations of parameters, but also a function's
+ * return type.
  *
  * For more info review the Concept on strict type checking in the PHP track <link>.
  * To disable strict typing, comment out the directive below.

--- a/src/Sniffs/ExplainStrictTypesSniff.php
+++ b/src/Sniffs/ExplainStrictTypesSniff.php
@@ -12,18 +12,24 @@ class ExplainStrictTypesSniff implements Sniff
 {
     private static string $explanation = <<<EOT
 /*
- * By adding type hints and enabling strict type checking, code can become easier to read,
- * self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt to
- * change the original type to match the type specified by the type-declaration.
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
  * In other words, if you pass a string to a function requiring a float,
  * it will attempt to convert the string value to a float.
- * To enable strict mode, a single declare directive must be placed at the top of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also a function's
- * return type.
  *
- * For more info review the Concept on strict type checking in the PHP track <link>.
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
  * To disable strict typing, comment out the directive below.
  */
 EOT;


### PR DESCRIPTION
Resolve #352 

This PR adds `declare(strict_types=1)` to all php files and an explanation what it means.

The sentences of the explanation are sometimes a bit long to match the 120 chars limit that is enforces with the PSR-2 standard. I therefore made some line breaks to meet this requirement.

## Changes

### Rule to enfore strict types

An additional phpcs rule enforces a proper declaration of strict types for each file. The rule [`SlevomatCodingStandard.TypeHints.DeclareStrictTypes`](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintsdeclarestricttypes-) from [`slevomat/coding-standards`](https://github.com/slevomat/coding-standard) takes care of this.

### Rule to enforce explanation of strict type

I've added a custom phpcs rule, that takes care of the explanation. I think this will make it easier to apply coding standards in the future.

### Using composer for lint check

To properly include the custom rules, [composer](https://getcomposer.org/) is used to run the check in Github actions. 

### Specifying php version

To properly specify the version used to CI action, the key `php-version` needs to be used, instead of `version`. See [`shivammathur/setup-php`](https://github.com/shivammathur/setup-php)