### PR TITLE
Concept of type juggling

### DIFF
--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -1,6 +1,7 @@
 # Type Juggling
 
-Type juggling may also be known as type coercion. Type juggling is when two values of different types are coerced to the same type to perform an operation.
+Type juggling may also be known as type coercion.
+Type juggling is when two values of different types are coerced to the same type to perform an operation.
 
 ```php
 $baskets = 5 // int
@@ -9,9 +10,11 @@ $baskets * $apples_per_basket
 # => 15 // int
 ```
 
-This implicitly converts the `string` to an `int` to execute the `*` operation. The decision, which type to coerce, is made by PHP according to the rules of the operation and these rules vary largely.
+This implicitly converts the `string` to an `int` to execute the `*` operation.
+The decision, which type to coerce, is made by PHP according to the rules of the operation and these rules vary largely.
 
-Type juggling **does not change** the type of the value stored in a variable. Only the value processed by the operation is converted.
+Type juggling **does not change** the type of the value stored in a variable.
+Only the value processed by the operation is converted.
 
 ```php
 $apples_per_basket = "3" // string
@@ -28,7 +31,8 @@ strlen(12321);
 
 ## Turn off type juggling
 
-Type juggling happens by default. We can stop PHP from coercing and force it to check types strictly:
+Type juggling happens by default.
+We can stop PHP from coercing and force it to check types strictly:
 
 ```php
 <?php
@@ -48,9 +52,11 @@ $my_number = (int) $apples_per_basket // cast string to int
 # => 3 // int
 ```
 
-This will forcibly convert the value to the type specified in the brackets `(...)`. Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.
+This will forcibly convert the value to the type specified in the brackets `(...)`.
+Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.
 
-Type casting **does not change** the type of the value stored in a variable. Only the value processed by the operation is converted.
+Type casting **does not change** the type of the value stored in a variable.
+Only the value processed by the operation is converted.
 
 ```php
 $apples_per_basket = "3" // string
@@ -86,7 +92,8 @@ Relying on casting, either explicitly or implicitly, may produce errors in a lar
 
 ## Explicit type casting to `array` and `object`
 
-Values can be cast to `array` and `object` types as well. If a value, which is not an array or an object is cast to an `array`, it is converted to a single item present in an array:
+Values can be cast to `array` and `object` types as well.
+If a value, which is not an array or an object is cast to an `array`, it is converted to a single item present in an array:
 
 ```php
 $day_of_the_week = 'Monday';

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -10,7 +10,7 @@ $baskets * $apples_per_basket
 # => 15 // int
 ```
 
-This implicitly converts the `string` to an `int` to execute the `*` operation.
+When the expression is evaluated, the string value is implicitly converted to an `int` to match the expectation of the `*` operator.
 The decision, which type to coerce, is made by PHP according to the rules of the operation and these rules vary largely.
 
 Type coercion also happens when calling functions and methods:
@@ -30,8 +30,8 @@ $my_number = (int) $apples_per_basket // cast string to int
 # => 3 // int
 ```
 
-This will forcibly convert the value to the type specified in the brackets `(...)`.
-Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.
+This will convert the value to the type specified in the brackets `(...)`.
+All primitive types can be used as the target type: `bool`, `int`, `float`, `string`, `array`, `object`.
 
 ## Temporary conversion only
 

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -28,7 +28,7 @@ strlen(12321);
 
 ## Turn off type juggling
 
-Type juggling happens by default. As for type declarations on variables and parameters, which we learned about before, we can stop PHP from coercing and force it to check types strictly:
+Type juggling happens by default. We can stop PHP from coercing and force it to check types strictly:
 
 ```php
 <?php

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -13,15 +13,6 @@ $baskets * $apples_per_basket
 This implicitly converts the `string` to an `int` to execute the `*` operation.
 The decision, which type to coerce, is made by PHP according to the rules of the operation and these rules vary largely.
 
-Type juggling **does not change** the type of the value stored in a variable.
-Only the value processed by the operation is converted.
-
-```php
-$apples_per_basket = "3" // string
-5 * $apples_per_basket
-# $apples_per_basket => "3" // string
-```
-
 Type coercion also happens when calling functions and methods:
 
 ```php
@@ -42,21 +33,18 @@ $my_number = (int) $apples_per_basket // cast string to int
 This will forcibly convert the value to the type specified in the brackets `(...)`.
 Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.
 
-Type casting **does not change** the type of the value stored in a variable.
-Only the value processed by the operation is converted.
+## Temporary conversion only
+
+Type juggling or casting **does not change** the type of the value stored in a variable.
+Only the input to the operation is converted.
 
 ```php
 $apples_per_basket = "3" // string
+5 * $apples_per_basket
+# $apples_per_basket => "3" // string
+
 $my_number = (int) $apples_per_basket // cast string to int
 # $apples_per_basket => "3" // string
-```
-
-To change the type of a value stored in a variable, we store the type casted result into it:
-
-```php
-$apples_per_basket = "3" // string
-$apples_per_basket = (int) $apples_per_basket // cast string to int
-# => 3 // int
 ```
 
 ## Loss of information

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -39,7 +39,7 @@ $my_number = (int) $apples_per_basket // cast string to int
 # $apples_per_basket => "3" // string
 ```
 
-If you want to change the type of a value stored in a variable, store the type casted result into it:
+To change the type of a value stored in a variable, we store the type casted result into it:
 
 ```php
 $apples_per_basket = "3" // string

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -74,7 +74,7 @@ $day_of_the_week = 'Monday';
 (array) $day_of_the_week
 // => array(1) {
 //      [0]=>
-//        string(1) "Monday"
+//        string(6) "Monday"
 //    }
 ```
 

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -26,6 +26,18 @@ strlen(12321);
 # => 5
 ```
 
+## Turn off type juggling
+
+Type juggling happens by default. As for type declarations on variables and parameters, which we learned about before, we can stop PHP from coercing and force it to check types strictly:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+strlen(12345); // => TypeError
+```
+
 ## Type Casting
 
 Rather than relying on implicit coercion, we can explicitly force a value to be evaluated as a certain type using `C`-style type casting:

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -9,6 +9,16 @@ $baskets * $apples_per_basket
 # => 15 // int
 ```
 
+This implicitly converts the `string` to an `int` to execute the `*` operation. The decision, which type to coerce, is made by PHP according to the rules of the operation and these rules vary largely.
+
+Type juggling **does not change** the type of the value stored in a variable. Only the value processed by the operation is converted.
+
+```php
+$apples_per_basket = "3" // string
+5 * $apples_per_basket
+# $apples_per_basket => "3" // string
+```
+
 ## Type Casting
 
 Rather than relying on implicit coercion, we can explicitly force a value to be evaluated as a certain type using `C`-style type casting:
@@ -20,6 +30,22 @@ $my_number = (int) $apples_per_basket // cast string to int
 ```
 
 This will forcibly convert the value to the type specified in the brackets `(...)`. Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.
+
+Type casting **does not change** the type of the value stored in a variable. Only the value processed by the operation is converted.
+
+```php
+$apples_per_basket = "3" // string
+$my_number = (int) $apples_per_basket // cast string to int
+# $apples_per_basket => "3" // string
+```
+
+If you want to change the type of a value stored in a variable, store the type casted result into it:
+
+```php
+$apples_per_basket = "3" // string
+$apples_per_basket = (int) $apples_per_basket // cast string to int
+# => 3 // int
+```
 
 ## Loss of information
 

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -6,7 +6,7 @@ Type juggling may also be known as type coercion. Type juggling is when two valu
 $baskets = 5 // int
 $apples_per_basket = "3" // string
 $baskets * $apples_per_basket
-# => 15
+# => 15 // int
 ```
 
 ## Type Casting

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -14,9 +14,9 @@ $baskets * $apples_per_basket
 Rather than relying on implicit coercion, we can explicitly force a value to be evaluated as a certain type using `C`-style type casting:
 
 ```php
-$my_number = "3"
-(int) 3
-# => 3
+$apples_per_basket = "3" // string
+$my_number = (int) $apples_per_basket // cast string to int
+# => 3 // int
 ```
 
 This will forcibly convert the value to the type specified in the brackets `(...)`. Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -19,6 +19,13 @@ $apples_per_basket = "3" // string
 # $apples_per_basket => "3" // string
 ```
 
+Type coercion also happens when calling functions and methods:
+
+```php
+strlen(12321);
+# => 5
+```
+
 ## Type Casting
 
 Rather than relying on implicit coercion, we can explicitly force a value to be evaluated as a certain type using `C`-style type casting:

--- a/concepts/type-juggling/about.md
+++ b/concepts/type-juggling/about.md
@@ -29,19 +29,6 @@ strlen(12321);
 # => 5
 ```
 
-## Turn off type juggling
-
-Type juggling happens by default.
-We can stop PHP from coercing and force it to check types strictly:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-strlen(12345); // => TypeError
-```
-
 ## Type Casting
 
 Rather than relying on implicit coercion, we can explicitly force a value to be evaluated as a certain type using `C`-style type casting:

--- a/concepts/type-juggling/introduction.md
+++ b/concepts/type-juggling/introduction.md
@@ -1,6 +1,7 @@
 # Type Juggling
 
-Type juggling may also be known as type coercion. Type juggling is when two values of different types are coerced to the same type to perform an operation.
+Type juggling may also be known as type coercion.
+Type juggling is when two values of different types are coerced to the same type to perform an operation.
 
 ```php
 $baskets = 5 // int
@@ -17,4 +18,5 @@ $my_number = (int) $apples_per_basket // cast string to int
 # => 3 // int
 ```
 
-Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`. Most commonly, type casting is used to change an integer (`int`) to a float (`float`) or vice-versa.
+Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`.
+Most commonly, type casting is used to change an integer (`int`) to a float (`float`) or vice-versa.

--- a/concepts/type-juggling/introduction.md
+++ b/concepts/type-juggling/introduction.md
@@ -12,9 +12,9 @@ $baskets * $apples_per_basket
 This can be done implicitly (see above example), or explicitly with `C`-style type casting:
 
 ```php
-$my_number = "3"
-(int) 3
-# => 3
+$apples_per_basket = "3" // string
+$my_number = (int) $apples_per_basket // cast string to int
+# => 3 // int
 ```
 
 Allowed types for manual type casting are: `bool`, `int`, `float`, `string`, `array`, `object`. Most commonly, type casting is used to change an integer (`int`) to a float (`float`) or vice-versa.


### PR DESCRIPTION
I read into the `type juggling` concept and found it to be a bit to concise. Here's my suggestions to:

* clarify what PHP does when coersion happens
* emphasize the type changes in the examples
* make clear, that coersion does not alter the variable value
* show `strict_types` to turn off type coercion

I also have questions about the whole mechanism behind the concepts and the exercises:

* The `/concepts/*/about.md` are the texts shown on `https://exercism.org/tracks/php/concepts/type-juggling`. Any other `*.md` in this directory can be imported into `/exercises/concept/*/.docs/introduction.md.tpl`? Or just `introduction.md`?
* How to convert `/exercises/concept/*/.docs/introduction.md.tpl` to the actual file? Is that happening magically for me?
* How do I tell exercism, that I have more than one exercise for a concept? Is that all taken from the exercise list in  `/config.json`?