### PR TITLE
Better interface for Circular Buffer

### DIFF
--- a/exercises/practice/circular-buffer/CircularBuffer.php
+++ b/exercises/practice/circular-buffer/CircularBuffer.php
@@ -24,16 +24,10 @@
 
 declare(strict_types=1);
 
-class BufferFullError extends Exception
-{
-}
-
-class BufferEmptyError extends Exception
-{
-}
-
 class CircularBuffer
 {
+    // You need to add more methods yourself!
+
     public function read()
     {
         throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
@@ -43,14 +37,12 @@ class CircularBuffer
     {
         throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
     }
+}
 
-    public function forceWrite($item): void
-    {
-        throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
-    }
+class BufferFullError extends Exception
+{
+}
 
-    public function clear(): void
-    {
-        throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
-    }
+class BufferEmptyError extends Exception
+{
 }


### PR DESCRIPTION
I solved Circular Buffer right now, and found the interface is not good for Exercisms community solutions. With the Exceptions at the top, all solutions look the same. And I think, there should be more methods to add by the student for being "medium".

- Exceptions at end (for representer / community solutions)
- Less methods predefined. A comment to say that this is intentional and not an error

As Circular Buffer is the Exercise of the week, I skip the review to get that online as soon as possible.