### PR TITLE
Adjust tests for Nucleotide Count exercise to match problem-specifications

### DIFF
--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -5,7 +5,8 @@
   "contributors": [
     "arueckauer",
     "kytrinyx",
-    "petemcfarlane"
+    "petemcfarlane",
+    "tomasnorre"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -31,6 +31,9 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         require_once 'NucleotideCount.php';
     }
 
+    /**
+     * uuid: 3e5c30a8-87e2-4845-a815-a49671ade970
+     */
     public function testEmptyDNASequence(): void
     {
         $this->assertSame([
@@ -41,6 +44,9 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount(''));
     }
 
+    /**
+     * uuid: a0ea42a6-06d9-4ac6-828c-7ccaccf98fec
+     */
     public function testDNASequenceSingleNucleotide(): void
     {
         $this->assertSame([
@@ -51,6 +57,9 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount('G'));
     }
 
+    /**
+     * uuid: eca0d565-ed8c-43e7-9033-6cefbf5115b5
+     */
     public function testRepetitiveDNASequence(): void
     {
         $this->assertSame([
@@ -61,6 +70,9 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount('GGGGGGG'));
     }
 
+    /**
+     * uuid: 40a45eac-c83f-4740-901a-20b22d15a39f
+     */
     public function testDNASequenceWithMultipleNucleotides(): void
     {
         $this->assertSame([
@@ -71,6 +83,9 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount('AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'));
     }
 
+    /**
+     * uuid: b4c47851-ee9e-4b0a-be70-a86e343bd851
+     */
     public function testDNASequenceWithInvalidNucleotides(): void
     {
         $this->expectException(Exception::class);

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -41,17 +41,27 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
         ], nucleotideCount(''));
     }
 
+    public function testDNASequenceSingleNucleotide(): void
+    {
+        $this->assertSame([
+            'a' => 0,
+            'c' => 0,
+            't' => 0,
+            'g' => 1,
+        ], nucleotideCount('G'));
+    }
+
     public function testRepetitiveDNASequence(): void
     {
         $this->assertSame([
-            'a' => 9,
+            'a' => 0,
             'c' => 0,
             't' => 0,
-            'g' => 0,
-        ], nucleotideCount('AAAAAAAAA'));
+            'g' => 7,
+        ], nucleotideCount('GGGGGGG'));
     }
 
-    public function testDNASequence(): void
+    public function testDNASequenceWithMultipleNucleotides(): void
     {
         $this->assertSame([
             'a' => 20,
@@ -59,5 +69,11 @@ class NucleotideCountTest extends PHPUnit\Framework\TestCase
             't' => 21,
             'g' => 17,
         ], nucleotideCount('AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'));
+    }
+
+    public function testDNASequenceWithInvalidNucleotides(): void
+    {
+        $this->expectException(Exception::class);
+        nucleotideCount('AGXXACT');
     }
 }


### PR DESCRIPTION
Adjusted tests, to problem specifications [1] and as agreed in forum [2]. Please let me know if changes wanted. I have tested that they work with my locally solved Nucleotide Count Exercise. They are also working locally with the `PHPUNIT_BIN="./bin/phpunit-9.phar" ./bin/test.sh`


1) https://github.com/exercism/problem-specifications/blob/main/exercises/nucleotide-count/canonical-data.json
2) https://forum.exercism.org/t/improvement-of-exercise-nucleotide-count/9651/1