### PR TITLE
Updated Resistor Color Exercise 

### DIFF
--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -1,6 +1,17 @@
-# Resistor Color
+# Instructions
 
-Resistors have color coded bands, where each color maps to a number. The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
 
 These colors are encoded as follows:
 
@@ -14,6 +25,11 @@ These colors are encoded as follows:
 - Violet: 7
 - Grey: 8
 - White: 9
+
+The goal of this exercise is to create a way:
+
+- to look up the numerical value associated with a particular color band
+- to list the different band colors
 
 Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array: Better Be Right Or Your Great Big Values Go Wrong.
 

--- a/exercises/practice/resistor-color/ResistorColorTest.php
+++ b/exercises/practice/resistor-color/ResistorColorTest.php
@@ -31,21 +31,6 @@ class ResistorColorTest extends PHPUnit\Framework\TestCase
         require_once 'ResistorColor.php';
     }
 
-    public function testBlackColorCode(): void
-    {
-        $this->assertEquals(colorCode("black"), 0);
-    }
-
-    public function testOrangeColorCode(): void
-    {
-        $this->assertEquals(colorCode("orange"), 3);
-    }
-
-    public function testWhiteColorCode(): void
-    {
-        $this->assertEquals(colorCode("white"), 9);
-    }
-
     public function testColors(): void
     {
         $this->assertEquals(COLORS, [
@@ -60,5 +45,20 @@ class ResistorColorTest extends PHPUnit\Framework\TestCase
             "grey",
             "white"
         ]);
+    }
+
+    public function testBlackColorCode(): void
+    {
+        $this->assertEquals(colorCode("black"), 0);
+    }
+
+    public function testOrangeColorCode(): void
+    {
+        $this->assertEquals(colorCode("orange"), 3);
+    }
+
+    public function testWhiteColorCode(): void
+    {
+        $this->assertEquals(colorCode("white"), 9);
     }
 }


### PR DESCRIPTION
Resistor color exercise error [Issue #414](https://github.com/exercism/php/issues/414)

Although nothings wrong with the exercise itself, it was mentioned in the comments that the last test should be moved to the first position, to help the students with their solution. Also I updated the instructions file to match a more up to date version from the js track. 