### PR TITLE
CI add back macos test

### DIFF
--- a/.github/workflows/exercise-tests-phpunit-9.yml
+++ b/.github/workflows/exercise-tests-phpunit-9.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        # os: [ubuntu-22.04, windows-2022, macOS-12]
         os: [ubuntu-22.04, windows-2022, macOS-13]
 
     steps:

--- a/.github/workflows/exercise-tests-phpunit-9.yml
+++ b/.github/workflows/exercise-tests-phpunit-9.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         php-version: [8.0, 8.1, 8.2]
         # os: [ubuntu-22.04, windows-2022, macOS-12]
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04, windows-2022, macOS-13]
 
     steps:
       - name: Set git line endings


### PR DESCRIPTION
With the failing tests yesterday we were running against `macOS-latest` (12.7.3) but for what ever reason `macOS-13` nor `macOS-14` is tagged as latest, but with the `macOS-13` it works again. 

I'll rebase my open PR when this is merged. 

Technically this shouldn't be needed any more after the `setup-php` as the issue https://github.com/shivammathur/setup-php/issues/823 has been resolved, but I would still opt for updating to `macOS-13` instead of `macOS-12` which `macOS-latest` pointed too. 

If you disagree, this PR can be closed. 