### PR TITLE
Improve contributor experience

### DIFF
--- a/.github/workflows/exercise-lint-phpcs-psr-12.yml
+++ b/.github/workflows/exercise-lint-phpcs-psr-12.yml
@@ -27,7 +27,7 @@ jobs:
           tools: composer
 
       - name: Install composer packages
-        run: CI="true" composer install
+        run: composer install
 
       - name: Lint exercises
         shell: bash

--- a/.github/workflows/exercise-lint-phpcs-psr-12.yml
+++ b/.github/workflows/exercise-lint-phpcs-psr-12.yml
@@ -27,7 +27,7 @@ jobs:
           tools: composer
 
       - name: Install composer packages
-        run: composer install
+        run: composer install --no-scripts
 
       - name: Lint exercises
         shell: bash

--- a/.github/workflows/exercise-lint-phpcs-psr-12.yml
+++ b/.github/workflows/exercise-lint-phpcs-psr-12.yml
@@ -10,27 +10,24 @@ on:
 jobs:
   test:
     name: PHPCS Linting - ${{ github.event_name }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        php-version: [8.2]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php-version }}
           extensions: gmp
           tools: composer
 
-      - name: Install dependencies
-        shell: bash
-        run: |
-          curl -Lo bin/phpcs.phar https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-          chmod +x bin/phpcs.phar
-
       - name: Install composer packages
-        run: composer install
+        run: CI="true" composer install
 
       - name: Lint exercises
         shell: bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ composer install # Required dependencies to develop this track
 `bin/configlet` is the official tool for managing Exercism language track repositories.
 See [Building Exercism docs][exercism-configlet].
 
+For convenience, you can use `composer configlet:fmt` to fix formatting issues in the Exercism track files.
+This is included in `composer ci` to run the CI checks locally.
+
 ## Running Unit Test Suite
 
 The tests are run with PHPUnit. A shell loop injecting `exemplar.php` is provided to ease testing.
@@ -35,15 +38,19 @@ Execute the following command to run the tests:
 composer test:run
 ```
 
+This is included in `composer ci` to run the CI checks locally.
+
 ## Running Style Checker
 
-This project use a slightly [modified][local-file-phpcs-config] version of [PSR-12].
+This project uses a slightly [modified][local-file-phpcs-config] version of [PSR-12].
 Use the following commands to apply code style:
 
 ```shell
 composer lint:check # Checks the files against the code style rules
-composer lint:fix # Automatically fix codestyle issues
+composer lint:fix # Automatically fix code style issues
 ```
+
+The `lint:check` is included in `composer ci` to run the CI checks locally.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following system dependencies are required:
 
 - `composer`, as recommended in the [PHP track installation docs][exercism-track-installation-composer].
 - [`bash` shell][gnu-bash].
-- PHP V8.2+ CLI
+- PHP V8.2+ CLI.
 - An active Internet connection for installing required tools / composer packages.
 
 Run the following command to get started with this project:

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ To solve the exercises, head to the [PHP track][exercism-track-home] and check t
 The following system dependencies are required:
 
 - `composer`, as recommended in the [PHP track installation docs][exercism-track-installation-composer].
-- [`bash` shell][gnu-bash]
+- [`bash` shell][gnu-bash].
 - PHP V8.2+ CLI
+- An active Internet connection for installing required tools / composer packages.
 
-Run the following commands to get started with this project:
+Run the following command to get started with this project:
 
 ```shell
-bin/fetch-configlet # The official tool for managing Exercism language track repositories
 composer install # Required dependencies to develop this track
 ```
 
 ## Running Exercism resources management
 
-`bin/configlet` is a tool to manage exercism resources in this track.
+`bin/configlet` is the official tool for managing Exercism language track repositories.
 See [Building Exercism docs][exercism-configlet].
 
 ## Running Unit Test Suite
@@ -49,8 +49,9 @@ composer lint:fix # Automatically fix codestyle issues
 
 - Read the documentation at [Exercism][exercism-docs].
 - Follow the [PSR-12] coding style (Exercisms PHP track uses a slightly [modified][local-file-phpcs-config] version of [PSR-12]).
+- Run `composer ci` to run CI checks locally before pushing.
 - CI is run on all pull requests, it must pass the required checks for merge.
-- CI is running all tests on PHP 8.0 to PHP 8.2
+- CI is running all tests on PHP 8.0 to PHP 8.2 for Linux, Windows and MacOS.
 
 ## Generating new practice exercises
 

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,12 @@
         "@lint:check",
         "@tests:run"
     ],
-    "tool:configlet:error": "[ -x bin/configlet ] || ( echo 'Fetch configlet first! Run: \"bin/fetch-configlet\"'; false )",
-    "tool:configlet:fetch": "[ -z \"$CI\" ] || [ -x bin/configlet ] || bin/fetch-configlet",
+    "tool:configlet:fetch": "[ -x bin/configlet ] || bin/fetch-configlet",
     "tool:configlet:update": [
         "rm bin/configlet || true",
-        "[ -n \"$CI\" ] || bin/fetch-configlet"
+        "bin/fetch-configlet"
     ],
     "configlet:fmt": [
-        "@tool:configlet:error",
         "bin/configlet fmt"
     ],
     "format:fix": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "post-install-cmd": [
-        "echo 'this must show up'; echo '$CI: '$CI",
+        "cat composer.json",
         "@tool:configlet:fetch"
     ],
     "post-update-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "post-install-cmd": [
-        "cat composer.json",
         "@tool:configlet:fetch"
     ],
     "post-update-cmd": [
@@ -32,7 +31,7 @@
     "tool:configlet:fetch": "[ -z \"$CI\" ] || [ -x bin/configlet ] || bin/fetch-configlet",
     "tool:configlet:update": [
         "rm bin/configlet || true",
-        "bin/fetch-configlet"
+        "[ -n \"$CI\" ] || bin/fetch-configlet"
     ],
     "configlet:fmt": [
         "@tool:configlet:error",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
         "@lint:check",
         "@tests:run"
     ],
-    "configlet:fmt": "bin/configlet fmt",
+    "tool:configlet:error": "[ -x bin/configlet ] || ( echo 'Fetch configlet first! Run: \"bin/fetch-configlet\"'; false )",
+    "configlet:fmt": [
+        "@tool:configlet:error",
+        "bin/configlet fmt"
+    ],
     "format:fix": [
         "@lint:fix",
         "@configlet:fmt"

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
   },
   "scripts": {
     "post-install-cmd": [
-        "echo 'this needs to show up'",
-        "env",
+        "echo 'this must show up'; echo '$CI: '$CI",
         "@tool:configlet:fetch"
     ],
     "post-update-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
     "squizlabs/php_codesniffer": "^3.9"
   },
   "scripts": {
+    "configlet:fmt": "bin/configlet fmt",
+    "format:fix": [
+        "@lint:fix",
+        "@configlet:fmt"
+    ],
     "lint:check": "phpcs",
     "lint:fix": "phpcbf",
     "tests:run": "PHPUNIT_BIN='phpunit' bin/test.sh"

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,25 @@
     "squizlabs/php_codesniffer": "^3.9"
   },
   "scripts": {
+    "post-install-cmd": [
+        "echo 'this needs to show up'",
+        "env",
+        "@tool:configlet:fetch"
+    ],
+    "post-update-cmd": [
+        "@tool:configlet:update"
+    ],
     "ci": [
         "@configlet:fmt",
         "@lint:check",
         "@tests:run"
     ],
     "tool:configlet:error": "[ -x bin/configlet ] || ( echo 'Fetch configlet first! Run: \"bin/fetch-configlet\"'; false )",
+    "tool:configlet:fetch": "[ -z \"$CI\" ] || [ -x bin/configlet ] || bin/fetch-configlet",
+    "tool:configlet:update": [
+        "rm bin/configlet || true",
+        "bin/fetch-configlet"
+    ],
     "configlet:fmt": [
         "@tool:configlet:error",
         "bin/configlet fmt"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   },
   "require-dev": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.0",
     "phpunit/phpunit": "^9.6 || ^10.5",
     "slevomat/coding-standard": "^8.14.1",
     "squizlabs/php_codesniffer": "^3.9"

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
     "squizlabs/php_codesniffer": "^3.9"
   },
   "scripts": {
+    "ci": [
+        "@configlet:fmt",
+        "@lint:check",
+        "@tests:run"
+    ],
     "configlet:fmt": "bin/configlet fmt",
     "format:fix": [
         "@lint:fix",


### PR DESCRIPTION
Closes #620 and fixes issues with the GitHub actions workflow for PHPCS linting:

- When a job has a `strategy` key, it must provide a `matrix` in that.
- We don't need the PHPCS PHAR in CI anymore.