### PR TITLE
Fix code style rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   },
   "require-dev": {
     "php": "^7.4|^8.0",
-    "slevomat/coding-standard": "^8.5",
-    "squizlabs/php_codesniffer": "^3.6"
+    "slevomat/coding-standard": "^8.14.1",
+    "squizlabs/php_codesniffer": "^3.8"
   },
   "scripts": {
     "lint:check": "./vendor/bin/phpcs --ignore=*/hello-world/*,*/concept/* --standard=phpcs-php.xml ./exercises",

--- a/phpcs-php.xml
+++ b/phpcs-php.xml
@@ -10,7 +10,7 @@
   </rule>
   <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php">
     <properties>
-      <property name="newlinesCountBetweenOpenTagAndDeclare" type="int" value="1" />
+      <property name="linesCountBeforeDeclare" type="int" value="1" />
       <property name="spacesCountAroundEqualsSign" type="int" value="0" />
     </properties>
   </rule>


### PR DESCRIPTION
Problem:

> "Invalid sniff properties set for individual sniffs will now result in an error and halt the execution of PHPCS"
> PHPCodeSniffer Release notes V3.8.0

Solution:

- [x] Change Slevomat Sniff property to current name