### PR TITLE
Add blurb for masked-credit-card exercise

### DIFF
--- a/exercises/practice/mask-credit-card/.meta/config.json
+++ b/exercises/practice/mask-credit-card/.meta/config.json
@@ -6,5 +6,5 @@
     "test": ["MaskCreditCardTest.php"],
     "example": [".meta/example.php"]
   },
-  "blurb": "TODO: blurb for credit card"
+  "blurb": "Create a function to mask digits of a credit card number."
 }


### PR DESCRIPTION
This removes the TODO visible on the https://exercism.org/tracks/php/exercises listing