### PR TITLE
Deprecate scale-generator

### DIFF
--- a/config.json
+++ b/config.json
@@ -1127,6 +1127,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
+        "status": "deprecated",
         "topics": [
           "conditionals",
           "strings"


### PR DESCRIPTION
The exercise was deprecated in problem specifications due to understandability issues. As shown in the documentation, nothing changes for students that already did the exercise.

Replaces #585