### PR TITLE
Add debug hints to show up in online editor

### DIFF
--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -1,0 +1,9 @@
+# Debug
+
+When a test fails, a message is displayed describing what went wrong and for which input.
+
+Printing values and contents of variables can also help with understanding what happens.
+PHP can print values using:
+
+- `echo 'Debug message';` to output a string of your choice
+- `var_dump($variable);` to get more insight into a value, e.g. the type PHP sees


### PR DESCRIPTION
I discovered that on the JavaScript track lately:

![JavaScript online editor](https://github.com/mk-mxp/php/blob/934d5f9b15e5bb43d27378e5a1e15f201c67d3fb/docs/github-images/debug-in-online-editor.png?raw=true)

It's easy to add that for PHP, too.