### PR TITLE
CI Add PHPUnit 10 and PHP 8.3

### DIFF
--- a/.github/workflows/exercise-tests-phpunit-10.yml
+++ b/.github/workflows/exercise-tests-phpunit-10.yml
@@ -12,11 +12,14 @@ jobs:
   test:
     name: PHP ${{ matrix.php-version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        php-version: [8.1, 8.2, 8.3]
-        os: [ubuntu-22.04, windows-2022, macOS-12]
+        #php-version: [8.1, 8.2, 8.3]
+        php-version: [8.3]
+        #os: [ubuntu-22.04, windows-2022, macOS-12]
+        os: [ubuntu-22.04]
 
     steps:
       - name: Set git line endings

--- a/.github/workflows/exercise-tests-phpunit-10.yml
+++ b/.github/workflows/exercise-tests-phpunit-10.yml
@@ -44,4 +44,5 @@ jobs:
         shell: bash
         env:
           PHPUNIT_BIN: 'bin/phpunit-10.phar'
+          XDEBUG_MODE: off
         run: bin/test.sh

--- a/.github/workflows/exercise-tests-phpunit-10.yml
+++ b/.github/workflows/exercise-tests-phpunit-10.yml
@@ -1,0 +1,45 @@
+name: Exercise tests with PHPUnit 10
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php-version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [8.1, 8.2, 8.3]
+        os: [ubuntu-22.04, windows-2022, macOS-12]
+
+    steps:
+      - name: Set git line endings
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - uses: shivammathur/setup-php@6d7209f44a25a59e904b1ee9f3b0c33ab2cd888d
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: gmp
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          curl -Lo ./bin/phpunit-10.phar https://phar.phpunit.de/phpunit-10.phar
+          chmod +x bin/phpunit-10.phar
+
+      - name: Test exercises\
+        shell: bash
+        env:
+          PHPUNIT_BIN: 'bin/phpunit-10.phar'
+        run: bin/test.sh

--- a/.github/workflows/exercise-tests-phpunit-10.yml
+++ b/.github/workflows/exercise-tests-phpunit-10.yml
@@ -5,14 +5,12 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
 
 jobs:
   test:
     name: PHP ${{ matrix.php-version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +39,8 @@ jobs:
           curl -Lo ./bin/phpunit-10.phar https://phar.phpunit.de/phpunit-10.phar
           chmod +x bin/phpunit-10.phar
 
-      - name: Test exercises\
+      - name: Test exercises
+        continue-on-error: true
         shell: bash
         env:
           PHPUNIT_BIN: 'bin/phpunit-10.phar'

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   },
   "require-dev": {
-    "php": "^8.0",
+    "php": "^7.4 || ^8.0",
     "phpunit/phpunit": "^9.6 || ^10.5",
     "slevomat/coding-standard": "^8.14.1",
     "squizlabs/php_codesniffer": "^3.9"

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }
   },
   "require-dev": {
-    "php": "^7.4|^8.0",
-    "phpunit/phpunit": "^9.6",
+    "php": "^8.0",
+    "phpunit/phpunit": "^9.6 || ^10.5",
     "slevomat/coding-standard": "^8.14.1",
     "squizlabs/php_codesniffer": "^3.9"
   },

--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -62,7 +62,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         }, $otherAllergen);
     }
 
-    public function provideListOfAllergen(): array
+    public static function provideListOfAllergen(): array
     {
         require_once 'Allergies.php';
 

--- a/exercises/practice/binary/BinaryTest.php
+++ b/exercises/practice/binary/BinaryTest.php
@@ -82,7 +82,7 @@ class BinaryTest extends PHPUnit\Framework\TestCase
         parse_binary($value);
     }
 
-    public function invalidValues(): array
+    public static function invalidValues(): array
     {
         return [
             ['2'], ['12345'], ['a'], ['0abcdef'],

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -37,7 +37,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         return new DateTimeImmutable($date, $UTC);
     }
 
-    public function inputAndExpectedDates(): array
+    public static function inputAndExpectedDates(): array
     {
         return [
             ['2011-04-25', '2043-01-01 01:46:40'],
@@ -48,7 +48,7 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
         ];
     }
 
-    public function inputDates(): array
+    public static function inputDates(): array
     {
         return [
             ['2011-04-25'],

--- a/exercises/practice/protein-translation/ProteinTranslationTest.php
+++ b/exercises/practice/protein-translation/ProteinTranslationTest.php
@@ -174,7 +174,7 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function invalidCodonDataProvider(): array
+    public static function invalidCodonDataProvider(): array
     {
         return [
             'Non-existing' => ['AAA'],


### PR DESCRIPTION
I'm not sure how to add the allow failure on GitHub Actions, with GitLab CI I would know how to do it, but to my knowledge it's not supported in GHA yet. 

This solves, from my understanding, the first 3 bullets in #652 

For some reason, the tests are slower with PHPUnit 10 and PHP 8.3, than PHPUnit 10 and PHP 8.2. I have not dug into that yet, but would be something that would interest me why. 

Todo: 

- [x] Add static DataProviders