### PR TITLE
[fix] update pizza pi instructions for excersise number one

### DIFF
--- a/exercises/concept/pizza-pi/.docs/instructions.md
+++ b/exercises/concept/pizza-pi/.docs/instructions.md
@@ -10,7 +10,7 @@ Will you help Lilly throw the proportionally perfect pizza party?
 ## 1. A Dough Ratio
 
 Lilly is a fan of thin, crispy pizzas with a thinner crust.
-The dough needed for the middle is a minimum 200g, but every person it serves requires another 45g of dough.
+The dough needed for the middle is a minimum 200g, but every person it serves requires another 20g of dough.
 
 `grams = pizzas * ((persons * 20) + 200)`
 


### PR DESCRIPTION
Currently the instructions are misleading. The description says that for every person that is served, 45g of dough are added. The example below calculates with 20g. As a result the corresponding test fails because the expected amount of dough is only true with 20g per person.