### PR TITLE
CI must fail on failing tests, MacOS has no `timeout`

### DIFF
--- a/.github/workflows/exercise-tests-phpunit-10.yml
+++ b/.github/workflows/exercise-tests-phpunit-10.yml
@@ -38,7 +38,6 @@ jobs:
           chmod +x bin/phpunit-10.phar
 
       - name: Test exercises
-        continue-on-error: true
         shell: bash
         env:
           PHPUNIT_BIN: 'bin/phpunit-10.phar'

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -58,18 +58,7 @@ function test {
     cp "${exercise_dir}/.meta/${example_file}" "${outdir}/${exercise_file}.${file_ext}"
   fi
 
-  # `54s` timeout is an approximation to ensure the tests will not timeont in Exercism Test Runner.
-  #
-  # 1. Exercism Test Runner is around 3 times faster than GitHub CI on Ubuntu.
-  #    See: https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8
-  # 2. Exercism Test Runner should complete in 20s and involves:
-  #    - Starting Docker container (~1s)
-  #    - Running the test suite
-  #    - Processing the results (~1s)
-  #
-  # This gives 18s maximum for the test suite to run in the Exercism Test Runner.
-  # Hence the test suite should complete in less than 18s x 3 = 54s in GitHub CI on Ubuntu.
-  timeout 54s "${PHPUNIT_BIN}" --no-configuration "${outdir}/${test_file}"
+  ${PHPUNIT_BIN} --no-configuration "${outdir}/${test_file}"
 }
 
 function installed {
@@ -93,6 +82,21 @@ deps=(curl "${PHPUNIT_BIN}")
 for dep in "${deps[@]}"; do
   installed "${dep}" || die "Missing '${dep}'"
 done
+
+# `54s` timeout is an approximation to ensure the tests will not timeont in Exercism Test Runner.
+#
+# 1. Exercism Test Runner is around 3 times faster than GitHub CI on Ubuntu.
+#    See: https://forum.exercism.org/t/test-tracks-for-the-20-seconds-limit-on-test-runners/10536/8
+# 2. Exercism Test Runner should complete in 20s and involves:
+#    - Starting Docker container (~1s)
+#    - Running the test suite
+#    - Processing the results (~1s)
+#
+# This gives 18s maximum for the test suite to run in the Exercism Test Runner.
+# Hence the test suite should complete in less than 18s x 3 = 54s in GitHub CI on Ubuntu.
+[ -f /etc/os-release ] && grep -q "ubuntu" /etc/os-release && {
+    PHPUNIT_BIN="timeout 54s ${PHPUNIT_BIN}"
+}
 
 main "$@"
 


### PR DESCRIPTION
For testing with PHPUnit 10 we allowed the CI to fail in that workflow. And when putting that into production, it was overlooked to make the workflow fail again.

This hid the fact, that MacOS has no `timeout` installed. I chose to use `timeout` for Ubuntu only, as I don't want to silently skip `timeout` in all CI images.

Closes #721 