### PR TITLE
Sync space age

### DIFF
--- a/exercises/practice/space-age/.docs/instructions.md
+++ b/exercises/practice/space-age/.docs/instructions.md
@@ -1,18 +1,28 @@
 # Instructions
 
-Given an age in seconds, calculate how old someone would be on:
+Given an age in seconds, calculate how old someone would be on a planet in our Solar System.
 
-   - Mercury: orbital period 0.2408467 Earth years
-   - Venus: orbital period 0.61519726 Earth years
-   - Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
-   - Mars: orbital period 1.8808158 Earth years
-   - Jupiter: orbital period 11.862615 Earth years
-   - Saturn: orbital period 29.447498 Earth years
-   - Uranus: orbital period 84.016846 Earth years
-   - Neptune: orbital period 164.79132 Earth years
+One Earth year equals 365.25 Earth days, or 31,557,600 seconds.
+If you were told someone was 1,000,000,000 seconds old, their age would be 31.69 Earth-years.
 
-So if you were told someone were 1,000,000,000 seconds old, you should
-be able to say that they're 31.69 Earth-years old.
+For the other planets, you have to account for their orbital period in Earth Years:
 
-If you're wondering why Pluto didn't make the cut, go watch [this
-youtube video](https://www.youtube.com/watch?v=Z_2gbGXzFbs).
+| Planet  | Orbital period in Earth Years |
+| ------- | ----------------------------- |
+| Mercury | 0.2408467                     |
+| Venus   | 0.61519726                    |
+| Earth   | 1.0                           |
+| Mars    | 1.8808158                     |
+| Jupiter | 11.862615                     |
+| Saturn  | 29.447498                     |
+| Uranus  | 84.016846                     |
+| Neptune | 164.79132                     |
+
+~~~~exercism/note
+The actual length of one complete orbit of the Earth around the sun is closer to 365.256 days (1 sidereal year).
+The Gregorian calendar has, on average, 365.2425 days.
+While not entirely accurate, 365.25 is the value used in this exercise.
+See [Year on Wikipedia][year] for more ways to measure a year.
+
+[year]: https://en.wikipedia.org/wiki/Year#Summary
+~~~~

--- a/exercises/practice/space-age/.docs/introduction.md
+++ b/exercises/practice/space-age/.docs/introduction.md
@@ -1,0 +1,20 @@
+# Introduction
+
+The year is 2525 and you've just embarked on a journey to visit all planets in the Solar System (Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus and Neptune).
+The first stop is Mercury, where customs require you to fill out a form (bureaucracy is apparently _not_ Earth-specific).
+As you hand over the form to the customs officer, they scrutinize it and frown.
+"Do you _really_ expect me to believe you're just 50 years old?
+You must be closer to 200 years old!"
+
+Amused, you wait for the customs officer to start laughing, but they appear to be dead serious.
+You realize that you've entered your age in _Earth years_, but the officer expected it in _Mercury years_!
+As Mercury's orbital period around the sun is significantly shorter than Earth, you're actually a lot older in Mercury years.
+After some quick calculations, you're able to provide your age in Mercury Years.
+The customs officer smiles, satisfied, and waves you through.
+You make a mental note to pre-calculate your planet-specific age _before_ future customs checks, to avoid such mix-ups.
+
+~~~~exercism/note
+If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
+
+[pluto-video]: https://www.youtube.com/watch?v=Z_2gbGXzFbs
+~~~~

--- a/exercises/practice/space-age/.meta/example.php
+++ b/exercises/practice/space-age/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class SpaceAge

--- a/exercises/practice/space-age/.meta/example.php
+++ b/exercises/practice/space-age/.meta/example.php
@@ -20,11 +20,6 @@ class SpaceAge
         $this->seconds = $seconds;
     }
 
-    public function seconds()
-    {
-        return $this->seconds;
-    }
-
     public function earth()
     {
         return $this->seconds / self::EARTH_YEAR_IN_SECONDS;

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [84f609af-5a91-4d68-90a3-9e32d8a5cd34]
 description = "age on Earth"
@@ -25,3 +32,7 @@ description = "age on Uranus"
 
 [80096d30-a0d4-4449-903e-a381178355d8]
 description = "age on Neptune"
+
+[57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
+description = "invalid planet causes error"
+include = false

--- a/exercises/practice/space-age/SpaceAge.php
+++ b/exercises/practice/space-age/SpaceAge.php
@@ -31,11 +31,6 @@ class SpaceAge
         throw new \BadMethodCallException("Implement the __construct method");
     }
 
-    public function seconds(): int
-    {
-        throw new \BadMethodCallException("Implement the seconds method");
-    }
-
     public function earth(): float
     {
         throw new \BadMethodCallException("Implement the earth method");

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -11,12 +11,6 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     public const DELTA = 0.01;
 
-    public function testAgeInSeconds(): void
-    {
-        $age = new SpaceAge(1000000);
-        $this->assertEquals(1000000, $age->seconds());
-    }
-
     /**
      * uuid 84f609af-5a91-4d68-90a3-9e32d8a5cd34
      * @testdox Age on Earth

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -17,51 +17,83 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(1000000, $age->seconds());
     }
 
+    /**
+     * uuid 84f609af-5a91-4d68-90a3-9e32d8a5cd34
+     * @testdox Age on Earth
+     */
     public function testAgeOnEarth(): void
     {
         $age = new SpaceAge(1000000000);
         $this->assertEqualsWithDelta(31.69, $age->earth(), self::DELTA);
     }
 
+    /**
+     * uuid ca20c4e9-6054-458c-9312-79679ffab40b
+     * @testdox Age on Mercury
+     */
     public function testAgeOnMercury(): void
     {
         $age = new SpaceAge(2134835688);
         $this->assertEqualsWithDelta(280.88, $age->mercury(), self::DELTA);
     }
 
+    /**
+     * uuid 502c6529-fd1b-41d3-8fab-65e03082b024
+     * @testdox Age on Venus
+     */
     public function testAgeOnVenus(): void
     {
         $age = new SpaceAge(189839836);
         $this->assertEqualsWithDelta(9.78, $age->venus(), self::DELTA);
     }
 
+    /**
+     * uuid 9ceadf5e-a0d5-4388-9d40-2c459227ceb8
+     * @testdox Age on Mars
+     */
     public function testAgeOnMars(): void
     {
-        $age = new SpaceAge(2329871239);
-        $this->assertEqualsWithDelta(39.25, $age->mars(), self::DELTA);
+        $age = new SpaceAge(2129871239);
+        $this->assertEqualsWithDelta(35.88, $age->mars(), self::DELTA);
     }
 
+    /**
+     * uuid 42927dc3-fe5e-4f76-a5b5-f737fc19bcde
+     * @testdox Age on Jupiter
+     */
     public function testAgeOnJupiter(): void
     {
         $age = new SpaceAge(901876382);
         $this->assertEqualsWithDelta(2.41, $age->jupiter(), self::DELTA);
     }
 
+    /**
+     * uuid 8469b332-7837-4ada-b27c-00ee043ebcad
+     * @testdox Age on Saturn
+     */
     public function testAgeOnSaturn(): void
     {
-        $age = new SpaceAge(3000000000);
-        $this->assertEqualsWithDelta(3.23, $age->saturn(), self::DELTA);
+        $age = new SpaceAge(2000000000);
+        $this->assertEqualsWithDelta(2.15, $age->saturn(), self::DELTA);
     }
 
+    /**
+     * uuid 999354c1-76f8-4bb5-a672-f317b6436743
+     * @testdox Age on Uranus
+     */
     public function testAgeOnUranus(): void
     {
-        $age = new SpaceAge(3210123456);
-        $this->assertEqualsWithDelta(1.21, $age->uranus(), self::DELTA);
+        $age = new SpaceAge(1210123456);
+        $this->assertEqualsWithDelta(0.46, $age->uranus(), self::DELTA);
     }
 
+    /**
+     * uuid 80096d30-a0d4-4449-903e-a381178355d8
+     * @testdox Age on Neptune
+     */
     public function testAgeOnNeptune(): void
     {
-        $age = new SpaceAge(8210123456);
-        $this->assertEqualsWithDelta(1.58, $age->neptune(), self::DELTA);
+        $age = new SpaceAge(1821023456);
+        $this->assertEqualsWithDelta(0.35, $age->neptune(), self::DELTA);
     }
 }

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class SpaceAgeTest extends PHPUnit\Framework\TestCase


### PR DESCRIPTION
This will be the `#48in24` exercise on 2024-06-04. Important files changed, but re-running tests on submitted student code not required.

- Documentation sync'ed and checked for mismatches to track tests
- Tests sync'ed with the problem specs
- I did not add the test for a wrong planet, as that makes all existing solutions invalid
- Removed the test for internal storage of `seconds`, as that should not be tested for

Closes #713 