### PR TITLE
Sync robot-simulator

### DIFF
--- a/config.json
+++ b/config.json
@@ -350,7 +350,7 @@
         "uuid": "cc6c3b27-b719-454c-a743-7bc73bd47cf1",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
+        "difficulty": 5,
         "topics": [
           "oop"
         ]

--- a/exercises/practice/robot-simulator/.docs/instructions.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.md
@@ -10,13 +10,10 @@ The robots have three possible movements:
 - turn left
 - advance
 
-Robots are placed on a hypothetical infinite grid, facing a particular
-direction (north, east, south, or west) at a set of {x,y} coordinates,
+Robots are placed on a hypothetical infinite grid, facing a particular direction (north, east, south, or west) at a set of {x,y} coordinates,
 e.g., {3,8}, with coordinates increasing to the north and east.
 
-The robot then receives a number of instructions, at which point the
-testing facility verifies the robot's new position, and in which
-direction it is pointing.
+The robot then receives a number of instructions, at which point the testing facility verifies the robot's new position, and in which direction it is pointing.
 
 - The letter-string "RAALAL" means:
   - Turn right
@@ -24,5 +21,5 @@ direction it is pointing.
   - Turn left
   - Advance once
   - Turn left yet again
-- Say a robot starts at {7, 3} facing north. Then running this stream
-  of instructions should leave it at {9, 4} facing west.
+- Say a robot starts at {7, 3} facing north.
+  Then running this stream of instructions should leave it at {9, 4} facing west.

--- a/exercises/practice/robot-simulator/.meta/design.md
+++ b/exercises/practice/robot-simulator/.meta/design.md
@@ -1,0 +1,36 @@
+# Design
+
+## Goal
+
+This exercise trains object oriented programming in PHP.
+The main aspect is data encapsulation.
+
+A robot is inherently stateful.
+This state shall be encapsulated as much as possible, but still must be accessible from the outside.
+Make students think about the many ways PHP supports doing this.
+
+## Learning objectives
+
+- Recognize the possibility to use constructor promotion
+- Recognize the getter method concept for data encapsulation
+- Know what `public`, `protected` and `private` properties are
+- Know how to implement getter methods, so internal data becomes
+  - readonly to the outside
+  - independent of interface contracts with the external world
+
+## Out of scope
+
+- Differences between `private` and `protected` properties
+
+## Prerequisites
+
+- We have no concept for OOP or data encapsulation, yet
+- Basic understanding of OOP and data encapsulation
+- Reading unit tests
+- Classes, properties and methods in PHP
+
+## Analyzer
+
+This exercise could benefit from the following rules added to a future analyzer:
+
+- To be defined

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -100,6 +100,16 @@ class RobotSimulator
         return $this;
     }
 
+    public function getPosition(): array
+    {
+        return $this->position;
+    }
+
+    public function getDirection(): string
+    {
+        return $this->direction;
+    }
+
     /**
      * List all possible clockwise turn combinations
      * @return array

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class Robot
+class RobotSimulator
 {
     public const DIRECTION_NORTH = 'north';
     public const DIRECTION_EAST = 'east';
@@ -41,9 +41,9 @@ class Robot
 
     /**
      * Turn the Robot clockwise
-     * @return Robot
+     * @return RobotSimulator
      */
-    public function turnRight(): \Robot
+    public function turnRight(): \RobotSimulator
     {
         $this->direction = self::listDirectionsClockwize()[$this->direction];
         return $this;
@@ -51,9 +51,9 @@ class Robot
 
     /**
      * Turn the Robot counterclockwise
-     * @return Robot
+     * @return RobotSimulator
      */
-    public function turnLeft(): \Robot
+    public function turnLeft(): \RobotSimulator
     {
         $this->direction = self::listDirectionsCounterClockwize()[$this->direction];
         return $this;
@@ -61,9 +61,9 @@ class Robot
 
     /**
      * Advance the Robot one step forward
-     * @return Robot
+     * @return RobotSimulator
      */
-    public function advance(): \Robot
+    public function advance(): \RobotSimulator
     {
         switch ($this->direction) {
             case self::DIRECTION_NORTH:

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -16,17 +16,18 @@ class RobotSimulator
     ) {
     }
 
-    /**
-     * Move the Robot according to instructions: R = Turn Right, L = Turn Left and A = Advance
-     */
     public function instructions(string $instructions): void
     {
         if (!preg_match('/^[LAR]+$/', $instructions)) {
             throw new InvalidArgumentException('Malformed instructions');
         }
 
-        foreach ($this->mapInstructionsToActions($instructions) as $action) {
-            $this->$action();
+        foreach (str_split($instructions) as $instruction) {
+            match ($instruction) {
+                'R' => $this->turnRight(),
+                'L' => $this->turnLeft(),
+                'A' => $this->advance(),
+            };
         }
     }
 
@@ -41,18 +42,6 @@ class RobotSimulator
         return $this->direction;
     }
 
-    /** @return string[] */
-    private function mapInstructionsToActions(string $instructions): array
-    {
-        return array_map(function ($x) {
-            return [
-                'L' => 'turnLeft',
-                'R' => 'turnRight',
-                'A' => 'advance',
-            ][$x];
-        }, str_split($instructions));
-    }
-
     private function turnRight(): void
     {
         $this->direction = $this->listDirectionsClockwize()[$this->direction];
@@ -65,23 +54,12 @@ class RobotSimulator
 
     private function advance(): void
     {
-        switch ($this->direction) {
-            case self::DIRECTION_NORTH:
-                $this->position[1]++;
-                break;
-
-            case self::DIRECTION_EAST:
-                $this->position[0]++;
-                break;
-
-            case self::DIRECTION_SOUTH:
-                $this->position[1]--;
-                break;
-
-            case self::DIRECTION_WEST:
-                $this->position[0]--;
-                break;
-        }
+        match ($this->direction) {
+            self::DIRECTION_NORTH => $this->position[1]++,
+            self::DIRECTION_EAST => $this->position[0]++,
+            self::DIRECTION_SOUTH => $this->position[1]--,
+            self::DIRECTION_WEST => $this->position[0]--,
+        };
     }
 
     /** @return Array<string, string> */

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -18,7 +18,7 @@ class RobotSimulator
 
     public function instructions(string $instructions): void
     {
-        if (!preg_match('/^[LAR]+$/', $instructions)) {
+        if (!preg_match('/^[RLA]+$/', $instructions)) {
             throw new InvalidArgumentException('Malformed instructions');
         }
 

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class Robot

--- a/exercises/practice/robot-simulator/.meta/example.php
+++ b/exercises/practice/robot-simulator/.meta/example.php
@@ -4,66 +4,66 @@ declare(strict_types=1);
 
 class RobotSimulator
 {
-    public const DIRECTION_NORTH = 'north';
-    public const DIRECTION_EAST = 'east';
-    public const DIRECTION_SOUTH = 'south';
-    public const DIRECTION_WEST = 'west';
+    private const DIRECTION_NORTH = 'north';
+    private const DIRECTION_EAST = 'east';
+    private const DIRECTION_SOUTH = 'south';
+    private const DIRECTION_WEST = 'west';
 
-    /**
-     *
-     * @var int[]
-     */
-    protected $position;
-
-    /**
-     *
-     * @var string
-     */
-    protected $direction;
-
-    public function __construct(array $position, string $direction)
-    {
-        $this->position = $position;
-        $this->direction = $direction;
+    /** @param int[] $position */
+    public function __construct(
+        private array $position,
+        private string $direction,
+    ) {
     }
 
     /**
-     * Make protected properties read-only.
-     * __get() is slow, but it's ok for the given task.
-     *
-     * @param string $name
-     * @return mixed
+     * Move the Robot according to instructions: R = Turn Right, L = Turn Left and A = Advance
      */
-    public function __get($name)
+    public function instructions(string $instructions): void
     {
-        return property_exists(self::class, $name) ? $this->$name : null;
+        if (!preg_match('/^[LAR]+$/', $instructions)) {
+            throw new InvalidArgumentException('Malformed instructions');
+        }
+
+        foreach ($this->mapInstructionsToActions($instructions) as $action) {
+            $this->$action();
+        }
     }
 
-    /**
-     * Turn the Robot clockwise
-     * @return RobotSimulator
-     */
-    public function turnRight(): \RobotSimulator
+    /** @return int[] */
+    public function getPosition(): array
     {
-        $this->direction = self::listDirectionsClockwize()[$this->direction];
-        return $this;
+        return $this->position;
     }
 
-    /**
-     * Turn the Robot counterclockwise
-     * @return RobotSimulator
-     */
-    public function turnLeft(): \RobotSimulator
+    public function getDirection(): string
     {
-        $this->direction = self::listDirectionsCounterClockwize()[$this->direction];
-        return $this;
+        return $this->direction;
     }
 
-    /**
-     * Advance the Robot one step forward
-     * @return RobotSimulator
-     */
-    public function advance(): \RobotSimulator
+    /** @return string[] */
+    private function mapInstructionsToActions(string $instructions): array
+    {
+        return array_map(function ($x) {
+            return [
+                'L' => 'turnLeft',
+                'R' => 'turnRight',
+                'A' => 'advance',
+            ][$x];
+        }, str_split($instructions));
+    }
+
+    private function turnRight(): void
+    {
+        $this->direction = $this->listDirectionsClockwize()[$this->direction];
+    }
+
+    private function turnLeft(): void
+    {
+        $this->direction = $this->listDirectionsCounterClockwize()[$this->direction];
+    }
+
+    private function advance(): void
     {
         switch ($this->direction) {
             case self::DIRECTION_NORTH:
@@ -82,39 +82,10 @@ class RobotSimulator
                 $this->position[0]--;
                 break;
         }
-        return $this;
     }
 
-    /**
-     * Move the Robot according to instructions: R = Turn Right, L = Turn Left and A = Advance
-     */
-    public function instructions($instructions)
-    {
-        if (!preg_match('/^[LAR]+$/', $instructions)) {
-            throw new InvalidArgumentException('Malformed instructions');
-        }
-
-        foreach ($this->mapInsructionsToActions($instructions) as $action) {
-            $this->$action();
-        }
-        return $this;
-    }
-
-    public function getPosition(): array
-    {
-        return $this->position;
-    }
-
-    public function getDirection(): string
-    {
-        return $this->direction;
-    }
-
-    /**
-     * List all possible clockwise turn combinations
-     * @return array
-     */
-    public static function listDirectionsClockwize(): array
+    /** @return Array<string, string> */
+    private function listDirectionsClockwize(): array
     {
         return [
             self::DIRECTION_NORTH => self::DIRECTION_EAST,
@@ -124,28 +95,9 @@ class RobotSimulator
         ];
     }
 
-    /**
-     * List all possible counterclockwise turn combinations
-     * @return array
-     */
-    public static function listDirectionsCounterClockwize(): array
+    /** @return Array<string, string> */
+    private function listDirectionsCounterClockwize(): array
     {
-        return array_flip(self::listDirectionsClockwize());
-    }
-
-    /**
-     * Translate instructions string to actions
-     * @param string $stringInstructions
-     * @return string[]
-     */
-    protected function mapInsructionsToActions($stringInstructions): array
-    {
-        return array_map(function ($x) {
-            return [
-                'L' => 'turnLeft',
-                'R' => 'turnRight',
-                'A' => 'advance',
-            ][$x];
-        }, str_split($stringInstructions));
+        return array_flip($this->listDirectionsClockwize());
     }
 }

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -26,20 +26,25 @@ declare(strict_types=1);
 
 class RobotSimulator
 {
-    /**
-     * @var int[]
-     */
-    protected array $position;
-
-    protected string $direction;
-
+    /** @param int[] $position */
     public function __construct(array $position, string $direction)
     {
-        throw new \BadMethodCallException("Implement the __construct method");
+        throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
     }
 
-    public function instructions(): void
+    public function instructions(string $instructions): void
     {
-        throw new \BadMethodCallException("Implement the instructions method");
+        throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
+    }
+
+    /** @return int[] */
+    public function getPosition(): array
+    {
+        throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
+    }
+
+    public function getDirection(): string
+    {
+        throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
     }
 }

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -27,34 +27,19 @@ declare(strict_types=1);
 class Robot
 {
     /**
-     *
      * @var int[]
      */
-    protected $position;
+    protected array $position;
 
-    /**
-     *
-     * @var string
-     */
-    protected $direction;
+    protected string $direction;
 
     public function __construct(array $position, string $direction)
     {
         throw new \BadMethodCallException("Implement the __construct method");
     }
 
-    public function turnRight(): self
+    public function instructions(): void
     {
-        throw new \BadMethodCallException("Implement the turnRight method");
-    }
-
-    public function turnLeft(): self
-    {
-        throw new \BadMethodCallException("Implement the turnLeft method");
-    }
-
-    public function advance(): self
-    {
-        throw new \BadMethodCallException("Implement the advance method");
+        throw new \BadMethodCallException("Implement the instructions method");
     }
 }

--- a/exercises/practice/robot-simulator/RobotSimulator.php
+++ b/exercises/practice/robot-simulator/RobotSimulator.php
@@ -24,7 +24,7 @@
 
 declare(strict_types=1);
 
-class Robot
+class RobotSimulator
 {
     /**
      * @var int[]

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -15,9 +15,9 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testCreateRobotAtOriginFacingNorth(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
+        $robot = new Robot([0, 0], 'north');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+        $this->assertEquals('north', $robot->direction);
     }
 
     /**
@@ -26,9 +26,9 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testCreateRobotAtNegativePositionFacingSouth(): void
     {
-        $robot = new Robot([-1, -1], Robot::DIRECTION_SOUTH);
+        $robot = new Robot([-1, -1], 'south');
         $this->assertEquals([-1, -1], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+        $this->assertEquals('south', $robot->direction);
     }
 
     /**
@@ -37,10 +37,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesNorthToEast(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
+        $robot = new Robot([0, 0], 'north');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_EAST, $robot->direction);
+        $this->assertEquals('east', $robot->direction);
     }
 
     /**
@@ -49,10 +49,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesEastToSouth(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_EAST);
+        $robot = new Robot([0, 0], 'east');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+        $this->assertEquals('south', $robot->direction);
     }
 
     /**
@@ -61,10 +61,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesSouthToWest(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_SOUTH);
+        $robot = new Robot([0, 0], 'south');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+        $this->assertEquals('west', $robot->direction);
     }
 
     /**
@@ -73,10 +73,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesWestToNorth(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_WEST);
+        $robot = new Robot([0, 0], 'west');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+        $this->assertEquals('north', $robot->direction);
     }
 
     /**
@@ -85,10 +85,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesNorthToWest(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
+        $robot = new Robot([0, 0], 'north');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+        $this->assertEquals('west', $robot->direction);
     }
 
     /**
@@ -97,10 +97,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesWestToSouth(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_WEST);
+        $robot = new Robot([0, 0], 'west');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+        $this->assertEquals('south', $robot->direction);
     }
 
     /**
@@ -109,10 +109,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesSouthToEast(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_SOUTH);
+        $robot = new Robot([0, 0], 'south');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_EAST, $robot->direction);
+        $this->assertEquals('east', $robot->direction);
     }
 
     /**
@@ -121,10 +121,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesEastToNorth(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_EAST);
+        $robot = new Robot([0, 0], 'east');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+        $this->assertEquals('north', $robot->direction);
     }
 
     /**
@@ -133,10 +133,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingNorthIncrementsY(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
+        $robot = new Robot([0, 0], 'north');
         $robot->instructions('A');
         $this->assertEquals([0, 1], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+        $this->assertEquals('north', $robot->direction);
     }
 
     /**
@@ -145,10 +145,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingSouthDecrementsY(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_SOUTH);
+        $robot = new Robot([0, 0], 'south');
         $robot->instructions('A');
         $this->assertEquals([0, -1], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+        $this->assertEquals('south', $robot->direction);
     }
 
     /**
@@ -157,10 +157,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingEastIncrementsX(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_EAST);
+        $robot = new Robot([0, 0], 'east');
         $robot->instructions('A');
         $this->assertEquals([1, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_EAST, $robot->direction);
+        $this->assertEquals('east', $robot->direction);
     }
 
     /**
@@ -169,10 +169,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingWestDecrementsX(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_WEST);
+        $robot = new Robot([0, 0], 'west');
         $robot->instructions('A');
         $this->assertEquals([-1, 0], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+        $this->assertEquals('west', $robot->direction);
     }
 
     /**
@@ -181,10 +181,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testFollowSeriesOfInstructionsMovingEastAndNorthFromInstructions(): void
     {
-        $robot = new Robot([7, 3], Robot::DIRECTION_NORTH);
+        $robot = new Robot([7, 3], 'north');
         $robot->instructions('RAALAL');
         $this->assertEquals([9, 4], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+        $this->assertEquals('west', $robot->direction);
     }
 
     /**
@@ -193,10 +193,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testFollowSeriesOfInstructionsMovingWestAndNorth(): void
     {
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
+        $robot = new Robot([0, 0], 'north');
         $robot->instructions('LAAARALA');
         $this->assertEquals([-4, 1], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+        $this->assertEquals('west', $robot->direction);
     }
 
     /**
@@ -206,10 +206,10 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     public function testFollowSeriesOfInstructionsMovingWestAndSouth(): void
     {
         // Instructions to move west and south
-        $robot = new Robot([2, -7], Robot::DIRECTION_EAST);
+        $robot = new Robot([2, -7], 'east');
         $robot->instructions('RRAAAAALA');
         $this->assertEquals([-3, -8], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+        $this->assertEquals('south', $robot->direction);
     }
 
     /**
@@ -219,9 +219,9 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     public function testFollowSeriesOfInstructionsMovingEastAndNorth(): void
     {
         // Instructions to move east and north
-        $robot = new Robot([8, 4], Robot::DIRECTION_SOUTH);
+        $robot = new Robot([8, 4], 'south');
         $robot->instructions('LAAARRRALLLL');
         $this->assertEquals([11, 5], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+        $this->assertEquals('north', $robot->direction);
     }
 }

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class RobotSimulatorTest extends PHPUnit\Framework\TestCase

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -10,156 +10,218 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * A robot is created with a position and a direction
+     * uuid: c557c16d-26c1-4e06-827c-f6602cd0785c
+     * @testdox Create robot - at origin facing north
      */
-    public function testCreate(): void
+    public function testCreateRobotAtOriginFacingNorth(): void
     {
-        // Robots are created with a position and direction
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+    }
 
-        // Negative positions are allowed
+    /**
+     * uuid: bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d
+     * @testdox Create robot - at negative position facing south
+     */
+    public function testCreateRobotAtNegativePositionFacingSouth(): void
+    {
         $robot = new Robot([-1, -1], Robot::DIRECTION_SOUTH);
         $this->assertEquals([-1, -1], $robot->position);
         $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
     }
 
     /**
-     * Rotate the robot's direction 90 degrees clockwise
+     * uuid: 8cbd0086-6392-4680-b9b9-73cf491e67e5
+     * @testdox Rotating clockwise - changes north to east
      */
-    public function testTurnRight(): void
+    public function testRotatingClockwiseChangesNorthToEast(): void
     {
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
-
-        // Change the direction from north to east
-        $robot->turnRight();
+        $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_EAST, $robot->direction);
+    }
 
-        // Change the direction from east to south
-        $robot->turnRight();
+    /**
+     * uuid: 8abc87fc-eab2-4276-93b7-9c009e866ba1
+     * @testdox Rotating clockwise - changes east to south
+     */
+    public function testRotatingClockwiseChangesEastToSouth(): void
+    {
+        $robot = new Robot([0, 0], Robot::DIRECTION_EAST);
+        $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+    }
 
-        // Change the direction from south to west
-        $robot->turnRight();
+    /**
+     * uuid: 3cfe1b85-bbf2-4bae-b54d-d73e7e93617a
+     * @testdox Rotating clockwise - changes south to west
+     */
+    public function testRotatingClockwiseChangesSouthToWest(): void
+    {
+        $robot = new Robot([0, 0], Robot::DIRECTION_SOUTH);
+        $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+    }
 
-        // Change the direction from west to north
-        $robot->turnRight();
+    /**
+     * uuid: 5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716
+     * @testdox Rotating clockwise - changes west to north
+     */
+    public function testRotatingClockwiseChangesWestToNorth(): void
+    {
+        $robot = new Robot([0, 0], Robot::DIRECTION_WEST);
+        $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
     }
 
     /**
-     * Rotate the robot's direction 90 degrees counterclockwise
+     * uuid: fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63
+     * @testdox Rotating counter-clockwise - changes north to west
      */
-    public function testTurnLeft(): void
+    public function testRotatingCounterClockwiseChangesNorthToWest(): void
     {
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
-
-        // Change the direction from north to west
-        $robot->turnLeft();
+        $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+    }
 
-        // Change the direction from west to south
-        $robot->turnLeft();
+    /**
+     * uuid: da33d734-831f-445c-9907-d66d7d2a92e2
+     * @testdox Rotating counter-clockwise - changes west to south
+     */
+    public function testRotatingCounterClockwiseChangesWestToSouth(): void
+    {
+        $robot = new Robot([0, 0], Robot::DIRECTION_WEST);
+        $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+    }
 
-        // Change the direction from south to east
-        $robot->turnLeft();
+    /**
+     * uuid: bd1ca4b9-4548-45f4-b32e-900fc7c19389
+     * @testdox Rotating counter-clockwise - changes south to east
+     */
+    public function testRotatingCounterClockwiseChangesSouthToEast(): void
+    {
+        $robot = new Robot([0, 0], Robot::DIRECTION_SOUTH);
+        $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_EAST, $robot->direction);
+    }
 
-        // Change the direction from east to north
-        $robot->turnLeft();
+    /**
+     * uuid: 2de27b67-a25c-4b59-9883-bc03b1b55bba
+     * @testdox Rotating counter-clockwise - changes east to north
+     */
+    public function testRotatingCounterClockwiseChangesEastToNorth(): void
+    {
+        $robot = new Robot([0, 0], Robot::DIRECTION_EAST);
+        $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
     }
 
     /**
-     * Move the robot forward 1 space in the direction it is pointing
+     * uuid: f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8
+     * @testdox Moving forward one - facing north increments Y
      */
-    public function testAdvance(): void
+    public function testMovingForwardOneFacingNorthIncrementsY(): void
     {
-        // Increases the y coordinate by one when facing north
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
-        $robot->advance();
+        $robot->instructions('A');
         $this->assertEquals([0, 1], $robot->position);
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
+    }
 
-        // Decreases the y coordinate by one when facing south
+    /**
+     * uuid: 2786cf80-5bbf-44b0-9503-a89a9c5789da
+     * @testdox Moving forward one - facing south decrements Y
+     */
+    public function testMovingForwardOneFacingSouthDecrementsY(): void
+    {
         $robot = new Robot([0, 0], Robot::DIRECTION_SOUTH);
-        $robot->advance();
+        $robot->instructions('A');
         $this->assertEquals([0, -1], $robot->position);
         $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+    }
 
-        // Increases the x coordinate by one when facing east
+    /**
+     * uuid: 84bf3c8c-241f-434d-883d-69817dbd6a48
+     * @testdox Moving forward one - facing east increments X
+     */
+    public function testMovingForwardOneFacingEastIncrementsX(): void
+    {
         $robot = new Robot([0, 0], Robot::DIRECTION_EAST);
-        $robot->advance();
+        $robot->instructions('A');
         $this->assertEquals([1, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_EAST, $robot->direction);
+    }
 
-        // Decreases the x coordinate by one when facing west
+    /**
+     * uuid: bb69c4a7-3bbf-4f64-b415-666fa72d7b04
+     * @testdox Moving forward one - facing west decrements X
+     */
+    public function testMovingForwardOneFacingWestDecrementsX(): void
+    {
         $robot = new Robot([0, 0], Robot::DIRECTION_WEST);
-        $robot->advance();
+        $robot->instructions('A');
         $this->assertEquals([-1, 0], $robot->position);
         $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
     }
 
     /**
-     * Where R = Turn Right, L = Turn Left and A = Advance,
-     * the robot can follow a series of instructions
-     * and end up with the correct position and direction
+     * uuid: e34ac672-4ed4-4be3-a0b8-d9af259cbaa1
+     * @testdox Follow series of instructions - moving east and north
      */
-    public function testInstructions(): void
+    public function testFollowSeriesOfInstructionsMovingEastAndNorth(): void
     {
-        // Instructions to move west and north
+        $robot = new Robot([7, 3], Robot::DIRECTION_NORTH);
+        $robot->instructions('RAALAL');
+        $this->assertEquals([9, 4], $robot->position);
+        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+    }
+
+    /**
+     * uuid: f30e4955-4b47-4aa3-8b39-ae98cfbd515b
+     * @testdox Follow series of instructions - moving west and north
+     */
+    public function testFollowSeriesOfInstructionsMovingWestAndNorth(): void
+    {
         $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
         $robot->instructions('LAAARALA');
         $this->assertEquals([-4, 1], $robot->position);
         $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
+    }
 
+    /**
+     * uuid: 3e466bf6-20ab-4d79-8b51-264165182fca
+     * @testdox Follow series of instructions - moving west and south
+     */
+    public function testFollowSeriesOfInstructionsMovingWestAndSouth(): void
+    {
         // Instructions to move west and south
         $robot = new Robot([2, -7], Robot::DIRECTION_EAST);
         $robot->instructions('RRAAAAALA');
         $this->assertEquals([-3, -8], $robot->position);
         $this->assertEquals(Robot::DIRECTION_SOUTH, $robot->direction);
+    }
 
+    /**
+     * uuid: 41f0bb96-c617-4e6b-acff-a4b279d44514
+     * @testdox Follow series of instructions - moving east and north another path
+     */
+    public function testFollowSeriesOfInstructionsMovingEastAndNorth2(): void
+    {
         // Instructions to move east and north
         $robot = new Robot([8, 4], Robot::DIRECTION_SOUTH);
         $robot->instructions('LAAARRRALLLL');
         $this->assertEquals([11, 5], $robot->position);
         $this->assertEquals(Robot::DIRECTION_NORTH, $robot->direction);
-    }
-
-    public function testMalformedInstructions(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
-        $robot->instructions('LARX');
-    }
-
-    /**
-     * Optional instructions chaining
-     */
-    public function testInstructionsChaining(): void
-    {
-        $robot = new Robot([0, 0], Robot::DIRECTION_NORTH);
-        $robot->turnLeft()
-            ->advance()
-            ->advance()
-            ->advance()
-            ->turnRight()
-            ->advance()
-            ->turnLeft()
-            ->advance();
-        $this->assertEquals([-4, 1], $robot->position);
-        $this->assertEquals(Robot::DIRECTION_WEST, $robot->direction);
     }
 }

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -177,9 +177,9 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e34ac672-4ed4-4be3-a0b8-d9af259cbaa1
-     * @testdox Follow series of instructions - moving east and north
+     * @testdox Follow series of instructions - moving east and north from instructions
      */
-    public function testFollowSeriesOfInstructionsMovingEastAndNorth(): void
+    public function testFollowSeriesOfInstructionsMovingEastAndNorthFromInstructions(): void
     {
         $robot = new Robot([7, 3], Robot::DIRECTION_NORTH);
         $robot->instructions('RAALAL');
@@ -214,9 +214,9 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 41f0bb96-c617-4e6b-acff-a4b279d44514
-     * @testdox Follow series of instructions - moving east and north another path
+     * @testdox Follow series of instructions - moving east and north
      */
-    public function testFollowSeriesOfInstructionsMovingEastAndNorth2(): void
+    public function testFollowSeriesOfInstructionsMovingEastAndNorth(): void
     {
         // Instructions to move east and north
         $robot = new Robot([8, 4], Robot::DIRECTION_SOUTH);

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -16,8 +16,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     public function testCreateRobotAtOriginFacingNorth(): void
     {
         $robot = new RobotSimulator([0, 0], 'north');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('north', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('north', $robot->getDirection());
     }
 
     /**
@@ -27,8 +27,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     public function testCreateRobotAtNegativePositionFacingSouth(): void
     {
         $robot = new RobotSimulator([-1, -1], 'south');
-        $this->assertEquals([-1, -1], $robot->position);
-        $this->assertEquals('south', $robot->direction);
+        $this->assertEquals([-1, -1], $robot->getPosition());
+        $this->assertEquals('south', $robot->getDirection());
     }
 
     /**
@@ -39,8 +39,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('R');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('east', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('east', $robot->getDirection());
     }
 
     /**
@@ -51,8 +51,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'east');
         $robot->instructions('R');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('south', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('south', $robot->getDirection());
     }
 
     /**
@@ -63,8 +63,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'south');
         $robot->instructions('R');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('west', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('west', $robot->getDirection());
     }
 
     /**
@@ -75,8 +75,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'west');
         $robot->instructions('R');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('north', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('north', $robot->getDirection());
     }
 
     /**
@@ -87,8 +87,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('L');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('west', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('west', $robot->getDirection());
     }
 
     /**
@@ -99,8 +99,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'west');
         $robot->instructions('L');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('south', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('south', $robot->getDirection());
     }
 
     /**
@@ -111,8 +111,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'south');
         $robot->instructions('L');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('east', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('east', $robot->getDirection());
     }
 
     /**
@@ -123,8 +123,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'east');
         $robot->instructions('L');
-        $this->assertEquals([0, 0], $robot->position);
-        $this->assertEquals('north', $robot->direction);
+        $this->assertEquals([0, 0], $robot->getPosition());
+        $this->assertEquals('north', $robot->getDirection());
     }
 
     /**
@@ -135,8 +135,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('A');
-        $this->assertEquals([0, 1], $robot->position);
-        $this->assertEquals('north', $robot->direction);
+        $this->assertEquals([0, 1], $robot->getPosition());
+        $this->assertEquals('north', $robot->getDirection());
     }
 
     /**
@@ -147,8 +147,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'south');
         $robot->instructions('A');
-        $this->assertEquals([0, -1], $robot->position);
-        $this->assertEquals('south', $robot->direction);
+        $this->assertEquals([0, -1], $robot->getPosition());
+        $this->assertEquals('south', $robot->getDirection());
     }
 
     /**
@@ -159,8 +159,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'east');
         $robot->instructions('A');
-        $this->assertEquals([1, 0], $robot->position);
-        $this->assertEquals('east', $robot->direction);
+        $this->assertEquals([1, 0], $robot->getPosition());
+        $this->assertEquals('east', $robot->getDirection());
     }
 
     /**
@@ -171,8 +171,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'west');
         $robot->instructions('A');
-        $this->assertEquals([-1, 0], $robot->position);
-        $this->assertEquals('west', $robot->direction);
+        $this->assertEquals([-1, 0], $robot->getPosition());
+        $this->assertEquals('west', $robot->getDirection());
     }
 
     /**
@@ -183,8 +183,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([7, 3], 'north');
         $robot->instructions('RAALAL');
-        $this->assertEquals([9, 4], $robot->position);
-        $this->assertEquals('west', $robot->direction);
+        $this->assertEquals([9, 4], $robot->getPosition());
+        $this->assertEquals('west', $robot->getDirection());
     }
 
     /**
@@ -195,8 +195,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     {
         $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('LAAARALA');
-        $this->assertEquals([-4, 1], $robot->position);
-        $this->assertEquals('west', $robot->direction);
+        $this->assertEquals([-4, 1], $robot->getPosition());
+        $this->assertEquals('west', $robot->getDirection());
     }
 
     /**
@@ -208,8 +208,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         // Instructions to move west and south
         $robot = new RobotSimulator([2, -7], 'east');
         $robot->instructions('RRAAAAALA');
-        $this->assertEquals([-3, -8], $robot->position);
-        $this->assertEquals('south', $robot->direction);
+        $this->assertEquals([-3, -8], $robot->getPosition());
+        $this->assertEquals('south', $robot->getDirection());
     }
 
     /**
@@ -221,7 +221,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
         // Instructions to move east and north
         $robot = new RobotSimulator([8, 4], 'south');
         $robot->instructions('LAAARRRALLLL');
-        $this->assertEquals([11, 5], $robot->position);
-        $this->assertEquals('north', $robot->direction);
+        $this->assertEquals([11, 5], $robot->getPosition());
+        $this->assertEquals('north', $robot->getDirection());
     }
 }

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -15,7 +15,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testCreateRobotAtOriginFacingNorth(): void
     {
-        $robot = new Robot([0, 0], 'north');
+        $robot = new RobotSimulator([0, 0], 'north');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('north', $robot->direction);
     }
@@ -26,7 +26,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testCreateRobotAtNegativePositionFacingSouth(): void
     {
-        $robot = new Robot([-1, -1], 'south');
+        $robot = new RobotSimulator([-1, -1], 'south');
         $this->assertEquals([-1, -1], $robot->position);
         $this->assertEquals('south', $robot->direction);
     }
@@ -37,7 +37,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesNorthToEast(): void
     {
-        $robot = new Robot([0, 0], 'north');
+        $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('east', $robot->direction);
@@ -49,7 +49,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesEastToSouth(): void
     {
-        $robot = new Robot([0, 0], 'east');
+        $robot = new RobotSimulator([0, 0], 'east');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('south', $robot->direction);
@@ -61,7 +61,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesSouthToWest(): void
     {
-        $robot = new Robot([0, 0], 'south');
+        $robot = new RobotSimulator([0, 0], 'south');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('west', $robot->direction);
@@ -73,7 +73,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingClockwiseChangesWestToNorth(): void
     {
-        $robot = new Robot([0, 0], 'west');
+        $robot = new RobotSimulator([0, 0], 'west');
         $robot->instructions('R');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('north', $robot->direction);
@@ -85,7 +85,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesNorthToWest(): void
     {
-        $robot = new Robot([0, 0], 'north');
+        $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('west', $robot->direction);
@@ -97,7 +97,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesWestToSouth(): void
     {
-        $robot = new Robot([0, 0], 'west');
+        $robot = new RobotSimulator([0, 0], 'west');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('south', $robot->direction);
@@ -109,7 +109,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesSouthToEast(): void
     {
-        $robot = new Robot([0, 0], 'south');
+        $robot = new RobotSimulator([0, 0], 'south');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('east', $robot->direction);
@@ -121,7 +121,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testRotatingCounterClockwiseChangesEastToNorth(): void
     {
-        $robot = new Robot([0, 0], 'east');
+        $robot = new RobotSimulator([0, 0], 'east');
         $robot->instructions('L');
         $this->assertEquals([0, 0], $robot->position);
         $this->assertEquals('north', $robot->direction);
@@ -133,7 +133,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingNorthIncrementsY(): void
     {
-        $robot = new Robot([0, 0], 'north');
+        $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('A');
         $this->assertEquals([0, 1], $robot->position);
         $this->assertEquals('north', $robot->direction);
@@ -145,7 +145,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingSouthDecrementsY(): void
     {
-        $robot = new Robot([0, 0], 'south');
+        $robot = new RobotSimulator([0, 0], 'south');
         $robot->instructions('A');
         $this->assertEquals([0, -1], $robot->position);
         $this->assertEquals('south', $robot->direction);
@@ -157,7 +157,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingEastIncrementsX(): void
     {
-        $robot = new Robot([0, 0], 'east');
+        $robot = new RobotSimulator([0, 0], 'east');
         $robot->instructions('A');
         $this->assertEquals([1, 0], $robot->position);
         $this->assertEquals('east', $robot->direction);
@@ -169,7 +169,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testMovingForwardOneFacingWestDecrementsX(): void
     {
-        $robot = new Robot([0, 0], 'west');
+        $robot = new RobotSimulator([0, 0], 'west');
         $robot->instructions('A');
         $this->assertEquals([-1, 0], $robot->position);
         $this->assertEquals('west', $robot->direction);
@@ -181,7 +181,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testFollowSeriesOfInstructionsMovingEastAndNorthFromInstructions(): void
     {
-        $robot = new Robot([7, 3], 'north');
+        $robot = new RobotSimulator([7, 3], 'north');
         $robot->instructions('RAALAL');
         $this->assertEquals([9, 4], $robot->position);
         $this->assertEquals('west', $robot->direction);
@@ -193,7 +193,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
      */
     public function testFollowSeriesOfInstructionsMovingWestAndNorth(): void
     {
-        $robot = new Robot([0, 0], 'north');
+        $robot = new RobotSimulator([0, 0], 'north');
         $robot->instructions('LAAARALA');
         $this->assertEquals([-4, 1], $robot->position);
         $this->assertEquals('west', $robot->direction);
@@ -206,7 +206,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     public function testFollowSeriesOfInstructionsMovingWestAndSouth(): void
     {
         // Instructions to move west and south
-        $robot = new Robot([2, -7], 'east');
+        $robot = new RobotSimulator([2, -7], 'east');
         $robot->instructions('RRAAAAALA');
         $this->assertEquals([-3, -8], $robot->position);
         $this->assertEquals('south', $robot->direction);
@@ -219,7 +219,7 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
     public function testFollowSeriesOfInstructionsMovingEastAndNorth(): void
     {
         // Instructions to move east and north
-        $robot = new Robot([8, 4], 'south');
+        $robot = new RobotSimulator([8, 4], 'south');
         $robot->instructions('LAAARRRALLLL');
         $this->assertEquals([11, 5], $robot->position);
         $this->assertEquals('north', $robot->direction);


### PR DESCRIPTION
Sync'ed according to #781. Changes tests heavily in structure, ~~but not~~ **and** in content. So ~~no~~ **re-testing** against existing solutions required.

- Spread out test cases to individual test methods
- Test only from the interface specified in problem specifications
- ~~Still~~ Re-design as discussed in #783 

I did find a way to do a re-structuring without altering the interface relied on by existing solutions. There are now no extra methods used, that I think were older than the current `instructions` property in problem spec.

The exercise is marked as `topic: ['oop']` in `config.json`, which hints on why there were specialised methods to change the internal state. And why our `example.php` (and an additional test) does method chaining (fluent interface design).

To stay as close to the problem spec as possible, the OOP-isms are seemingly superfluous. A fluent interface design deviates totally from the string style `instructions`. On the other hand one could transform the string input into the fluent interface while writing the tests, and also allow immutable instances as a more modern approach that way. But still, I think such OOP-isms should only be in additional PHP track exercises.