### PR TITLE
Update tests and example to use actual newlines

### DIFF
--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -1,7 +1,7 @@
 {
   "blurb": "Tally the results of a small football competition.",
   "authors": ["MichaelBunker"],
-  "contributors": [],
+  "contributors": ["dstockto"],
   "files": {
     "solution": ["Tournament.php"],
     "test": ["TournamentTest.php"],

--- a/exercises/practice/tournament/.meta/example.php
+++ b/exercises/practice/tournament/.meta/example.php
@@ -26,13 +26,13 @@ declare(strict_types=1);
 
 class Tournament
 {
-    private string $header  = 'Team                           | MP |  W |  D |  L |  P\n';
-    private string $teamRow = '%s                               |  %d |  %d |  %d |  %d |  %d\n';
+    private string $header  = "Team                           | MP |  W |  D |  L |  P\n";
+    private string $teamRow = "%s                               |  %d |  %d |  %d |  %d |  %d\n";
 
     public function tally(string $scores): string
     {
         if (!$scores) {
-            return rtrim($this->header, '\n');
+            return rtrim($this->header, "\n");
         }
 
         $teamTotals = $this->calculateTournamentTotals($scores);
@@ -44,18 +44,15 @@ class Tournament
 
         $output = $this->formatResults($teamTotals);
 
-        return rtrim($output, '\n');
+        return rtrim($output, "\n");
     }
 
     private function calculateTournamentTotals(string $scores): array
     {
         $teamTotals = [];
 
-        foreach (explode('\n', $scores) as $match) {
-            $gameInfo = explode(';', $match);
-            $homeTeam = $gameInfo[0];
-            $awayTeam = $gameInfo[1];
-            $result   = $gameInfo[2];
+        foreach (explode("\n", $scores) as $match) {
+            [$homeTeam, $awayTeam, $result] = explode(';', $match);
 
             $teamTotals[$homeTeam] ??= $this->createTeamResult($homeTeam);
             $teamTotals[$awayTeam] ??= $this->createTeamResult($awayTeam);

--- a/exercises/practice/tournament/TournamentTest.php
+++ b/exercises/practice/tournament/TournamentTest.php
@@ -49,9 +49,9 @@ class TournamentTest extends PHPUnit\Framework\TestCase
     {
         $scores = 'Allegoric Alaskans;Blithering Badgers;win';
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n' .
-            'Blithering Badgers             |  1 |  0 |  0 |  1 |  0';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n" .
+            "Blithering Badgers             |  1 |  0 |  0 |  1 |  0";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
@@ -59,9 +59,9 @@ class TournamentTest extends PHPUnit\Framework\TestCase
     {
         $scores = 'Blithering Badgers;Allegoric Alaskans;loss';
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n' .
-            'Blithering Badgers             |  1 |  0 |  0 |  1 |  0';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3\n" .
+            "Blithering Badgers             |  1 |  0 |  0 |  1 |  0";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
@@ -69,9 +69,9 @@ class TournamentTest extends PHPUnit\Framework\TestCase
     {
         $scores = 'Blithering Badgers;Allegoric Alaskans;win';
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Blithering Badgers             |  1 |  1 |  0 |  0 |  3\n' .
-            'Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Blithering Badgers             |  1 |  1 |  0 |  0 |  3\n" .
+            "Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
@@ -79,99 +79,99 @@ class TournamentTest extends PHPUnit\Framework\TestCase
     {
         $scores = 'Allegoric Alaskans;Blithering Badgers;draw';
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1\n' .
-            'Blithering Badgers             |  1 |  0 |  1 |  0 |  1';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1\n" .
+            "Blithering Badgers             |  1 |  0 |  1 |  0 |  1";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
     public function testThereCanBeMultipleMatches(): void
     {
         $scores =
-            'Allegoric Alaskans;Blithering Badgers;win\n' .
-            'Allegoric Alaskans;Blithering Badgers;win';
+            "Allegoric Alaskans;Blithering Badgers;win\n" .
+            "Allegoric Alaskans;Blithering Badgers;win";
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n' .
-            'Blithering Badgers             |  2 |  0 |  0 |  2 |  0';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n" .
+            "Blithering Badgers             |  2 |  0 |  0 |  2 |  0";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
     public function testThereCanBeMoreThanOneWinner(): void
     {
         $scores =
-            'Allegoric Alaskans;Blithering Badgers;loss\n' .
-            'Allegoric Alaskans;Blithering Badgers;win';
+            "Allegoric Alaskans;Blithering Badgers;loss\n" .
+            "Allegoric Alaskans;Blithering Badgers;win";
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3\n' .
-            'Blithering Badgers             |  2 |  1 |  0 |  1 |  3';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3\n" .
+            "Blithering Badgers             |  2 |  1 |  0 |  1 |  3";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
     public function testThereCanBeMoreThanTwoTeams(): void
     {
         $scores =
-            'Allegoric Alaskans;Blithering Badgers;win\n' .
-            'Blithering Badgers;Courageous Californians;win\n' .
-            'Courageous Californians;Allegoric Alaskans;loss';
+            "Allegoric Alaskans;Blithering Badgers;win\n" .
+            "Blithering Badgers;Courageous Californians;win\n" .
+            "Courageous Californians;Allegoric Alaskans;loss";
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n' .
-            'Blithering Badgers             |  2 |  1 |  0 |  1 |  3\n' .
-            'Courageous Californians        |  2 |  0 |  0 |  2 |  0';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6\n" .
+            "Blithering Badgers             |  2 |  1 |  0 |  1 |  3\n" .
+            "Courageous Californians        |  2 |  0 |  0 |  2 |  0";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
     public function testStandardInput(): void
     {
         $scores =
-            'Allegoric Alaskans;Blithering Badgers;win\n' .
-            'Devastating Donkeys;Courageous Californians;draw\n' .
-            'Devastating Donkeys;Allegoric Alaskans;win\n' .
-            'Courageous Californians;Blithering Badgers;loss\n' .
-            'Blithering Badgers;Devastating Donkeys;loss\n' .
-            'Allegoric Alaskans;Courageous Californians;win';
+            "Allegoric Alaskans;Blithering Badgers;win\n" .
+            "Devastating Donkeys;Courageous Californians;draw\n" .
+            "Devastating Donkeys;Allegoric Alaskans;win\n" .
+            "Courageous Californians;Blithering Badgers;loss\n" .
+            "Blithering Badgers;Devastating Donkeys;loss\n" .
+            "Allegoric Alaskans;Courageous Californians;win";
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Devastating Donkeys            |  3 |  2 |  1 |  0 |  7\n' .
-            'Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6\n' .
-            'Blithering Badgers             |  3 |  1 |  0 |  2 |  3\n' .
-            'Courageous Californians        |  3 |  0 |  1 |  2 |  1';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Devastating Donkeys            |  3 |  2 |  1 |  0 |  7\n" .
+            "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6\n" .
+            "Blithering Badgers             |  3 |  1 |  0 |  2 |  3\n" .
+            "Courageous Californians        |  3 |  0 |  1 |  2 |  1";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
     public function testIncompleteCompetitionWhereNotAllGamesPlayed(): void
     {
         $scores =
-            'Allegoric Alaskans;Blithering Badgers;loss\n' .
-            'Devastating Donkeys;Allegoric Alaskans;loss\n' .
-            'Courageous Californians;Blithering Badgers;draw\n' .
-            'Allegoric Alaskans;Courageous Californians;win';
+            "Allegoric Alaskans;Blithering Badgers;loss\n" .
+            "Devastating Donkeys;Allegoric Alaskans;loss\n" .
+            "Courageous Californians;Blithering Badgers;draw\n" .
+            "Allegoric Alaskans;Courageous Californians;win";
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6\n' .
-            'Blithering Badgers             |  2 |  1 |  1 |  0 |  4\n' .
-            'Courageous Californians        |  2 |  0 |  1 |  1 |  1\n' .
-            'Devastating Donkeys            |  1 |  0 |  0 |  1 |  0';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6\n" .
+            "Blithering Badgers             |  2 |  1 |  1 |  0 |  4\n" .
+            "Courageous Californians        |  2 |  0 |  1 |  1 |  1\n" .
+            "Devastating Donkeys            |  1 |  0 |  0 |  1 |  0";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 
     public function testTiesSortedAlphabetically(): void
     {
         $scores =
-            'Courageous Californians;Devastating Donkeys;win\n' .
-            'Allegoric Alaskans;Blithering Badgers;win\n' .
-            'Devastating Donkeys;Allegoric Alaskans;loss\n' .
-            'Courageous Californians;Blithering Badgers;win\n' .
-            'Blithering Badgers;Devastating Donkeys;draw\n' .
-            'Allegoric Alaskans;Courageous Californians;draw';
+            "Courageous Californians;Devastating Donkeys;win\n" .
+            "Allegoric Alaskans;Blithering Badgers;win\n" .
+            "Devastating Donkeys;Allegoric Alaskans;loss\n" .
+            "Courageous Californians;Blithering Badgers;win\n" .
+            "Blithering Badgers;Devastating Donkeys;draw\n" .
+            "Allegoric Alaskans;Courageous Californians;draw";
         $expected =
-            'Team                           | MP |  W |  D |  L |  P\n' .
-            'Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7\n' .
-            'Courageous Californians        |  3 |  2 |  1 |  0 |  7\n' .
-            'Blithering Badgers             |  3 |  0 |  1 |  2 |  1\n' .
-            'Devastating Donkeys            |  3 |  0 |  1 |  2 |  1';
+            "Team                           | MP |  W |  D |  L |  P\n" .
+            "Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7\n" .
+            "Courageous Californians        |  3 |  2 |  1 |  0 |  7\n" .
+            "Blithering Badgers             |  3 |  0 |  1 |  2 |  1\n" .
+            "Devastating Donkeys            |  3 |  0 |  1 |  2 |  1";
         $this->assertEquals($expected, $this->tournament->tally($scores));
     }
 }


### PR DESCRIPTION
Single-quoted \n is just that character, so the actual
output was just a single long line. This will make the output
look more like the instructions say it should and reduce confusion
when implementing.