### PR TITLE
Remove > from shell readme, to ease copy pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Exercism exercises in PHP
 ### All dependencies
 
 ```shell
-> ./bin/install.sh
+./bin/install.sh
 ```
 
 ### Only tests dependencies
 
 ```shell
-> ./bin/install-phpunit-9.sh
+./bin/install-phpunit-9.sh
 ```
 
 ### Only style-check dependencies
 
 ```shell
-> ./bin/install-phpcs.sh
+./bin/install-phpcs.sh
 ```
 
 ## Running Unit Test Suite
@@ -30,7 +30,7 @@ Exercism exercises in PHP
 ### PHPUnit 9
 
 ```shell
-> PHPUNIT_BIN="./bin/phpunit-9.phar" ./bin/test.sh
+PHPUNIT_BIN="./bin/phpunit-9.phar" ./bin/test.sh
 ```
 
 ## Running Style Checker
@@ -38,7 +38,7 @@ Exercism exercises in PHP
 ### PSR-12 rules
 
 ```shell
-> PHPCS_BIN="./bin/phpcs.phar" PHPCS_RULES="./phpcs-php.xml" ./bin/lint.sh
+PHPCS_BIN="./bin/phpcs.phar" PHPCS_RULES="./phpcs-php.xml" ./bin/lint.sh
 ```
 
 ## Contributing


### PR DESCRIPTION
We haven't agreed on this change, so feel free to reject it.

Currently, the GitHub copy function isn't working with the `> ./bin/install.sh` command. 

It will end up in a loop waiting for input, and write an empty `bin/install.sh` file.

By removing the `>` it can be copied directly into a terminal and the commands can be executed as wanted.