### PR TITLE
[Fix] testColors to green

### DIFF
--- a/exercises/practice/resistor-color/ResistorColorTest.php
+++ b/exercises/practice/resistor-color/ResistorColorTest.php
@@ -34,16 +34,16 @@ class ResistorColorTest extends PHPUnit\Framework\TestCase
     public function testColors(): void
     {
         $this->assertEquals([
-            "black",
-            "brown",
-            "red",
-            "orange",
-            "yellow",
-            "green",
-            "blue",
-            "violet",
-            "grey",
-            "white"
+            'black' => 0,
+            'brown' => 1,
+            'red' => 2,
+            'orange' => 3,
+            'yellow' => 4,
+            'green' => 5,
+            'blue' => 6,
+            'violet' => 7,
+            'grey' => 8,
+            'white' => 9,
         ], COLORS);
     }
 


### PR DESCRIPTION
One of Resistor Color tests is failing - testColors. By other tests seems that assoc arrray is meant to be used here. Updated test to green.  