### PR TITLE
Sync roman-numerals

### DIFF
--- a/exercises/practice/roman-numerals/.meta/example.php
+++ b/exercises/practice/roman-numerals/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 function toRoman($number)

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,60 +1,91 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
-description = "1 is a single I"
+description = "1 is I"
 
 [f088f064-2d35-4476-9a41-f576da3f7b03]
-description = "2 is two I's"
+description = "2 is II"
 
 [b374a79c-3bea-43e6-8db8-1286f79c7106]
-description = "3 is three I's"
+description = "3 is III"
 
 [05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
-description = "4, being 5 - 1, is IV"
+description = "4 is IV"
 
 [57c0f9ad-5024-46ab-975d-de18c430b290]
-description = "5 is a single V"
+description = "5 is V"
 
 [20a2b47f-e57f-4797-a541-0b3825d7f249]
-description = "6, being 5 + 1, is VI"
+description = "6 is VI"
 
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
-description = "9, being 10 - 1, is IX"
+description = "9 is IX"
+
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
 
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
-description = "20 is two X's"
+description = "27 is XXVII"
 
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
-description = "48 is not 50 - 2 but rather 40 + 8"
+description = "48 is XLVIII"
 
 [607ead62-23d6-4c11-a396-ef821e2e5f75]
-description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
+description = "49 is XLIX"
 
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
-description = "50 is a single L"
+description = "59 is LIX"
+
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
 
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
-description = "90, being 100 - 10, is XC"
+description = "93 is XCIII"
 
 [30494be1-9afb-4f84-9d71-db9df18b55e3]
-description = "100 is a single C"
+description = "141 is CXLI"
 
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
-description = "60, being 50 + 10, is LX"
+description = "163 is CLXIII"
+
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
 
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
-description = "400, being 500 - 100, is CD"
+description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
-description = "500 is a single D"
+description = "575 is DLXXV"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
-description = "900, being 1000 - 100, is CM"
+description = "911 is CMXI"
 
 [e6de6d24-f668-41c0-88d7-889c0254d173]
-description = "1000 is a single M"
+description = "1024 is MXXIV"
+
+[efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
+description = "1666 is MDCLXVI"
 
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
-description = "3000 is three M's"
+description = "3000 is MMM"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -73,6 +73,15 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @testdox 16 is XVI
+     * uuid 6d1d82d5-bf3e-48af-9139-87d7165ed509
+     */
+    public function test16IsXVI(): void
+    {
+        $this->assertSame('XVI', toRoman(16));
+    }
+
+    /**
      * @testdox 27 is XXVII
      * uuid 2bda64ca-7d28-4c56-b08d-16ce65716cf6
      */
@@ -109,6 +118,15 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @testdox 66 is LXVI
+     * uuid 4465ffd5-34dc-44f3-ada5-56f5007b6dad
+     */
+    public function test66IsLXVI(): void
+    {
+        $this->assertSame('LXVI', toRoman(66));
+    }
+
+    /**
      * @testdox 93 is XCIII
      * uuid 46b46e5b-24da-4180-bfe2-2ef30b39d0d0
      */
@@ -136,6 +154,15 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @testdox 166 is CLXVI
+     * uuid 902ad132-0b4d-40e3-8597-ba5ed611dd8d
+     */
+    public function test166IsCLXVI(): void
+    {
+        $this->assertSame('CLXVI', toRoman(166));
+    }
+
+    /**
      * @testdox 402 is CDII
      * uuid cdb06885-4485-4d71-8bfb-c9d0f496b404
      */
@@ -151,6 +178,15 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
     public function test575IsDLXXV(): void
     {
         $this->assertSame('DLXXV', toRoman(575));
+    }
+
+    /**
+     * @testdox 666 is DCLXVI
+     * uuid dacb84b9-ea1c-4a61-acbb-ce6b36674906
+     */
+    public function test666IsDCLXVI(): void
+    {
+        $this->assertSame('DCLXVI', toRoman(666));
     }
 
     /**
@@ -172,11 +208,47 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @testdox 1666 is MDCLXVI
+     * uuid efbe1d6a-9f98-4eb5-82bc-72753e3ac328
+     */
+    public function test1666IsMDCLXVI(): void
+    {
+        $this->assertSame('MDCLXVI', toRoman(1666));
+    }
+
+    /**
      * @testdox 3000 is MMM
      * uuid bb550038-d4eb-4be2-a9ce-f21961ac3bc6
      */
     public function test3000IsMMM(): void
     {
         $this->assertSame('MMM', toRoman(3000));
+    }
+
+    /**
+     * @testdox 3001 is MMMI
+     * uuid 3bc4b41c-c2e6-49d9-9142-420691504336
+     */
+    public function test3001IsMMMI(): void
+    {
+        $this->assertSame('MMMI', toRoman(3001));
+    }
+
+    /**
+     * @testdox 3888 is MMMDCCCLXXXVIII
+     * uuid 2f89cad7-73f6-4d1b-857b-0ef531f68b7e
+     */
+    public function test3888IsMMMDCCCLXXXVIII(): void
+    {
+        $this->assertSame('MMMDCCCLXXXVIII', toRoman(3888));
+    }
+
+    /**
+     * @testdox 3999 is MMMCMXCIX
+     * uuid 4e18e96b-5fbb-43df-a91b-9cb511fe0856
+     */
+    public function test3999IsMMMCMXCIX(): void
+    {
+        $this->assertSame('MMMCMXCIX', toRoman(3999));
     }
 }

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class RomanNumeralsTest extends PHPUnit\Framework\TestCase
@@ -31,107 +9,173 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
         require_once 'RomanNumerals.php';
     }
 
-    public function test1(): void
+    /**
+     * @testdox 1 is I
+     * uuid 19828a3a-fbf7-4661-8ddd-cbaeee0e2178
+     */
+    public function test1IsI(): void
     {
         $this->assertSame('I', toRoman(1));
     }
 
-    public function test2(): void
+    /**
+     * @testdox 2 is II
+     * uuid f088f064-2d35-4476-9a41-f576da3f7b03
+     */
+    public function test2IsII(): void
     {
         $this->assertSame('II', toRoman(2));
     }
 
-    public function test3(): void
+    /**
+     * @testdox 3 is III
+     * uuid b374a79c-3bea-43e6-8db8-1286f79c7106
+     */
+    public function test3IsIII(): void
     {
         $this->assertSame('III', toRoman(3));
     }
 
-    public function test4(): void
+    /**
+     * @testdox 4 is IV
+     * uuid 05a0a1d4-a140-4db1-82e8-fcc21fdb49bb
+     */
+    public function test4IsIV(): void
     {
         $this->assertSame('IV', toRoman(4));
     }
 
-    public function test5(): void
+    /**
+     * @testdox 5 is V
+     * uuid 57c0f9ad-5024-46ab-975d-de18c430b290
+     */
+    public function test5IsV(): void
     {
         $this->assertSame('V', toRoman(5));
     }
 
-    public function test6(): void
+    /**
+     * @testdox 6 is VI
+     * uuid 20a2b47f-e57f-4797-a541-0b3825d7f249
+     */
+    public function test6IsVI(): void
     {
         $this->assertSame('VI', toRoman(6));
     }
 
-    public function test9(): void
+    /**
+     * @testdox 9 is IX
+     * uuid ff3fb08c-4917-4aab-9f4e-d663491d083d
+     */
+    public function test9IsIX(): void
     {
         $this->assertSame('IX', toRoman(9));
     }
 
-    public function test27(): void
+    /**
+     * @testdox 27 is XXVII
+     * uuid 2bda64ca-7d28-4c56-b08d-16ce65716cf6
+     */
+    public function test27IsXXVII(): void
     {
         $this->assertSame('XXVII', toRoman(27));
     }
 
-    public function test48(): void
+    /**
+     * @testdox 48 is XLVIII
+     * uuid a1f812ef-84da-4e02-b4f0-89c907d0962c
+     */
+    public function test48IsXLVIII(): void
     {
         $this->assertSame('XLVIII', toRoman(48));
     }
 
-    public function test49(): void
+    /**
+     * @testdox 49 is XLIX
+     * uuid 607ead62-23d6-4c11-a396-ef821e2e5f75
+     */
+    public function test49IsXLIX(): void
     {
         $this->assertSame('XLIX', toRoman(49));
     }
 
-    public function test59(): void
+    /**
+     * @testdox 59 is LIX
+     * uuid d5b283d4-455d-4e68-aacf-add6c4b51915
+     */
+    public function test59IsLIX(): void
     {
         $this->assertSame('LIX', toRoman(59));
     }
 
-    public function test93(): void
+    /**
+     * @testdox 93 is XCIII
+     * uuid 46b46e5b-24da-4180-bfe2-2ef30b39d0d0
+     */
+    public function test93IsXCIII(): void
     {
         $this->assertSame('XCIII', toRoman(93));
     }
 
-    public function test141(): void
+    /**
+     * @testdox 141 is CXLI
+     * uuid 30494be1-9afb-4f84-9d71-db9df18b55e3
+     */
+    public function test141IsCXLI(): void
     {
         $this->assertSame('CXLI', toRoman(141));
     }
 
-    public function test163(): void
+    /**
+     * @testdox 163 is CLXIII
+     * uuid 267f0207-3c55-459a-b81d-67cec7a46ed9
+     */
+    public function test163IsCLXIII(): void
     {
         $this->assertSame('CLXIII', toRoman(163));
     }
 
-    public function test402(): void
+    /**
+     * @testdox 402 is CDII
+     * uuid cdb06885-4485-4d71-8bfb-c9d0f496b404
+     */
+    public function test402IsCDII(): void
     {
         $this->assertSame('CDII', toRoman(402));
     }
 
-    public function test575(): void
+    /**
+     * @testdox 575 is DLXXV
+     * uuid 6b71841d-13b2-46b4-ba97-dec28133ea80
+     */
+    public function test575IsDLXXV(): void
     {
         $this->assertSame('DLXXV', toRoman(575));
     }
 
-    public function test911(): void
+    /**
+     * @testdox 911 is CMXI
+     * uuid 432de891-7fd6-4748-a7f6-156082eeca2f
+     */
+    public function test911IsCMXI(): void
     {
         $this->assertSame('CMXI', toRoman(911));
     }
 
-    public function test1024(): void
+    /**
+     * @testdox 1024 is MXXIV
+     * uuid e6de6d24-f668-41c0-88d7-889c0254d173
+     */
+    public function test1024IsMXXIV(): void
     {
         $this->assertSame('MXXIV', toRoman(1024));
     }
 
-    public function test1998(): void
-    {
-        $this->assertSame('MCMXCVIII', toRoman(1998));
-    }
-
-    public function test2999(): void
-    {
-        $this->assertSame('MMCMXCIX', toRoman(2999));
-    }
-
-    public function test3000(): void
+    /**
+     * @testdox 3000 is MMM
+     * uuid bb550038-d4eb-4be2-a9ce-f21961ac3bc6
+     */
+    public function test3000IsMMM(): void
     {
         $this->assertSame('MMM', toRoman(3000));
     }


### PR DESCRIPTION
https://github.com/exercism/php/issues/742

@mk-mxp 

I have removed strict type from the example and test cases file.

I also added `testdox` and `UUID` please take note that no new test cases are added and I removed 2 test cases that are not present in the `test.toml` file.

This below 2 functions are removed.
`test1998 , test2999`

