### PR TITLE
Remove URL from Lucky Number popup teaser

### DIFF
--- a/exercises/concept/lucky-numbers/.meta/config.json
+++ b/exercises/concept/lucky-numbers/.meta/config.json
@@ -15,7 +15,7 @@
       ]
    },
    "language_version": ">=8.1",
-   "blurb": "Practice type juggling while helping your friend Kojo with his website www.fun-with-numbers.com.",
+   "blurb": "Practice type juggling while helping your friend Kojo with his website.",
    "forked_from": [
       "javascript/lucky-numbers"
    ]


### PR DESCRIPTION
Somehow I forgot to remove the non-existent domain from the Lucky Number popup teaser. No exercism stars earned...