### PR TITLE
Test timeout issues

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -58,7 +58,7 @@ function test {
     cp "${exercise_dir}/.meta/${example_file}" "${outdir}/${exercise_file}.${file_ext}"
   fi
 
-  eval "${PHPUNIT_BIN}" --default-time-limit 7 --enforce-time-limit --fail-on-risky --no-configuration "${outdir}/${test_file}"
+  eval "${PHPUNIT_BIN}" --default-time-limit 20 --enforce-time-limit --fail-on-risky --no-configuration "${outdir}/${test_file}"
 }
 
 function installed {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -58,7 +58,7 @@ function test {
     cp "${exercise_dir}/.meta/${example_file}" "${outdir}/${exercise_file}.${file_ext}"
   fi
 
-  eval "${PHPUNIT_BIN}" --no-configuration "${outdir}/${test_file}"
+  eval "${PHPUNIT_BIN}" --default-time-limit 7 --enforce-time-limit --fail-on-risky --no-configuration "${outdir}/${test_file}"
 }
 
 function installed {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -58,7 +58,23 @@ function test {
     cp "${exercise_dir}/.meta/${example_file}" "${outdir}/${exercise_file}.${file_ext}"
   fi
 
-  eval "${PHPUNIT_BIN}" --default-time-limit 20 --enforce-time-limit --fail-on-risky --no-configuration "${outdir}/${test_file}"
+  # The time-limit `18` is based on an approximation of the performance.
+  # Online Test Runner is appr. 3x faster than GitHub CI on Ubuntu.
+  #
+  # The total runtime limit of the Online Test Runner is 20 seconds including
+  # Docker container launch and processing the results. That leaves appr. 18
+  # seconds for all tests of an exercise. But that's not the `18` here.
+  #
+  # The longest running exercise tests in CI are in `alphametics`. It has 3 slow
+  # test cases (9 letters and 10 letters) that require appr. 15 secs each in CI
+  # and appr. 5 seconds each in the Online Test Runner.
+  #
+  # Putting that together gives a max. of 6 seconds for each of the slow test
+  # cases in the Online Test Runner before hitting the timeout in production
+  # -> use 3x 6secs = 18 seconds as a CI limit to ensure tests can actually
+  # be run in production.
+  # See: https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8
+  eval "${PHPUNIT_BIN}" --default-time-limit 18 --enforce-time-limit --fail-on-risky --no-configuration "${outdir}/${test_file}"
 }
 
 function installed {

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -58,16 +58,17 @@ function test {
     cp "${exercise_dir}/.meta/${example_file}" "${outdir}/${exercise_file}.${file_ext}"
   fi
 
-  # The time-limit `54` is based on an approximation of the performance.
-  # Online Test Runner is appr. 3x faster than GitHub CI on Ubuntu.
+  # `54s` timeout is an approximation to ensure the tests will not timeont in Exercism Test Runner.
   #
-  # The total runtime limit of the Online Test Runner is 20 seconds including
-  # Docker container launch and processing the results. That leaves appr. 18
-  # seconds for all tests of an exercise.
+  # 1. Exercism Test Runner is around 3 times faster than GitHub CI on Ubuntu.
+  #    See: https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8
+  # 2. Exercism Test Runner should complete in 20s and involves:
+  #    - Starting Docker container (~1s)
+  #    - Running the test suite
+  #    - Processing the results (~1s)
   #
-  # Putting that together gives a max. of 18 seconds x3 = 54 seconds for any
-  # test class in CI.
-  # See: https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8
+  # This gives 18s maximum for the test suite to run in the Exercism Test Runner.
+  # Hence the test suite should complete in less than 18s x 3 = 54s in GitHub CI on Ubuntu.
   timeout 54s "${PHPUNIT_BIN}" --no-configuration "${outdir}/${test_file}"
 }
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -58,23 +58,17 @@ function test {
     cp "${exercise_dir}/.meta/${example_file}" "${outdir}/${exercise_file}.${file_ext}"
   fi
 
-  # The time-limit `18` is based on an approximation of the performance.
+  # The time-limit `54` is based on an approximation of the performance.
   # Online Test Runner is appr. 3x faster than GitHub CI on Ubuntu.
   #
   # The total runtime limit of the Online Test Runner is 20 seconds including
   # Docker container launch and processing the results. That leaves appr. 18
-  # seconds for all tests of an exercise. But that's not the `18` here.
+  # seconds for all tests of an exercise.
   #
-  # The longest running exercise tests in CI are in `alphametics`. It has 3 slow
-  # test cases (9 letters and 10 letters) that require appr. 15 secs each in CI
-  # and appr. 5 seconds each in the Online Test Runner.
-  #
-  # Putting that together gives a max. of 6 seconds for each of the slow test
-  # cases in the Online Test Runner before hitting the timeout in production
-  # -> use 3x 6secs = 18 seconds as a CI limit to ensure tests can actually
-  # be run in production.
+  # Putting that together gives a max. of 18 seconds x3 = 54 seconds for any
+  # test class in CI.
   # See: https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8
-  eval "${PHPUNIT_BIN}" --default-time-limit 18 --enforce-time-limit --fail-on-risky --no-configuration "${outdir}/${test_file}"
+  timeout 54s "${PHPUNIT_BIN}" --no-configuration "${outdir}/${test_file}"
 }
 
 function installed {

--- a/exercises/practice/robot-name/RobotNameTest.php
+++ b/exercises/practice/robot-name/RobotNameTest.php
@@ -73,18 +73,34 @@ class RobotNameTest extends PHPUnit\Framework\TestCase
         $this->assertMatchesRegularExpression('/\w{2}\d{3}/', $name2);
     }
 
+    /**
+     * PHPUnit ^10.5 has an issue with
+     *   $this->assertArrayNotHasKey($name, $names, sprintf...
+     * that leads to test timeouts. This is fixed in PHPUnit ^11.
+     * Revert workaround
+     *   $this->assertFalse(isset($names[$name]), sprintf...
+     * when upgrading.
+     */
     public function testNameArentRecycled(): void
     {
         $names = [];
 
         for ($i = 0; $i < 10000; $i++) {
             $name = $this->robot->getName();
-            $this->assertArrayNotHasKey($name, $names, sprintf('Name %s reissued after Reset.', $name));
+            $this->assertFalse(isset($names[$name]), sprintf('Name %s reissued after Reset.', $name));
             $names[$name] = true;
             $this->robot->reset();
         }
     }
 
+    /**
+     * PHPUnit ^10.5 has an issue with
+     *   $this->assertArrayNotHasKey($name, $names, sprintf...
+     * that leads to test timeouts. This is fixed in PHPUnit ^11.
+     * Revert workaround
+     *   $this->assertFalse(isset($names[$name]), sprintf...
+     * when upgrading.
+     */
     // This test is optional.
     public function testNameUniquenessManyRobots(): void
     {
@@ -92,7 +108,7 @@ class RobotNameTest extends PHPUnit\Framework\TestCase
 
         for ($i = 0; $i < 10000; $i++) {
             $name = (new Robot())->getName();
-            $this->assertArrayNotHasKey($name, $names, sprintf('Name %s reissued after %d robots', $name, $i));
+            $this->assertFalse(isset($names[$name]), sprintf('Name %s reissued after %d robots', $name, $i));
             $names[$name] = true;
         }
     }


### PR DESCRIPTION
## PHPUnit 10.5 `assertArrayNotHasKey()`

PHPUnit `^10.3` has an issue with `assertArrayNotHasKey()`. Only this (and the opposite `assertArrayHasKey()`) are affected. The issue is not listed in PHPUnit's issue list / mentioned in Pull Requests, but the issue is gone in `11.0.0`.

This contains a workaround for this and enables upgrading to PHPUnit 10.5. I replaced that assertion with a functionally equivalent one, but that prints some misleading output in addition to the helpful message. So it should be reverted when upgrading to PHPUnit 11.

## CI limit for test runtime

I also added a time limit of 18 (lowest value possible on my machine with equal performance to Online Test Runner) x 3 (to compensate lower CI performance) = 54 seconds for each exercise test class using `timeout` command. This should prevent running into performance degradation issues in the future.

As [discussed in the forum](https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536) there is no recommendation or guiding data for such a limit. Only guesses about "test runner is expected to be slower than GitHub CI". But the production limit of 20 seconds exists and is enforced. So I took a guess [based on my measurements](https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8).

Part of #652 