### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/configlet-generate.yml
+++ b/.github/workflows/configlet-generate.yml
@@ -27,4 +27,4 @@ jobs:
         run: configlet generate
 
       - name: Commit generated code
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.