### PR TITLE
Clarify instructions on city office

### DIFF
--- a/exercises/concept/city-office/.docs/instructions.md
+++ b/exercises/concept/city-office/.docs/instructions.md
@@ -5,29 +5,29 @@ You have been working in the city office for a while, and you have developed a s
 Now, a new colleague is joining you, and you realized your tools might not be self-explanatory.
 There are a lot of weird conventions in your office, like always filling out forms with uppercase letters and avoiding leaving fields empty.
 
-As a first step you decide to add PHP type hints so that it is easier for your new colleague to hop right in and start using your tools.
+As a first step you decide to add PHP type declarations so that it is easier for your new colleague to hop right in and start using your tools.
 
 ## 1. Declare the types for the Address class
 
-Add property type hints to each of the `Address` class properties declared.
+Add property type declarations to each of the `Address` class properties declared.
 Each class property should be declared as a string.
 
 ## 2. Declare the types to fill out the form with blank values
 
-Add a parameter type hint and a return type hint to the `blanks` method in the `Form` class.
+Add a parameter type declaration and a return type declaration to the `blanks` method in the `Form` class.
 The method should take in an integer length, and return a string representation of the blank line.
 
 ## 3. Declare the type when splitting a value into separate letters
 
-Add a parameter type hint and a return type hint to the `letters` method in the `Form` class.
+Add a parameter type declaration and a return type declaration to the `letters` method in the `Form` class.
 The method should take in a string, representing words, and return an array of letters.
 
 ## 4. Declare the type when checking if a value will fit into a form
 
-Add parameter type hints and a return type hint to the `checkLength` method in the `Form` class.
+Add parameter type declarations and a return type declaration to the `checkLength` method in the `Form` class.
 The method should take in a string word, and an integer maximum length, and return a true or false value.
 
 ## 5. Declare the type when formatting an address in the form
 
-Add a parameter type hint, making use of the `Address` class updated previously, and a return type hint to the `formatAddress` method in the `Form` class.
+Add a parameter type declaration, making use of the `Address` class updated previously, and a return type declaration to the `formatAddress` method in the `Form` class.
 The method should take in an `Address` and return a formatted string.

--- a/exercises/concept/city-office/.docs/instructions.md
+++ b/exercises/concept/city-office/.docs/instructions.md
@@ -2,31 +2,32 @@
 
 You have been working in the city office for a while, and you have developed a set of tools that speed up your day-to-day work, for example with filling out forms.
 
-Now, a new colleague is joining you, and you realized your tools might not be self-explanatory. There are a lot of weird conventions in your office, like always filling out forms with uppercase letters and avoiding leaving fields empty.
+Now, a new colleague is joining you, and you realized your tools might not be self-explanatory.
+There are a lot of weird conventions in your office, like always filling out forms with uppercase letters and avoiding leaving fields empty.
 
-You decide to write some documentation so that it's easier for your new colleague to hop right in and start using your tools.
+As a first step you decide to add PHP type hints so that it is easier for your new colleague to hop right in and start using your tools.
 
-## 1. Document the types for the Address class
+## 1. Declare the types for the Address class
 
-Add property types to each of the `Address` class properties declared.
+Add property type hints to each of the `Address` class properties declared.
 Each class property should be declared as a string.
 
-## 2. Document the types to fill out the form with blank values
+## 2. Declare the types to fill out the form with blank values
 
-Add a parameter type and a return type to the `blanks` method in the `Form` class.
+Add a parameter type hint and a return type hint to the `blanks` method in the `Form` class.
 The method should take in an integer length, and return a string representation of the blank line.
 
-## 3. Document the type when splitting a value into separate letters
+## 3. Declare the type when splitting a value into separate letters
 
-Add a parameter type and a return type to the `letters` method in the `Form` class.
+Add a parameter type hint and a return type hint to the `letters` method in the `Form` class.
 The method should take in a string, representing words, and return an array of letters.
 
-## 4. Document the type when checking if a value will fit into a form
+## 4. Declare the type when checking if a value will fit into a form
 
-Add parameter types and a return type to the `checkLength` method in the `Form` class.
+Add parameter type hints and a return type hint to the `checkLength` method in the `Form` class.
 The method should take in a string word, and an integer maximum length, and return a true or false value.
 
-## 5. Document the type when formatting an address in the form
+## 5. Declare the type when formatting an address in the form
 
-Add a parameter type, making use of the `Address` class updated previously, and a return type to the `formatAddress` method in the `Form` class.
+Add a parameter type hint, making use of the `Address` class updated previously, and a return type hint to the `formatAddress` method in the `Form` class.
 The method should take in an `Address` and return a formatted string.

--- a/exercises/concept/city-office/.meta/design.md
+++ b/exercises/concept/city-office/.meta/design.md
@@ -2,6 +2,7 @@
 
 This exercise should provide a boilerplate with already implemented functions that only need a type declaration.
 The functions should be simple so that the exercise can appear early in the concept tree.
+The instructions should clearly express that it is all about native PHP type declarations, not comments (PHPDoc or phpstan/psalm types).
 
 ## Learning objectives
 


### PR DESCRIPTION
See [exercism forum post](https://forum.exercism.org/t/instructions-for-type-declaration-exercise-city-office-could-be-clearer/9070) for details.

I read through the instructions and also found, that when one has some knowledge about PHPDoc comments (or JSDoc or JavaDoc) the wording is misleading.

I rephrased the instructions to reflect the intended PHP type declarations / type hints.