### PR TITLE
Add ListOps exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -939,7 +939,7 @@
         "uuid": "56f36086-96a8-4941-8c46-b563f02e5b09",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 7
+        "difficulty": 6
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -932,6 +932,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2
+      },
+      {
+        "slug": "list-ops",
+        "name": "List Ops",
+        "uuid": "56f36086-96a8-4941-8c46-b563f02e5b09",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7
       }
     ]
   },

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,0 +1,16 @@
+## Callable
+
+In PHP there is a concept of [callable](https://www.php.net/manual/en/language.types.callable.php).
+
+Those can take multiple forms, but we will focus on [anonymous functions](https://www.php.net/manual/en/functions.anonymous.php).
+
+It is possible to create an anonymous function in a variable and call it with parameters:
+
+```php
+$double = function ($number) {
+    return $number * 2;
+}
+
+$double(2); // returns 4
+$double(4); // returns 8
+```

--- a/exercises/practice/list-ops/.docs/instructions.md
+++ b/exercises/practice/list-ops/.docs/instructions.md
@@ -1,0 +1,19 @@
+# Instructions
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and `reduce` are very common.
+Implement a series of basic list operations, without using existing functions.
+
+The precise number and names of the operations to be implemented will be track dependent to avoid conflicts with existing names, but the general operations you will implement include:
+
+- `append` (_given two lists, add all items in the second list to the end of the first list_);
+- `concatenate` (_given a series of lists, combine all items in all lists into one flattened list_);
+- `filter` (_given a predicate and a list, return the list of all items for which `predicate(item)` is True_);
+- `length` (_given a list, return the total number of items within it_);
+- `map` (_given a function and a list, return the list of the results of applying `function(item)` on all items_);
+- `foldl` (_given a function, a list, and initial accumulator, fold (reduce) each item into the accumulator from the left_);
+- `foldr` (_given a function, a list, and an initial accumulator, fold (reduce) each item into the accumulator from the right_);
+- `reverse` (_given a list, return a list with all the original items, but in reversed order_).
+
+Note, the ordering in which arguments are passed to the fold functions (`foldl`, `foldr`) is significant.

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,0 +1,15 @@
+{
+  "authors": ["homersimpsons"],
+  "files": {
+    "solution": [
+      "ListOps.php"
+    ],
+    "test": [
+      "ListOpsTest.php"
+    ],
+    "example": [
+      ".meta/example.php"
+    ]
+  },
+  "blurb": "Implement basic list operations."
+}

--- a/exercises/practice/list-ops/.meta/example.php
+++ b/exercises/practice/list-ops/.meta/example.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 class ListOps
 {
-    public static function append(array $list1, array $list2): array
+    public function append(array $list1, array $list2): array
     {
         foreach ($list2 as $el) {
             $list1[] = $el;
@@ -34,7 +34,7 @@ class ListOps
         return $list1;
     }
 
-    public static function concat(array $list1, array ...$listn): array
+    public function concat(array $list1, array ...$listn): array
     {
         foreach ($listn as $list) {
             $list1 = self::append($list1, $list);
@@ -42,7 +42,7 @@ class ListOps
         return $list1;
     }
 
-    public static function filter(callable $predicate, array $list): array
+    public function filter(callable $predicate, array $list): array
     {
         $result = [];
         foreach ($list as $el) {
@@ -53,7 +53,7 @@ class ListOps
         return $result;
     }
 
-    public static function length(array $list): int
+    public function length(array $list): int
     {
         $count = 0;
         foreach ($list as $_el) {
@@ -62,7 +62,7 @@ class ListOps
         return $count;
     }
 
-    public static function map(callable $function, array $list): array
+    public function map(callable $function, array $list): array
     {
         $result = [];
         foreach ($list as $el) {
@@ -71,7 +71,7 @@ class ListOps
         return $result;
     }
 
-    public static function foldl(callable $function, array $list, $accumulator)
+    public function foldl(callable $function, array $list, $accumulator)
     {
         foreach ($list as $el) {
             $accumulator = $function($accumulator, $el);
@@ -79,7 +79,7 @@ class ListOps
         return $accumulator;
     }
 
-    public static function foldr(callable $function, array $list, $accumulator)
+    public function foldr(callable $function, array $list, $accumulator)
     {
         while (self::length($list) > 0) {
             $el = array_pop($list);
@@ -88,7 +88,7 @@ class ListOps
         return $accumulator;
     }
 
-    public static function reverse(array $list): array
+    public function reverse(array $list): array
     {
         $result = [];
         while (self::length($list) > 0) {

--- a/exercises/practice/list-ops/.meta/example.php
+++ b/exercises/practice/list-ops/.meta/example.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+class ListOps
+{
+    public static function append(array $list1, array $list2): array
+    {
+        foreach ($list2 as $el) {
+            $list1[] = $el;
+        }
+        return $list1;
+    }
+
+    public static function concat(array $list1, array ...$listn): array
+    {
+        foreach ($listn as $list) {
+            $list1 = self::append($list1, $list);
+        }
+        return $list1;
+    }
+
+    public static function filter(callable $predicate, array $list): array
+    {
+        $result = [];
+        foreach ($list as $el) {
+            if ($predicate($el)) {
+                $result[] = $el;
+            }
+        }
+        return $result;
+    }
+
+    public static function length(array $list): int
+    {
+        $count = 0;
+        foreach ($list as $_el) {
+            $count++;
+        }
+        return $count;
+    }
+
+    public static function map(callable $function, array $list): array
+    {
+        $result = [];
+        foreach ($list as $el) {
+            $result[] = $function($el);
+        }
+        return $result;
+    }
+
+    public static function foldl(callable $function, array $list, $accumulator)
+    {
+        foreach ($list as $el) {
+            $accumulator = $function($accumulator, $el);
+        }
+        return $accumulator;
+    }
+
+    public static function foldr(callable $function, array $list, $accumulator)
+    {
+        while (self::length($list) > 0) {
+            $el = array_pop($list);
+            $accumulator = $function($accumulator, $el);
+        }
+        return $accumulator;
+    }
+
+    public static function reverse(array $list): array
+    {
+        $result = [];
+        while (self::length($list) > 0) {
+            $result[] = array_pop($list);
+        }
+        return $result;
+    }
+}

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,0 +1,106 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b9452-bf94-40f7-a3db-c3cf4850066a]
+description = "append entries to a list and return the new list -> empty lists"
+
+[2c894696-b609-4569-b149-8672134d340a]
+description = "append entries to a list and return the new list -> list to empty list"
+
+[e842efed-3bf6-4295-b371-4d67a4fdf19c]
+description = "append entries to a list and return the new list -> empty list to list"
+
+[71dcf5eb-73ae-4a0e-b744-a52ee387922f]
+description = "append entries to a list and return the new list -> non-empty lists"
+
+[28444355-201b-4af2-a2f6-5550227bde21]
+description = "concatenate a list of lists -> empty list"
+
+[331451c1-9573-42a1-9869-2d06e3b389a9]
+description = "concatenate a list of lists -> list of lists"
+
+[d6ecd72c-197f-40c3-89a4-aa1f45827e09]
+description = "concatenate a list of lists -> list of nested lists"
+
+[0524fba8-3e0f-4531-ad2b-f7a43da86a16]
+description = "filter list returning only values that satisfy the filter function -> empty list"
+
+[88494bd5-f520-4edb-8631-88e415b62d24]
+description = "filter list returning only values that satisfy the filter function -> non-empty list"
+
+[1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
+description = "returns the length of a list -> empty list"
+
+[d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
+description = "returns the length of a list -> non-empty list"
+
+[c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> empty list"
+
+[11e71a95-e78b-4909-b8e4-60cdcaec0e91]
+description = "return a list of elements whose values equal the list value transformed by the mapping function -> non-empty list"
+
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+include = false
+
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+include = false
+
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
+description = "folds (reduces) the given list from the left with a function -> empty list"
+reimplements = "613b20b7-1873-4070-a3a6-70ae5f50d7cc"
+
+[7a626a3c-03ec-42bc-9840-53f280e13067]
+description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
+reimplements = "e56df3eb-9405-416a-b13a-aabb4c3b5194"
+
+[d7fcad99-e88e-40e1-a539-4c519681f390]
+description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
+reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
+
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+include = false
+
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+include = false
+
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+include = false
+
+[17214edb-20ba-42fc-bda8-000a5ab525b0]
+description = "folds (reduces) the given list from the right with a function -> empty list"
+reimplements = "aeb576b9-118e-4a57-a451-db49fac20fdc"
+
+[e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
+description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
+reimplements = "c4b64e58-313e-4c47-9c68-7764964efb8e"
+
+[8066003b-f2ff-437e-9103-66e6df474844]
+description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
+reimplements = "be396a53-c074-4db3-8dd6-f7ed003cce7c"
+
+[94231515-050e-4841-943d-d4488ab4ee30]
+description = "reverse the elements of the list -> empty list"
+
+[fcc03d1e-42e0-4712-b689-d54ad761f360]
+description = "reverse the elements of the list -> non-empty list"
+
+[40872990-b5b8-4cb8-9085-d91fc0d05d26]
+description = "reverse the elements of the list -> list of lists is not flattened"

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -51,14 +51,17 @@ description = "return a list of elements whose values equal the list value trans
 [613b20b7-1873-4070-a3a6-70ae5f50d7cc]
 description = "folds (reduces) the given list from the left with a function -> empty list"
 include = false
+comment = "Re-implemented in 36549237-f765-4a4c-bfd9-5d3a8f7b07d2"
 
 [e56df3eb-9405-416a-b13a-aabb4c3b5194]
 description = "folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list"
 include = false
+comment = "Re-implemented in 7a626a3c-03ec-42bc-9840-53f280e13067"
 
 [d2cf5644-aee1-4dfc-9b88-06896676fe27]
 description = "folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list"
 include = false
+comment = "Re-implemented in d7fcad99-e88e-40e1-a539-4c519681f390"
 
 [36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
 description = "folds (reduces) the given list from the left with a function -> empty list"
@@ -75,14 +78,17 @@ reimplements = "d2cf5644-aee1-4dfc-9b88-06896676fe27"
 [aeb576b9-118e-4a57-a451-db49fac20fdc]
 description = "folds (reduces) the given list from the right with a function -> empty list"
 include = false
+comment = "Re-implemented in 17214edb-20ba-42fc-bda8-000a5ab525b0"
 
 [c4b64e58-313e-4c47-9c68-7764964efb8e]
 description = "folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list"
 include = false
+comment = "Re-implemented in e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd"
 
 [be396a53-c074-4db3-8dd6-f7ed003cce7c]
 description = "folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list"
 include = false
+comment = "Re-implemented in 8066003b-f2ff-437e-9103-66e6df474844"
 
 [17214edb-20ba-42fc-bda8-000a5ab525b0]
 description = "folds (reduces) the given list from the right with a function -> empty list"

--- a/exercises/practice/list-ops/ListOps.php
+++ b/exercises/practice/list-ops/ListOps.php
@@ -26,12 +26,12 @@ declare(strict_types=1);
 
 class ListOps
 {
-    public static function append(array $list1, array $list2): array
+    public function append(array $list1, array $list2): array
     {
         throw new \BadMethodCallException("Implement the append function");
     }
 
-    public static function concat(array $list1, array ...$listn): array
+    public function concat(array $list1, array ...$listn): array
     {
         throw new \BadMethodCallException("Implement the concat function");
     }
@@ -39,12 +39,12 @@ class ListOps
     /**
      * @param callable(mixed $el): bool $predicate
      */
-    public static function filter(callable $predicate, array $list): array
+    public function filter(callable $predicate, array $list): array
     {
         throw new \BadMethodCallException("Implement the filter function");
     }
 
-    public static function length(array $list): int
+    public function length(array $list): int
     {
         throw new \BadMethodCallException("Implement the length function");
     }
@@ -52,7 +52,7 @@ class ListOps
     /**
      * @param callable(mixed $el): mixed $function
      */
-    public static function map(callable $function, array $list): array
+    public function map(callable $function, array $list): array
     {
         throw new \BadMethodCallException("Implement the map function");
     }
@@ -60,7 +60,7 @@ class ListOps
     /**
      * @param callable(mixed $acc, mixed $el): mixed $function
      */
-    public static function foldl(callable $function, array $list, $accumulator)
+    public function foldl(callable $function, array $list, $accumulator)
     {
         throw new \BadMethodCallException("Implement the foldl function");
     }
@@ -68,12 +68,12 @@ class ListOps
     /**
      * @param callable(mixed $acc, mixed $el): mixed $function
      */
-    public static function foldr(callable $function, array $list, $accumulator)
+    public function foldr(callable $function, array $list, $accumulator)
     {
         throw new \BadMethodCallException("Implement the foldr function");
     }
 
-    public static function reverse(array $list): array
+    public function reverse(array $list): array
     {
         throw new \BadMethodCallException("Implement the reverse function");
     }

--- a/exercises/practice/list-ops/ListOps.php
+++ b/exercises/practice/list-ops/ListOps.php
@@ -37,7 +37,7 @@ class ListOps
     }
 
     /**
-     * @param callable(mixed $el): bool $predicate
+     * @param callable(mixed $item): bool $predicate
      */
     public function filter(callable $predicate, array $list): array
     {
@@ -50,7 +50,7 @@ class ListOps
     }
 
     /**
-     * @param callable(mixed $el): mixed $function
+     * @param callable(mixed $item): mixed $function
      */
     public function map(callable $function, array $list): array
     {
@@ -58,7 +58,7 @@ class ListOps
     }
 
     /**
-     * @param callable(mixed $acc, mixed $el): mixed $function
+     * @param callable(mixed $accumulator, mixed $item): mixed $function
      */
     public function foldl(callable $function, array $list, $accumulator)
     {
@@ -66,7 +66,7 @@ class ListOps
     }
 
     /**
-     * @param callable(mixed $acc, mixed $el): mixed $function
+     * @param callable(mixed $accumulator, mixed $item): mixed $function
      */
     public function foldr(callable $function, array $list, $accumulator)
     {

--- a/exercises/practice/list-ops/ListOps.php
+++ b/exercises/practice/list-ops/ListOps.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+class ListOps
+{
+    public static function append(array $list1, array $list2): array
+    {
+        throw new \BadMethodCallException("Implement the append function");
+    }
+
+    public static function concat(array $list1, array ...$listn): array
+    {
+        throw new \BadMethodCallException("Implement the concat function");
+    }
+
+    /**
+     * @param callable(mixed $el): bool $predicate
+     */
+    public static function filter(callable $predicate, array $list): array
+    {
+        throw new \BadMethodCallException("Implement the filter function");
+    }
+
+    public static function length(array $list): int
+    {
+        throw new \BadMethodCallException("Implement the length function");
+    }
+
+    /**
+     * @param callable(mixed $el): mixed $function
+     */
+    public static function map(callable $function, array $list): array
+    {
+        throw new \BadMethodCallException("Implement the map function");
+    }
+
+    /**
+     * @param callable(mixed $acc, mixed $el): mixed $function
+     */
+    public static function foldl(callable $function, array $list, $accumulator)
+    {
+        throw new \BadMethodCallException("Implement the foldl function");
+    }
+
+    /**
+     * @param callable(mixed $acc, mixed $el): mixed $function
+     */
+    public static function foldr(callable $function, array $list, $accumulator)
+    {
+        throw new \BadMethodCallException("Implement the foldr function");
+    }
+
+    public static function reverse(array $list): array
+    {
+        throw new \BadMethodCallException("Implement the reverse function");
+    }
+}

--- a/exercises/practice/list-ops/ListOpsTest.php
+++ b/exercises/practice/list-ops/ListOpsTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+class ListOpsTest extends PHPUnit\Framework\TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once 'ListOps.php';
+    }
+
+    /**
+     * @testdox append entries to a list and return the new list -> empty lists
+     */
+    public function testAppendEmptyLists()
+    {
+        $this->assertEquals([], ListOps::append([], []));
+    }
+
+    /**
+     * @testdox append entries to a list and return the new list -> empty list to list
+     */
+    public function testAppendNonEmptyListToEmptyList()
+    {
+        $this->assertEquals([1, 2, 3, 4], ListOps::append([1, 2, 3, 4], []));
+    }
+
+    /**
+     * @testdox append entries to a list and return the new list -> non-empty lists
+     */
+    public function testAppendNonEmptyLists()
+    {
+        $this->assertEquals([1, 2, 2, 3, 4, 5], ListOps::append([1, 2], [2, 3, 4, 5]));
+    }
+
+    /**
+     * @testdox concat lists and lists of lists into new list -> empty list
+     */
+    public function testConcatEmptyLists()
+    {
+        $this->assertEquals([], ListOps::concat([], []));
+    }
+
+    /**
+     * @testdox concat lists and lists of lists into new list -> list of lists
+     */
+    public function testConcatLists()
+    {
+        $this->assertEquals([1, 2, 3, 4, 5, 6], ListOps::concat([1, 2], [3], [], [4, 5, 6]));
+    }
+
+    /**
+     * @testdox filter list returning only values that satisfy the filter function -> empty list
+     */
+    public function testFilterEmptyList()
+    {
+        $this->assertEquals(
+            [],
+            ListOps::filter(static fn ($el) => $el % 2 === 1, [])
+        );
+    }
+
+    /**
+     * @testdox filter list returning only values that satisfy the filter function -> non empty list
+     */
+    public function testFilterNonEmptyList()
+    {
+        $this->assertEquals(
+            [1, 3, 5],
+            ListOps::filter(static fn ($el) => $el % 2 === 1, [1, 2, 3, 5])
+        );
+    }
+
+    /**
+     * @testdox returns the length of a list -> empty list
+     */
+    public function testLengthEmptyList()
+    {
+        $this->assertEquals(0, ListOps::length([]));
+    }
+
+    /**
+     * @testdox returns the length of a list -> non-empty list
+     */
+    public function testLengthNonEmptyList()
+    {
+        $this->assertEquals(4, ListOps::length([1, 2, 3, 4]));
+    }
+
+    /**
+     * @testdox returns a list of elements whose values equal the list value transformed by the mapping function -> empty list
+     */
+    public function testMapEmptyList()
+    {
+        $this->assertEquals(
+            [],
+            ListOps::map(static fn ($el) => $el + 1, [])
+        );
+    }
+
+    /**
+     * @testdox returns a list of elements whose values equal the list value transformed by the mapping function -> non-empty list
+     */
+    public function testMapNonEmptyList()
+    {
+        $this->assertEquals(
+            [2, 4, 6, 8],
+            ListOps::map(static fn ($el) => $el + 1, [1, 3, 5, 7])
+        );
+    }
+
+    /**
+     * @testdox folds (reduces) the given list from the left with a function -> empty list
+     */
+    public function testFoldlEmptyList()
+    {
+        $this->assertEquals(
+            2,
+            ListOps::foldl(static fn ($acc, $el) => $el * $acc, [], 2)
+        );
+    }
+
+    /**
+     * @testdox folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list
+     */
+    public function testFoldlDirectionIndependentNonEmptyList()
+    {
+        $this->assertEquals(
+            15,
+            ListOps::foldl(static fn ($acc, $el) => $acc + $el, [1, 2, 3, 4], 5)
+        );
+    }
+
+    /**
+     * @testdox folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list
+     */
+    public function testFoldlDirectionDependentNonEmptyList()
+    {
+        $this->assertEquals(
+            64,
+            ListOps::foldl(static fn ($acc, $el) => $el / $acc, [1, 2, 3, 4], 24)
+        );
+    }
+
+    /**
+     * @testdox folds (reduces) the given list from the right with a function -> empty list
+     */
+    public function testFoldrEmptyList()
+    {
+        $this->assertEquals(
+            2,
+            ListOps::foldr(static fn ($acc, $el) => $el * $acc, [], 2)
+        );
+    }
+
+    /**
+     * @testdox folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list
+     */
+    public function testFoldrDirectionIndependentNonEmptyList()
+    {
+        $this->assertEquals(
+            15,
+            ListOps::foldr(static fn ($acc, $el) => $acc + $el, [1, 2, 3, 4], 5)
+        );
+    }
+
+    /**
+     * @testdox folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list
+     */
+    public function testFoldrDirectionDependentNonEmptyList()
+    {
+        $this->assertEquals(
+            9,
+            ListOps::foldr(static fn ($acc, $el) => $el / $acc, [1, 2, 3, 4], 24)
+        );
+    }
+
+    /**
+     * @testdox reverse the elements of a list -> empty list
+     */
+    public function testReverseEmptyList()
+    {
+        $this->assertEquals([], ListOps::reverse([]));
+    }
+
+    /**
+     * @testdox reverse the elements of a list -> non-empty list
+     */
+    public function testReverseNonEmptyList()
+    {
+        $this->assertEquals([7, 5, 3, 1], ListOps::reverse([1, 3, 5, 7]));
+    }
+
+    /**
+     * @testdox reverse the elements of a list -> list of lists is not flattened
+     */
+    public function testReverseNonEmptyListIsNotFlattened()
+    {
+        $this->assertEquals([[4, 5, 6], [], [3], [1, 2]], ListOps::reverse([[1, 2], [3], [], [4, 5, 6]]));
+    }
+}

--- a/exercises/practice/list-ops/ListOpsTest.php
+++ b/exercises/practice/list-ops/ListOpsTest.php
@@ -38,7 +38,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testAppendEmptyLists()
     {
-        $this->assertEquals([], ListOps::append([], []));
+        $listOps = new ListOps();
+        $this->assertEquals([], $listOps->append([], []));
     }
 
     /**
@@ -46,7 +47,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testAppendNonEmptyListToEmptyList()
     {
-        $this->assertEquals([1, 2, 3, 4], ListOps::append([1, 2, 3, 4], []));
+        $listOps = new ListOps();
+        $this->assertEquals([1, 2, 3, 4], $listOps->append([1, 2, 3, 4], []));
     }
 
     /**
@@ -54,7 +56,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testAppendNonEmptyLists()
     {
-        $this->assertEquals([1, 2, 2, 3, 4, 5], ListOps::append([1, 2], [2, 3, 4, 5]));
+        $listOps = new ListOps();
+        $this->assertEquals([1, 2, 2, 3, 4, 5], $listOps->append([1, 2], [2, 3, 4, 5]));
     }
 
     /**
@@ -62,7 +65,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testConcatEmptyLists()
     {
-        $this->assertEquals([], ListOps::concat([], []));
+        $listOps = new ListOps();
+        $this->assertEquals([], $listOps->concat([], []));
     }
 
     /**
@@ -70,7 +74,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testConcatLists()
     {
-        $this->assertEquals([1, 2, 3, 4, 5, 6], ListOps::concat([1, 2], [3], [], [4, 5, 6]));
+        $listOps = new ListOps();
+        $this->assertEquals([1, 2, 3, 4, 5, 6], $listOps->concat([1, 2], [3], [], [4, 5, 6]));
     }
 
     /**
@@ -78,9 +83,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFilterEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             [],
-            ListOps::filter(static fn ($el) => $el % 2 === 1, [])
+            $listOps->filter(static fn ($el) => $el % 2 === 1, [])
         );
     }
 
@@ -89,9 +95,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFilterNonEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             [1, 3, 5],
-            ListOps::filter(static fn ($el) => $el % 2 === 1, [1, 2, 3, 5])
+            $listOps->filter(static fn ($el) => $el % 2 === 1, [1, 2, 3, 5])
         );
     }
 
@@ -100,7 +107,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testLengthEmptyList()
     {
-        $this->assertEquals(0, ListOps::length([]));
+        $listOps = new ListOps();
+        $this->assertEquals(0, $listOps->length([]));
     }
 
     /**
@@ -108,7 +116,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testLengthNonEmptyList()
     {
-        $this->assertEquals(4, ListOps::length([1, 2, 3, 4]));
+        $listOps = new ListOps();
+        $this->assertEquals(4, $listOps->length([1, 2, 3, 4]));
     }
 
     /**
@@ -116,9 +125,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testMapEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             [],
-            ListOps::map(static fn ($el) => $el + 1, [])
+            $listOps->map(static fn ($el) => $el + 1, [])
         );
     }
 
@@ -127,9 +137,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testMapNonEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             [2, 4, 6, 8],
-            ListOps::map(static fn ($el) => $el + 1, [1, 3, 5, 7])
+            $listOps->map(static fn ($el) => $el + 1, [1, 3, 5, 7])
         );
     }
 
@@ -138,9 +149,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFoldlEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             2,
-            ListOps::foldl(static fn ($acc, $el) => $el * $acc, [], 2)
+            $listOps->foldl(static fn ($acc, $el) => $el * $acc, [], 2)
         );
     }
 
@@ -149,9 +161,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFoldlDirectionIndependentNonEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             15,
-            ListOps::foldl(static fn ($acc, $el) => $acc + $el, [1, 2, 3, 4], 5)
+            $listOps->foldl(static fn ($acc, $el) => $acc + $el, [1, 2, 3, 4], 5)
         );
     }
 
@@ -160,9 +173,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFoldlDirectionDependentNonEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             64,
-            ListOps::foldl(static fn ($acc, $el) => $el / $acc, [1, 2, 3, 4], 24)
+            $listOps->foldl(static fn ($acc, $el) => $el / $acc, [1, 2, 3, 4], 24)
         );
     }
 
@@ -171,9 +185,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFoldrEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             2,
-            ListOps::foldr(static fn ($acc, $el) => $el * $acc, [], 2)
+            $listOps->foldr(static fn ($acc, $el) => $el * $acc, [], 2)
         );
     }
 
@@ -182,9 +197,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFoldrDirectionIndependentNonEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             15,
-            ListOps::foldr(static fn ($acc, $el) => $acc + $el, [1, 2, 3, 4], 5)
+            $listOps->foldr(static fn ($acc, $el) => $acc + $el, [1, 2, 3, 4], 5)
         );
     }
 
@@ -193,9 +209,10 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testFoldrDirectionDependentNonEmptyList()
     {
+        $listOps = new ListOps();
         $this->assertEquals(
             9,
-            ListOps::foldr(static fn ($acc, $el) => $el / $acc, [1, 2, 3, 4], 24)
+            $listOps->foldr(static fn ($acc, $el) => $el / $acc, [1, 2, 3, 4], 24)
         );
     }
 
@@ -204,7 +221,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testReverseEmptyList()
     {
-        $this->assertEquals([], ListOps::reverse([]));
+        $listOps = new ListOps();
+        $this->assertEquals([], $listOps->reverse([]));
     }
 
     /**
@@ -212,7 +230,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testReverseNonEmptyList()
     {
-        $this->assertEquals([7, 5, 3, 1], ListOps::reverse([1, 3, 5, 7]));
+        $listOps = new ListOps();
+        $this->assertEquals([7, 5, 3, 1], $listOps->reverse([1, 3, 5, 7]));
     }
 
     /**
@@ -220,6 +239,7 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
      */
     public function testReverseNonEmptyListIsNotFlattened()
     {
-        $this->assertEquals([[4, 5, 6], [], [3], [1, 2]], ListOps::reverse([[1, 2], [3], [], [4, 5, 6]]));
+        $listOps = new ListOps();
+        $this->assertEquals([[4, 5, 6], [], [3], [1, 2]], $listOps->reverse([[1, 2], [3], [], [4, 5, 6]]));
     }
 }

--- a/exercises/practice/list-ops/ListOpsTest.php
+++ b/exercises/practice/list-ops/ListOpsTest.php
@@ -43,12 +43,21 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox append entries to a list and return the new list -> empty list to list
+     * @testdox append entries to a list and return the new list -> list to empty list
      */
     public function testAppendNonEmptyListToEmptyList()
     {
         $listOps = new ListOps();
         $this->assertEquals([1, 2, 3, 4], $listOps->append([1, 2, 3, 4], []));
+    }
+
+    /**
+     * @testdox append entries to a list and return the new list -> empty list to list
+     */
+    public function testAppendEmptyListToNonEmptyList()
+    {
+        $listOps = new ListOps();
+        $this->assertEquals([1, 2, 3, 4], $listOps->append([], [1, 2, 3, 4]));
     }
 
     /**
@@ -61,7 +70,7 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox concat lists and lists of lists into new list -> empty list
+     * @testdox concatenate a list of lists -> empty list
      */
     public function testConcatEmptyLists()
     {
@@ -70,12 +79,21 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox concat lists and lists of lists into new list -> list of lists
+     * @testdox concatenate a list of lists -> list of lists
      */
     public function testConcatLists()
     {
         $listOps = new ListOps();
         $this->assertEquals([1, 2, 3, 4, 5, 6], $listOps->concat([1, 2], [3], [], [4, 5, 6]));
+    }
+
+    /**
+     * @testdox concatenate a list of lists -> list of nested lists
+     */
+    public function testConcatNestedLists()
+    {
+        $listOps = new ListOps();
+        $this->assertEquals([[1], [2], [3], [], [4, 5, 6]], $listOps->concat([[1], [2]], [[3]], [[]], [[4, 5, 6]]));
     }
 
     /**

--- a/phpcs-php.xml
+++ b/phpcs-php.xml
@@ -2,6 +2,8 @@
 <ruleset name="xPHP">
   <description>Coding standard for xPHP</description>
 
+  <arg value="n" />
+
   <!-- Include all sniffs in the PSR12 standard except... -->
   <rule ref="PSR12">
     <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace" />


### PR DESCRIPTION
This is the first time I add an exercise. I followed the walkthrough at https://exercism.org/docs/building/tracks/practice-exercises.

Do not hesitate to tell me if anything is wrong. I may try to implement other exercises so better be right from the beginning.

Some notes:
- I inspired myself from the javaScript track https://github.com/exercism/javascript/blob/main/exercises/practice/list-ops, but they are creating a "class" to represent the string, on this part I decided to stick closer to my understanding of the instructions and followed what the java track did https://github.com/exercism/java/blob/main/exercises/practice/list-ops/src/main/java/ListOps.java (Note that the Go track also takes the "class" approach too)
- for the `example.php` I tried to follow the instructions (not using std's functions), so maybe I could also put it as exemplar (with some added phpdoc)
- [x] Should I add template documentation for the callable received in `filter`, `map`, `foldl` and `foldr` ? => Added to ease completion of the exercise
- [x] Should I update the instructions ? => Added an "append" file to add some context around callables
- [x] The PHPCS warnings are for line length in `@testdox` comments, how should I go to fix them ? => I do not think it is relevant to fix them here
- [x] There is no task for this exercise, should I create them ? => I may do it in an up-comming Pull Request, but I do not think it is that necessary
- [x] I used configlet to generate the exercise, it looks like this created a huge diff to `config.json` should I revert it to only add the relevant part for `list-ops` ? => I kept the diff as small as possible here
- [x] Which level of difficulty is this exercise ? => Hard (7)

@neenjaw I put you as a reviewer as it looks like you are the maintainer for the exercises.