### PR TITLE
Sync difference of squares

### DIFF
--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -8,10 +8,7 @@ The square of the sum of the first ten natural numbers is
 The sum of the squares of the first ten natural numbers is
 1² + 2² + ... + 10² = 385.
 
-Hence the difference between the square of the sum of the first
-ten natural numbers and the sum of the squares of the first ten
-natural numbers is 3025 - 385 = 2640.
+Hence the difference between the square of the sum of the first ten natural numbers and the sum of the squares of the first ten natural numbers is 3025 - 385 = 2640.
 
-You are not expected to discover an efficient solution to this yourself from
-first principles; research is allowed, indeed, encouraged. Finding the best
-algorithm for the problem is a key skill in software engineering.
+You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
+Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -7,7 +7,8 @@
     "kytrinyx",
     "lafent",
     "petemcfarlane",
-    "Scientifica96"
+    "Scientifica96",
+    "mk-mxp"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/difference-of-squares/.meta/example.php
+++ b/exercises/practice/difference-of-squares/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 function squareOfSum($max)

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -9,46 +9,82 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
         require_once 'DifferenceOfSquares.php';
     }
 
+    /**
+     * uuid 9b3f96cb-638d-41ee-99b7-b4f9c0622948
+     * @testdox Square of sum 5
+     */
     public function testSquareOfSumTo5(): void
     {
         $this->assertEquals(225, squareOfSum(5));
     }
 
+    /**
+     * uuid c93900cd-8cc2-4ca4-917b-dd3027023499
+     * @testdox Sum of squares 5
+     */
     public function testSumOfSquaresTo5(): void
     {
         $this->assertEquals(55, sumOfSquares(5));
     }
 
+    /**
+     * uuid 005cb2bf-a0c8-46f3-ae25-924029f8b00b
+     * @testdox Difference of squares 5
+     */
     public function testDifferenceOfSumTo5(): void
     {
         $this->assertEquals(170, difference(5));
     }
 
-    public function testSquareOfSumTo10(): void
+    /**
+     * uuid e46c542b-31fc-4506-bcae-6b62b3268537
+     * @testdox Square of sum 1
+     */
+    public function testSquareOfSumTo1(): void
     {
-        $this->assertEquals(3025, squareOfSum(10));
+        $this->assertEquals(1, squareOfSum(1));
     }
 
-    public function testSumOfSquaresTo10(): void
+    /**
+     * uuid 01d84507-b03e-4238-9395-dd61d03074b5
+     * @testdox Sum of squares 1
+     */
+    public function testSumOfSquaresTo1(): void
     {
-        $this->assertEquals(385, sumOfSquares(10));
+        $this->assertEquals(1, sumOfSquares(1));
     }
 
-    public function testDifferenceOfSumTo10(): void
+    /**
+     * uuid 44f72ae6-31a7-437f-858d-2c0837adabb6
+     * @testdox Difference of squares 1
+     */
+    public function testDifferenceOfSumTo1(): void
     {
-        $this->assertEquals(2640, difference(10));
+        $this->assertEquals(0, difference(1));
     }
 
+    /**
+     * uuid 54ba043f-3c35-4d43-86ff-3a41625d5e86
+     * @testdox Square of sum 100
+     */
     public function testSquareOfSumTo100(): void
     {
         $this->assertEquals(25502500, squareOfSum(100));
     }
 
+    /**
+     * uuid 94807386-73e4-4d9e-8dec-69eb135b19e4
+     * @testdox Sum of squares 100
+     */
     public function testSumOfSquaresTo100(): void
     {
         $this->assertEquals(338350, sumOfSquares(100));
     }
 
+    /**
+     * uuid b1bf19de-9a16-41c0-a62b-1f02ecc0b036
+     * @testdox Difference of squares 100
+     */
     public function testDifferenceOfSumTo100(): void
     {
         $this->assertEquals(25164150, difference(100));

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -10,33 +10,6 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * uuid 9b3f96cb-638d-41ee-99b7-b4f9c0622948
-     * @testdox Square of sum 5
-     */
-    public function testSquareOfSumTo5(): void
-    {
-        $this->assertEquals(225, squareOfSum(5));
-    }
-
-    /**
-     * uuid c93900cd-8cc2-4ca4-917b-dd3027023499
-     * @testdox Sum of squares 5
-     */
-    public function testSumOfSquaresTo5(): void
-    {
-        $this->assertEquals(55, sumOfSquares(5));
-    }
-
-    /**
-     * uuid 005cb2bf-a0c8-46f3-ae25-924029f8b00b
-     * @testdox Difference of squares 5
-     */
-    public function testDifferenceOfSumTo5(): void
-    {
-        $this->assertEquals(170, difference(5));
-    }
-
-    /**
      * uuid e46c542b-31fc-4506-bcae-6b62b3268537
      * @testdox Square of sum 1
      */
@@ -46,21 +19,12 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * uuid 01d84507-b03e-4238-9395-dd61d03074b5
-     * @testdox Sum of squares 1
+     * uuid 9b3f96cb-638d-41ee-99b7-b4f9c0622948
+     * @testdox Square of sum 5
      */
-    public function testSumOfSquaresTo1(): void
+    public function testSquareOfSumTo5(): void
     {
-        $this->assertEquals(1, sumOfSquares(1));
-    }
-
-    /**
-     * uuid 44f72ae6-31a7-437f-858d-2c0837adabb6
-     * @testdox Difference of squares 1
-     */
-    public function testDifferenceOfSumTo1(): void
-    {
-        $this->assertEquals(0, difference(1));
+        $this->assertEquals(225, squareOfSum(5));
     }
 
     /**
@@ -73,12 +37,48 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * uuid 01d84507-b03e-4238-9395-dd61d03074b5
+     * @testdox Sum of squares 1
+     */
+    public function testSumOfSquaresTo1(): void
+    {
+        $this->assertEquals(1, sumOfSquares(1));
+    }
+
+    /**
+     * uuid c93900cd-8cc2-4ca4-917b-dd3027023499
+     * @testdox Sum of squares 5
+     */
+    public function testSumOfSquaresTo5(): void
+    {
+        $this->assertEquals(55, sumOfSquares(5));
+    }
+
+    /**
      * uuid 94807386-73e4-4d9e-8dec-69eb135b19e4
      * @testdox Sum of squares 100
      */
     public function testSumOfSquaresTo100(): void
     {
         $this->assertEquals(338350, sumOfSquares(100));
+    }
+
+    /**
+     * uuid 44f72ae6-31a7-437f-858d-2c0837adabb6
+     * @testdox Difference of squares 1
+     */
+    public function testDifferenceOfSumTo1(): void
+    {
+        $this->assertEquals(0, difference(1));
+    }
+
+    /**
+     * uuid 005cb2bf-a0c8-46f3-ae25-924029f8b00b
+     * @testdox Difference of squares 5
+     */
+    public function testDifferenceOfSumTo5(): void
+    {
+        $this->assertEquals(170, difference(5));
     }
 
     /**

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase


### PR DESCRIPTION
This will be the `#48in24` exercise on 2024-04-16. Important files changed, but re-running tests on submitted student code not required.

- Tests included input "10", problem spec had input "1" instead. As the problem is linear, only cheating solutions would fail the changed test suite.
- Test ordered according to problem spec order.

Closes #676