### PR TITLE
Update  pascalsTriangleRows to allow nullable type

### DIFF
--- a/exercises/practice/pascals-triangle/PascalsTriangle.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangle.php
@@ -24,7 +24,7 @@
 
 declare(strict_types=1);
 
-function pascalsTriangleRows(int $rowCount)
+function pascalsTriangleRows(?int $rowCount)
 {
     throw new \BadFunctionCallException("Implement the pascalsTriangleRows function");
 }


### PR DESCRIPTION
The current version of `pascalTriangleRows` has an `int` type declaration for its parameter `$rowCount`, but this causes one of the unit tests to fail:

```
There was 1 error:

1) PascalsTriangleTest::testNullNoRows
TypeError: pascalsTriangleRows(): Argument #1 ($rowCount) must be of type int, null given
```

Marking it as nullable results in all unit tests passing.