### PR TITLE
Remove checking for the color array

### DIFF
--- a/exercises/practice/resistor-color/ResistorColorTest.php
+++ b/exercises/practice/resistor-color/ResistorColorTest.php
@@ -46,19 +46,4 @@ class ResistorColorTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(colorCode("white"), 9);
     }
 
-    public function testColors(): void
-    {
-        $this->assertEquals(COLORS, [
-            "black",
-            "brown",
-            "red",
-            "orange",
-            "yellow",
-            "green",
-            "blue",
-            "violet",
-            "grey",
-            "white"
-        ]);
-    }
 }


### PR DESCRIPTION
- i do not think that we need to check for the color array
- as in my solution, i defined the colour array inside the function itself

Here's a preview of my code:
```php

function colorCode(string $color): int
{
    $array = array(
"black" => 0,
"brown" => 1,
"red"=> 2,
"orange"=> 3,
"yellow"=> 4,
"green"=> 5,
"blue"=> 6,
"violet"=> 7,
"grey"=> 8,
"white"=> 9,
);
return $array[$color];
}
```