### PR TITLE
resistor-color-trio: sync

### DIFF
--- a/exercises/practice/resistor-color-trio/.docs/instructions.md
+++ b/exercises/practice/resistor-color-trio/.docs/instructions.md
@@ -1,27 +1,32 @@
 # Instructions
 
-If you want to build something using a Raspberry Pi, you'll probably use _resistors_. For this exercise, you need to know only three things about them:
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know only three things about them:
 
 - Each resistor has a resistance value.
 - Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
   To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
-- Each band acts as a digit of a number. For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
-  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands. The program will take 3 colors as input, and outputs the correct value, in ohms.
+- Each band acts as a digit of a number.
+  For example, if they printed a brown band (value 1) followed by a green band (value 5), it would translate to the number 15.
+  In this exercise, you are going to create a helpful program so that you don't have to remember the values of the bands.
+  The program will take 3 colors as input, and outputs the correct value, in ohms.
   The color bands are encoded as follows:
 
-- Black: 0
-- Brown: 1
-- Red: 2
-- Orange: 3
-- Yellow: 4
-- Green: 5
-- Blue: 6
-- Violet: 7
-- Grey: 8
-- White: 9
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
 
-In `resistor-color duo` you decoded the first two colors. For instance: orange-orange got the main value `33`.
-The third color stands for how many zeros need to be added to the main value. The main value plus the zeros gives us a value in ohms.
+In Resistor Color Duo you decoded the first two colors.
+For instance: orange-orange got the main value `33`.
+The third color stands for how many zeros need to be added to the main value.
+The main value plus the zeros gives us a value in ohms.
 For the exercise it doesn't matter what ohms really are.
 For example:
 
@@ -29,7 +34,9 @@ For example:
 - orange-orange-red would be 33 and 2 zeros, which becomes 3300 ohms.
 - orange-orange-orange would be 33 and 3 zeros, which becomes 33000 ohms.
 
-(If Math is your thing, you may want to think of the zeros as exponents of 10. If Math is not your thing, go with the zeros. It really is the same thing, just in plain English instead of Math lingo.)
+(If Math is your thing, you may want to think of the zeros as exponents of 10.
+If Math is not your thing, go with the zeros.
+It really is the same thing, just in plain English instead of Math lingo.)
 
 This exercise is about translating the colors into a label:
 
@@ -39,7 +46,9 @@ So an input of `"orange", "orange", "black"` should return:
 
 > "33 ohms"
 
-When we get to larger resistors, a [metric prefix][metric-prefix] is used to indicate a larger magnitude of ohms, such as "kiloohms". That is similar to saying "2 kilometers" instead of "2000 meters", or "2 kilograms" for "2000 grams".
+When we get to larger resistors, a [metric prefix][metric-prefix] is used to indicate a larger magnitude of ohms, such as "kiloohms".
+That is similar to saying "2 kilometers" instead of "2000 meters", or "2 kilograms" for "2000 grams".
+
 For example, an input of `"orange", "orange", "orange"` should return:
 
 > "33 kiloohms"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -13,5 +13,7 @@
       ".meta/example.php"
     ]
   },
-  "blurb": "Convert color codes, as used on resistors, to a human-readable label."
+  "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1549"
 }


### PR DESCRIPTION
Sync the `resistor-color-trio` exercise with the latest data, as defined in https://github.com/exercism/problem-specifications/tree/main/exercises/resistor-color-trio.

- Feel free to close this PR if there is another PR that also syncs this exercise.
- When approved, feel free to merge this PR yourselves (you don't have to wait for me).

As this PR only updates docs and/or metadata, it won't trigger a re-run of existing solutions (see [the docs](https://exercism.org/docs/building/tracks)).