### PR TITLE
Sync pangram

### DIFF
--- a/exercises/practice/pangram/.docs/instructions.md
+++ b/exercises/practice/pangram/.docs/instructions.md
@@ -5,4 +5,4 @@ Your task is to figure out if a sentence is a pangram.
 A pangram is a sentence using every letter of the alphabet at least once.
 It is case insensitive, so it doesn't matter if a letter is lower-case (e.g. `k`) or upper-case (e.g. `K`).
 
-For this exercise we only use the basic letters used in the English alphabet: `a` to `z`.
+For this exercise, a sentence is a pangram if it contains each of the 26 letters in the English alphabet.

--- a/exercises/practice/pangram/.meta/example.php
+++ b/exercises/practice/pangram/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 function isPangram($string)

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
@@ -31,3 +38,8 @@ description = "mixed case and punctuation"
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
+include = false
+
+[7138e389-83e4-4c6e-8413-1e40a0076951]
+description = "a-m and A-M are 26 different characters but not a pangram"
+reimplements = "2577bf54-83c8-402d-a64b-a2c0f7bb213a"

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -11,7 +11,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 64f61791-508e-4f5c-83ab-05de042b0149
-     * @testdox empty sentence
+     * @testdox Empty sentence
      */
     public function testSentenceEmpty(): void
     {
@@ -20,7 +20,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 74858f80-4a4d-478b-8a5e-c6477e4e4e84
-     * @testdox perfect lower case
+     * @testdox Perfect lower case
      */
     public function testPerfectLowerCase(): void
     {
@@ -29,7 +29,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 61288860-35ca-4abe-ba08-f5df76ecbdcd
-     * @testdox only lower case
+     * @testdox Only lower case
      */
     public function testPangramWithOnlyLowerCase(): void
     {
@@ -38,7 +38,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6564267d-8ac5-4d29-baf2-e7d2e304a743
-     * @testdox missing the letter 'x'
+     * @testdox Missing the letter 'x'
      */
     public function testMissingCharacterX(): void
     {
@@ -47,7 +47,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0
-     * @testdox missing the letter 'h'
+     * @testdox Missing the letter 'h'
      */
     public function testMissingCharacterH(): void
     {
@@ -56,7 +56,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d835ec38-bc8f-48e4-9e36-eb232427b1df
-     * @testdox with underscores
+     * @testdox With underscores
      */
     public function testPangramWithUnderscores(): void
     {
@@ -65,7 +65,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8cc1e080-a178-4494-b4b3-06982c9be2a8
-     * @testdox with numbers
+     * @testdox With numbers
      */
     public function testPangramWithNumbers(): void
     {
@@ -74,7 +74,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bed96b1c-ff95-45b8-9731-fdbdcb6ede9a
-     * @testdox missing letters replaced by numbers
+     * @testdox Missing letters replaced by numbers
      */
     public function testMissingLettersReplacedByNumbers(): void
     {
@@ -83,7 +83,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 938bd5d8-ade5-40e2-a2d9-55a338a01030
-     * @testdox mixed case and punctuation
+     * @testdox Mixed case and punctuation
      */
     public function testPangramWithMixedCaseAndPunctuation(): void
     {

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -9,53 +9,105 @@ class PangramTest extends PHPUnit\Framework\TestCase
         require_once 'Pangram.php';
     }
 
+    /**
+     * uuid 64f61791-508e-4f5c-83ab-05de042b0149
+     * @testdox empty sentence
+     */
     public function testSentenceEmpty(): void
     {
         $this->assertFalse(isPangram(''));
     }
 
+    /**
+     * uuid 74858f80-4a4d-478b-8a5e-c6477e4e4e84
+     * @testdox perfect lower case
+     */
+    public function testPerfectLowerCase(): void
+    {
+        $this->assertTrue(isPangram('abcdefghijklmnopqrstuvwxyz'));
+    }
+
+    /**
+     * uuid 61288860-35ca-4abe-ba08-f5df76ecbdcd
+     * @testdox only lower case
+     */
     public function testPangramWithOnlyLowerCase(): void
     {
         $this->assertTrue(isPangram('the quick brown fox jumps over the lazy dog'));
     }
 
+    /**
+     * uuid 6564267d-8ac5-4d29-baf2-e7d2e304a743
+     * @testdox missing the letter 'x'
+     */
     public function testMissingCharacterX(): void
     {
         $this->assertFalse(isPangram('a quick movement of the enemy will jeopardize five gunboats'));
     }
 
-    public function testAnotherMissingCharacterX(): void
+    /**
+     * uuid c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0
+     * @testdox missing the letter 'h'
+     */
+    public function testMissingCharacterH(): void
     {
-        $this->assertFalse(isPangram('the quick brown fish jumps over the lazy dog'));
+        $this->assertFalse(isPangram('five boxing wizards jump quickly at it'));
     }
 
+    /**
+     * uuid d835ec38-bc8f-48e4-9e36-eb232427b1df
+     * @testdox with underscores
+     */
     public function testPangramWithUnderscores(): void
     {
         $this->assertTrue(isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog'));
     }
 
+    /**
+     * uuid 8cc1e080-a178-4494-b4b3-06982c9be2a8
+     * @testdox with numbers
+     */
     public function testPangramWithNumbers(): void
     {
         $this->assertTrue(isPangram('the 1 quick brown fox jumps over the 2 lazy dogs'));
     }
 
+    /**
+     * uuid bed96b1c-ff95-45b8-9731-fdbdcb6ede9a
+     * @testdox missing letters replaced by numbers
+     */
     public function testMissingLettersReplacedByNumbers(): void
     {
         $this->assertFalse(isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog'));
     }
 
+    /**
+     * uuid 938bd5d8-ade5-40e2-a2d9-55a338a01030
+     * @testdox mixed case and punctuation
+     */
     public function testPangramWithMixedCaseAndPunctuation(): void
     {
-        $this->assertTrue(isPangram('\Five quacking Zephyrs jolt my wax bed.\\'));
+        $this->assertTrue(isPangram('"Five quacking Zephyrs jolt my wax bed."'));
     }
 
-    public function testPangramWithNonAsciiCharacters(): void
+    /**
+     * uuid 7138e389-83e4-4c6e-8413-1e40a0076951
+     * @testdox a-m and A-M are 26 different characters but not a pangram
+     */
+    public function testEnoughDifferentCharsButOnlyCaseDiffers(): void
+    {
+        $this->assertFalse(isPangram('abcdefghijklm ABCDEFGHIJKLM'));
+    }
+
+    /*
+     * PHP track addons
+     */
+
+    /**
+     * @testdox Unicode mixed into pangram
+     */
+    public function testPangramMixedWithUnicode(): void
     {
         $this->assertTrue(isPangram('Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.'));
-    }
-
-    public function testMissingLetterReplacedWithUpperCaseCharacter(): void
-    {
-        $this->assertFalse(isPangram("Tthe quick brown fo jumps over the lazy dog"));
     }
 }

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class PangramTest extends PHPUnit\Framework\TestCase


### PR DESCRIPTION
This will be the `#48in24` exercise on 2024-04-23. Important files changed, but re-running tests on submitted student code not required.

- Tests included test cases that were not in the problem spec, but only doubled existing other tests. These were removed.
- Tests from problem spec were missing, those were added.
- I kept the unicode test, which is not in problem spec but inline with the instructions.
- Test ordered according to problem spec order.

Closes #677 