### PR TITLE
Update Isogram function name

### DIFF
--- a/exercises/practice/isogram/Isogram.php
+++ b/exercises/practice/isogram/Isogram.php
@@ -24,7 +24,7 @@
 
 declare(strict_types=1);
 
-function isogram(string $word): bool
+function isIsogram(string $word): bool
 {
     throw new \BadFunctionCallException("Implement the isogram function");
 }

--- a/exercises/practice/isogram/Isogram.php
+++ b/exercises/practice/isogram/Isogram.php
@@ -26,5 +26,5 @@ declare(strict_types=1);
 
 function isIsogram(string $word): bool
 {
-    throw new \BadFunctionCallException("Implement the isogram function");
+    throw new \BadFunctionCallException("Implement the isIsogram function");
 }


### PR DESCRIPTION
Unit test cases in [IsogramTest](https://github.com/exercism/php/blob/main/exercises/practice/isogram/IsogramTest.php) are looking for `isIsogram`  resulting in an undefined function error when running tests.

```
IsogramTest::testIsogram
Error: Call to undefined function isIsogram()

/mnt/exercism-iteration/IsogramTest.php:36
```