### PR TITLE
Fix "class names" in Basics (long concept text)

### DIFF
--- a/concepts/basic-syntax/about.md
+++ b/concepts/basic-syntax/about.md
@@ -189,7 +189,7 @@ $sum = add(1, 2);
 
 ## Naming conventions
 
-Classnames should all be `PascalCase`.
+Class names should all be `PascalCase`.
 Depending on the style standard; variables, functions, and method names may be either `camelCase` or `snake_case`.
 Names may contain letters `a-zA-Z`, numbers `0-9`, and underscores `_` but they cannot start with a number.
 


### PR DESCRIPTION
Replaces #593 . The places changed there are no longer relevant, but the problem still was in the long concept text.