### PR TITLE
Update TrinaryTest.php

### DIFF
--- a/exercises/practice/trinary/TrinaryTest.php
+++ b/exercises/practice/trinary/TrinaryTest.php
@@ -75,4 +75,9 @@ class TrinaryTest extends PHPUnit\Framework\TestCase
     {
         $this->assertSame(0, toDecimal('13201'));
     }
+    
+    public function test311IsDecimal0(): void
+    {
+        $this->assertSame(0, toDecimal('311'));
+    }
 }


### PR DESCRIPTION
My solution should not have passed all the tests. For 311 it gives 31, but the correct answer is 0

function toDecimal(string $number): int
{
    return array_reduce(
                str_split(strrev($number)),
                fn (array $acc,int $digit): array => array(
                    'power' => $acc['power'] + 1,
                    'valid' => $acc['valid'] && in_array($digit,range(0,2)),
                    'sum' => ($digit * 3 ** $acc['power'] + $acc['sum']) * $acc['valid'],
                ),
                array(
                    'power' => 0,
                    'sum' => 0,
                    'valid' => 1
                )
            )['sum'];
}