### PR TITLE
Fix typo in instructions.md

### DIFF
--- a/exercises/concept/language-list/.docs/instructions.md
+++ b/exercises/concept/language-list/.docs/instructions.md
@@ -66,7 +66,7 @@ Assume the list will always have at least one item.
 
 $language_list = language_list("PHP", "Prolog");
 // => ["PHP", "Prolog"]
-$fisrt = current_language($language_list);
+$first = current_language($language_list);
 // => "PHP"
 ```
 


### PR DESCRIPTION
Instruction no. 5 had a typo in a declared variable