### PR TITLE
🤖 Remove empty `source` and `source_url` properties

### DIFF
--- a/exercises/practice/mask-credit-card/.meta/config.json
+++ b/exercises/practice/mask-credit-card/.meta/config.json
@@ -6,7 +6,5 @@
     "test": ["MaskCreditCardTest.php"],
     "example": [".meta/example.php"]
   },
-  "source": "",
-  "source_url": "",
   "blurb": "TODO: blurb for credit card"
 }

--- a/exercises/practice/ordinal-number/.meta/config.json
+++ b/exercises/practice/ordinal-number/.meta/config.json
@@ -17,6 +17,5 @@
       ".meta/example.php"
     ]
   },
-  "source": "",
   "source_url": "https://en.wikipedia.org/wiki/Ordinal_numeral"
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -7,6 +7,5 @@
     "test": ["RobotSimulatorTest.php"],
     "example": [".meta/example.php"]
   },
-  "source": "Inspired by an interview question at a famous company.",
-  "source_url": ""
+  "source": "Inspired by an interview question at a famous company."
 }


### PR DESCRIPTION
The track CI runs `configlet lint`, which currently exits with a
non-zero exit code if it sees an optional string key that has the value
of the empty string.

This PR therefore removes all such key/value pairs on the track -
they otherwise cause a failing CI check.


---

Tracking: https://github.com/exercism/v3-launch/issues/57
