### PR TITLE
fix: explode with empty separator in exemplar

### DIFF
--- a/exercises/concept/city-office/.meta/exemplar/Form.php
+++ b/exercises/concept/city-office/.meta/exemplar/Form.php
@@ -9,7 +9,7 @@ class Form
 
     function letters(string $word): array
     {
-        return explode("", $word);
+        return mb_str_split($word);
     }
 
     function checkLength(string $word, int $max_length): bool

--- a/exercises/concept/city-office/Form.php
+++ b/exercises/concept/city-office/Form.php
@@ -9,7 +9,7 @@ class Form
 
     function letters($word)
     {
-        return explode("", $word);
+        return mb_str_split($word);
     }
 
     function checkLength($word, $max_length)


### PR DESCRIPTION
Explode with empty separator errs: https://3v4l.org/RevTj
Use mb_str_split instead: https://3v4l.org/VAKbR