### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/configlet-generate.yml
+++ b/.github/workflows/configlet-generate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   configlet-generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: write

--- a/.github/workflows/exercise-lint-phpcs-psr-12.yml
+++ b/.github/workflows/exercise-lint-phpcs-psr-12.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macOS-latest]
 
     steps:
       - name: Set git line endings
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --system core.autocrlf false
           git config --system core.eol lf

--- a/.github/workflows/exercise-tests-phpunit-9.yml
+++ b/.github/workflows/exercise-tests-phpunit-9.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macOS-latest]
 
     steps:
       - name: Set git line endings
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --system core.autocrlf false
           git config --system core.eol lf


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.