### PR TITLE
Update Installation OSX

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -32,7 +32,7 @@ For further instructions, read the manual on [Installation on Unix systems](http
 
 While PHP is often bundled with macOS, it is often outdated. We recommended installing php through [Homebrew](https://brew.sh/). You can install Homebrew following the instructions [here](https://brew.sh/#install).
 
-To confirm its installation try the following command, it should output Homebrew 3.2.x at the time of this writing.
+To confirm its installation try the following command, it should output Homebrew `3.2.x` at the time of this writing.
 ```bash
 $ brew --version 
 ```


### PR DESCRIPTION
[Issue #346](https://github.com/exercism/php/issues/346)

Removed deprecated installation methods, added more instructions for HomeBrew installation method. Showed how to run .php files via the command line. Made recommendations for installing composer, and recommend installing globally on a mac, to aid when trying to install php unit globally in the following instructions. 