### PR TITLE
Remove unnecessary colon

### DIFF
--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -10,7 +10,7 @@ Define the `Lasagna::expectedCookTime` function that does not take any arguments
 
 ```php
 <?php
-$timer = new Lasagna();:
+$timer = new Lasagna();
 $timer->expectedCookTime()
 // => 40
 ```


### PR DESCRIPTION
Fixed code snippet in the lasagna task introduction document where someone left unnecessary colon symbol