### PR TITLE
Drop MacOS from CI

### DIFF
--- a/.github/workflows/exercise-tests-phpunit-9.yml
+++ b/.github/workflows/exercise-tests-phpunit-9.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [8.0, 8.1, 8.2]
-        os: [ubuntu-22.04, windows-2022, macOS-12]
+        os: [ubuntu-22.04, windows-2022]
 
     steps:
       - name: Set git line endings


### PR DESCRIPTION
Once again MacOS fails for unknown reasons out of our control... So don't test on MacOS.