### PR TITLE
Mark new exercises as WIP so configlet can pass

### DIFF
--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -2,6 +2,7 @@
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "authors": ["MichaelBunker"],
   "contributors": [],
+  "status": "wip",
   "files": {
     "solution": ["Darts.php"],
     "test": ["DartsTest.php"],

--- a/exercises/practice/mask-credit-card/.meta/config.json
+++ b/exercises/practice/mask-credit-card/.meta/config.json
@@ -1,6 +1,7 @@
 {
   "authors": ["codedge"],
   "contributors": ["neenjaw"],
+  "status": "wip",
   "files": {
     "solution": ["MaskCreditCard.php"],
     "test": ["MaskCreditCardTest.php"],

--- a/exercises/practice/ordinal-number/.meta/config.json
+++ b/exercises/practice/ordinal-number/.meta/config.json
@@ -6,6 +6,7 @@
   "contributors": [
     "neenjaw"
   ],
+  "status": "wip",
   "files": {
     "solution": [
       "OrdinalNumber.php"

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -2,6 +2,7 @@
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
   "authors": ["camilopayan"],
   "contributors": ["0x647262"],
+  "status": "wip",
   "files": {
     "solution": ["ScaleGenerator.php"],
     "test": ["ScaleGeneratorTest.php"],


### PR DESCRIPTION
Tried working on #415 but got a bunch of failures about exercises that are not in the slugs array or marked as WIP. This marks those as WIP until they can be updated to be published exercises.