### PR TITLE
Add Poker exercise to PHP Track.

### DIFF
--- a/config.json
+++ b/config.json
@@ -802,6 +802,19 @@
         ]
       },
       {
+        "slug": "poker",
+        "name": "Poker",
+        "uuid": "e8669c8e-bfdd-4207-baf6-23c2e4b12d13",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "games",
+          "parsing",
+          "sorting"
+        ]
+      },
+      {
         "slug": "palindrome-products",
         "name": "Palindrome Products",
         "uuid": "3201ddeb-9046-4801-a31a-28c292686e1e",

--- a/exercises/practice/poker/.docs/instructions.md
+++ b/exercises/practice/poker/.docs/instructions.md
@@ -1,0 +1,5 @@
+# Instructions
+
+Pick the best hand(s) from a list of poker hands.
+
+See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an overview of poker hands.

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "Pick the best hand(s) from a list of poker hands.",
+  "authors": ["MichaelBunker"],
+  "contributors": [],
+  "files": {
+    "solution": ["Poker.php"],
+    "test": ["PokerTest.php"],
+    "example": [".meta/example.php"]
+  }
+}

--- a/exercises/practice/poker/.meta/example.php
+++ b/exercises/practice/poker/.meta/example.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+class Poker
+{
+    public array $bestHands = [];
+    // The '..' prefix for card ranks allows for matching index -> value increasing readability.
+    public const CARD_RANKS = '..23456789TJQKA';
+    public const CARD_SUITS = 'HSDC';
+
+    public function __construct(array $hands)
+    {
+        $this->bestHands = $this->calculateBestHands($hands);
+    }
+
+    private function calculateBestHands(array $hands): array
+    {
+        $bestHands   = [];
+        $parsedHands = [];
+
+        foreach ($hands as $handData) {
+            $parsedHands[] = $this->parseHand($handData);
+        }
+
+        $highestScore       = max(array_map(fn(Hand $hand): int => $hand->result->score, $parsedHands));
+        $handsWithHighScore = array_filter($parsedHands, fn(Hand $hand): bool => $hand->result->score == $highestScore);
+
+        if (count($handsWithHighScore) === 1) {
+            $bestHands[] = current($handsWithHighScore)->input;
+
+            return $bestHands;
+        }
+
+        $highestTieBreaks       = max(array_map(fn(Hand $hand): int => $hand->result->tiebreakScore, $parsedHands));
+        $handsWithHighTiebreaks = array_filter(
+            $parsedHands,
+            fn(Hand $hand): bool =>
+                $hand->result->tiebreakScore == $highestTieBreaks &&
+                $hand->result->score === $highestScore
+        );
+
+        foreach ($handsWithHighTiebreaks as $winningHands) {
+            $bestHands[] = $winningHands->input;
+        }
+
+        return $bestHands;
+    }
+
+    private function parseHand(string $handData): Hand
+    {
+        $parsedCards = $this->parseCards($handData);
+        $score       = $this->scoreHand($parsedCards);
+
+        return new Hand($handData, $score);
+    }
+
+    private function parseCards(string $handData): array
+    {
+        $normalizedHand = str_replace('10', 'T', $handData);
+        $cards          = explode(',', $normalizedHand);
+        $hand           = [];
+
+        foreach ($cards as $cardData) {
+            $card = $this->parseCard($cardData);
+            $hand[] = $card;
+        }
+        //Sort Hands by Card rank.
+        usort($hand, fn(Card $current, Card $next) => ($current->rank <=> $next->rank));
+
+        return $hand;
+    }
+
+    private function parseCard(string $cardData): Card
+    {
+        $cardRank = strpos(self::CARD_RANKS, $cardData[0]);
+        $cardSuit = strpos(self::CARD_SUITS, $cardData[1]);
+
+        return new Card($cardRank, $cardSuit);
+    }
+
+    private function scoreHand(array $cards): Score
+    {
+        $ranks = [];
+        $suits = [];
+        foreach ($cards as $card) {
+            $ranks[] = $card->rank;
+            $suits[] = $card->suit;
+        }
+
+        $rankValues  = array_count_values($ranks);
+        $ranksByFreq = $rankValues;
+        sort($ranksByFreq);
+
+        $dualSortedCards = [];
+
+        foreach ($rankValues as $num => $rate) {
+            $dualSortedCards[] = ['rank' => $num, 'frequency' => $rate];
+        }
+
+        //Sort by card rank AND frequency they occur. If three ranks appear 2,2,1 times. The first two will appear first
+        //even if they are lower value than the card appearing only once.
+        $sortRank      = array_column($dualSortedCards, 'rank');
+        $sortFrequency = array_column($dualSortedCards, 'frequency');
+        array_multisort($sortFrequency, SORT_DESC, $sortRank, SORT_DESC, $dualSortedCards);
+
+        $cardsByRank = [];
+        foreach ($dualSortedCards as $sortedValue) {
+            $cardsByRank[] = $sortedValue['rank'];
+        }
+
+        //Normalize aces for low straights.
+        if ($this->isEqualHandRanks([14, 2, 3, 4, 5], $ranks)) {
+            $ranks = [5, 4, 3, 2, 1];
+        }
+
+        $isFlush    = count(array_unique($suits)) === 1;
+        $isStraight = (count(array_unique($ranks)) === 5 && max($ranks) - min($ranks) === 4);
+
+        if ($isStraight && $isFlush) {
+            return new Score(800 + current($ranks), 0);
+        }
+
+        if ($this->isEqualHandRanks($ranksByFreq, [4, 1])) {
+            return new Score(700 + $cardsByRank[0], $cardsByRank[1]);
+        }
+
+        if ($this->isEqualHandRanks($ranksByFreq, [3,2])) {
+            return new Score(600 + $cardsByRank[0], $cardsByRank[1]);
+        }
+
+        if ($isFlush) {
+            return new Score(500 + current($cardsByRank), 0);
+        }
+
+        if ($isStraight) {
+            return new Score(400 + current($cardsByRank), 0);
+        }
+
+        if ($this->isEqualHandRanks($ranksByFreq, [3,1,1])) {
+            return new Score(300 + $cardsByRank[0], $cardsByRank[1]);
+        }
+
+        if ($this->isEqualHandRanks($ranksByFreq, [2,2,1])) {
+            return new Score(200 + $cardsByRank[0] + $cardsByRank[1], $cardsByRank[2]);
+        }
+
+        if ($this->isEqualHandRanks($ranksByFreq, [2,1,1,1])) {
+            return new Score(100 + $cardsByRank[0], 0);
+        }
+
+        return new Score(max($ranks), $cardsByRank[4]);
+    }
+
+    private function isEqualHandRanks(array $handOne, array $handTwo): bool
+    {
+        //Ensures hands have the same number of cards and the values are the same even if in different orders.
+        return (count($handOne) == count($handTwo) && array_diff($handOne, $handTwo) == array_diff($handTwo, $handOne));
+    }
+}
+
+class Card
+{
+    public int $rank;
+    public int $suit;
+
+    public function __construct(int $rank, int $suit)
+    {
+        $this->rank = $rank;
+        $this->suit = $suit;
+    }
+}
+
+class Hand
+{
+    public string $input;
+    public Score $result;
+
+    public function __construct(string $input, Score $result)
+    {
+        $this->input  = $input;
+        $this->result = $result;
+    }
+}
+
+class Score
+{
+    public int $score;
+    public int $tiebreakScore = 0;
+
+    public function __construct(int $score, int $tiebreakScore)
+    {
+        $this->score         = $score;
+        $this->tiebreakScore = $tiebreakScore;
+    }
+}

--- a/exercises/practice/poker/Poker.php
+++ b/exercises/practice/poker/Poker.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+class Poker
+{
+    public array $bestHands = [];
+
+    public function __construct(array $hands)
+    {
+        throw new BadFunctionCallException("Please implement the Poker class!");
+    }
+}

--- a/exercises/practice/poker/PokerTest.php
+++ b/exercises/practice/poker/PokerTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+class PokerTest extends PHPUnit\Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once 'Poker.php';
+    }
+
+    public function testSingleHandAlwaysWins(): void
+    {
+        $hands = ['4S,5S,7H,8D,JC'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,5S,7H,8D,JC'], $game->bestHands);
+    }
+
+    public function testHighestCardOutOfAllHandsWins(): void
+    {
+        $hands = ['4D,5S,6S,8D,3C', '2S,4C,7S,9H,10H', '3S,4S,5D,6H,JH'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['3S,4S,5D,6H,JH'], $game->bestHands);
+    }
+
+    public function testHighCardTiesHaveMultipleWinners(): void
+    {
+        $hands = ['4D,5S,6S,8D,3C', '2S,4C,7S,9H,10H', '3S,4S,5D,6H,JH', '3H,4H,5C,6C,JD'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['3S,4S,5D,6H,JH', '3H,4H,5C,6C,JD'], $game->bestHands);
+    }
+
+    public function testMultipleHandsWithSameHighCardsNextHighestCardWins(): void
+    {
+        $hands = ['3S,5H,6S,8D,7H', '2S,5D,6D,8C,7S'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['3S,5H,6S,8D,7H'], $game->bestHands);
+    }
+
+    public function testOnePairBeatsHighCard(): void
+    {
+        $hands = ['4S,5H,6C,8D,KH', '2S,4H,6S,4D,JH'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['2S,4H,6S,4D,JH'], $game->bestHands);
+    }
+
+    public function testHighestPairWins(): void
+    {
+        $hands = ['4S,2H,6S,2D,JH', '2S,4H,6C,4D,JD'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['2S,4H,6C,4D,JD'], $game->bestHands);
+    }
+
+    public function testTwoPairBeatsOnePair(): void
+    {
+        $hands = ['2S,8H,6S,8D,JH', '4S,5H,4C,8C,5C'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,5H,4C,8C,5C'], $game->bestHands);
+    }
+
+    public function testHighestTwoPairWins(): void
+    {
+        $hands = ['2S,8H,2D,8D,3H', '4S,5H,4C,8S,5D'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['2S,8H,2D,8D,3H'], $game->bestHands);
+    }
+
+    public function testSameHighPairForTwoPairHigherSecondPairWins(): void
+    {
+        $hands = ['2S,QS,2C,QD,JH', 'JD,QH,JS,8D,QC'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['JD,QH,JS,8D,QC'], $game->bestHands);
+    }
+
+    public function testSameTwoPairsForTwoPairHighCardWins(): void
+    {
+        $hands = ['JD,QH,JS,8D,QC', 'JS,QS,JC,2D,QD'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['JD,QH,JS,8D,QC'], $game->bestHands);
+    }
+
+    public function testThreeOfAKindBeatsTwoPair(): void
+    {
+        $hands = ['2S,8H,2H,8D,JH', '4S,5H,4C,8S,4H'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,5H,4C,8S,4H'], $game->bestHands);
+    }
+
+    public function testHighestThreeOfAKindWins(): void
+    {
+        $hands = ['2S,2H,2C,8D,JH', '4S,AH,AS,8C,AD'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,AH,AS,8C,AD'], $game->bestHands);
+    }
+
+    public function testSameThreeOfAKindHighCardsWin(): void
+    {
+        $hands = ['4S,AH,AS,7C,AD', '4S,AH,AS,8C,AD'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,AH,AS,8C,AD'], $game->bestHands);
+    }
+
+    public function testStraightBeatsThreeOfAKind(): void
+    {
+        $hands = ['4S,5H,4C,8D,4H', '3S,4D,2S,6D,5C'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['3S,4D,2S,6D,5C'], $game->bestHands);
+    }
+
+    public function testAcesCanBeHighCardForAStraight(): void
+    {
+        $hands = ['4S,5H,4C,8D,4H', '10D,JH,QS,KD,AC'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['10D,JH,QS,KD,AC'], $game->bestHands);
+    }
+
+    public function testAcesCanBeLowCardForAStraight(): void
+    {
+        $hands = ['4S,5H,4C,8D,4H', '4D,AH,3S,2D,5C'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4D,AH,3S,2D,5C'], $game->bestHands);
+    }
+
+    public function testHigherStraightWins(): void
+    {
+        $hands = ['4S,6C,7S,8D,5H', '5S,7H,8S,9D,6H'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['5S,7H,8S,9D,6H'], $game->bestHands);
+    }
+
+    public function testFlushBeatsAStraight(): void
+    {
+        $hands = ['4C,6H,7D,8D,5H', '2S,4S,5S,6S,7S'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['2S,4S,5S,6S,7S'], $game->bestHands);
+    }
+
+    public function testHighestFlushWins(): void
+    {
+        $hands = ['4H,7H,8H,9H,6H', '2S,4S,5S,6S,7S'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4H,7H,8H,9H,6H'], $game->bestHands);
+    }
+
+    public function testFullHouseBeatsAFlush(): void
+    {
+        $hands = ['3H,6H,7H,8H,5H', '4S,5H,4C,5D,4H'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,5H,4C,5D,4H'], $game->bestHands);
+    }
+
+    public function testHigherTripletFullHouseWins(): void
+    {
+        $hands = ['4H,4S,4D,9S,9D', '5H,5S,5D,8S,8D'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['5H,5S,5D,8S,8D'], $game->bestHands);
+    }
+
+    public function testSameTripleFullHouseHighPairWins(): void
+    {
+        $hands = ['5H,5S,5D,9S,9D', '5H,5S,5D,8S,8D'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['5H,5S,5D,9S,9D'], $game->bestHands);
+    }
+
+    public function testFourOfAKindBeatsAFullHouse(): void
+    {
+        $hands = ['4S,5H,4D,5D,4H', '3S,3H,2S,3D,3C'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['3S,3H,2S,3D,3C'], $game->bestHands);
+    }
+
+    public function testHigherFourOfAKindWins(): void
+    {
+        $hands = ['2S,2H,2C,8D,2D', '4S,5H,5S,5D,5C'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['4S,5H,5S,5D,5C'], $game->bestHands);
+    }
+
+    public function testSameFourOfAKindHighCardWins(): void
+    {
+        $hands = ['3S,3H,2S,3D,3C', '3S,3H,4S,3D,3C'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['3S,3H,4S,3D,3C'], $game->bestHands);
+    }
+
+    public function testStraightFlushBeatsFourOfAKind(): void
+    {
+        $hands = ['4S,5H,5S,5D,5C', '7S,8S,9S,6S,10S'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['7S,8S,9S,6S,10S'], $game->bestHands);
+    }
+
+    public function testHigherStraightFlushWins(): void
+    {
+        $hands = ['4H,6H,7H,8H,5H', '5S,7S,8S,9S,6S'];
+        $game = new Poker($hands);
+
+        $this->assertEquals(['5S,7S,8S,9S,6S'], $game->bestHands);
+    }
+}


### PR DESCRIPTION
## This Pull Requests adds the Poker exercise to the PHP Track.

### A few important notes.

- The README is intentionally small because it matches the READMEs for this exercise from other tracks.
- The example solution is fairly long (200+ lines). I'm open to recommendations on trimming it down if possible since it's fairly large, However, I think it strikes the right balance between readability and succinctness given the challenge requirements.
- There are multiple classes in the example file. I personally tend to avoid having more than one class in a single file, but I don't know what this would do in the Exercism ecosystem if we had multiple files for an example. Having classes instead of stdClass objects helps readability AND I think including them in the single example file will help readability and simplicity for students/mentors if they end up referencing the example.


### Poker README
#### Instructions

Pick the best hand(s) from a list of poker hands.

See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an overview of poker hands.

