### PR TITLE
fix author of Say exercise

### DIFF
--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,6 +1,6 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": ["joohan"],
+  "authors": ["vnkmpf"],
   "contributors": [],
   "files": {
     "solution": ["Say.php"],


### PR DESCRIPTION
It's awkward, but I incorrectly set my Exercism name instead of GitHub name.

I want to be correctly set as the author of this exercise.
Proof: #553