### PR TITLE
Disable testing on MacOS due to sudden problems with PHP

### DIFF
--- a/.github/workflows/exercise-tests-phpunit-9.yml
+++ b/.github/workflows/exercise-tests-phpunit-9.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        os: [ubuntu-22.04, windows-2022, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, 'macOS-12:664173ba02188c19a49cd941cdd13af57d57bd90']
 
     steps:
       - name: Set git line endings

--- a/.github/workflows/exercise-tests-phpunit-9.yml
+++ b/.github/workflows/exercise-tests-phpunit-9.yml
@@ -16,7 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        os: [ubuntu-22.04, windows-2022, 'macOS-12:664173ba02188c19a49cd941cdd13af57d57bd90']
+        # os: [ubuntu-22.04, windows-2022, macOS-12]
+        os: [ubuntu-22.04, windows-2022]
 
     steps:
       - name: Set git line endings


### PR DESCRIPTION
@ErikSchierboom I followed the advice you gave in #641 , but that doesn't change anything. I found https://github.com/shivammathur/setup-php/issues/823 , so I will disable testing on MacOS for now.