### PR TITLE
Normalize array index on *Canonicalizing assertions

### DIFF
--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -73,7 +73,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
             new Allergen(Allergen::POLLEN),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList());
+        ], array_values($allergies->getList()));
     }
 
     public function testIsAllergicToEggsAndPeanuts(): void
@@ -83,7 +83,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::PEANUTS),
-        ], $allergies->getList());
+        ], array_values($allergies->getList()));
     }
 
     public function testIsAllergicToEggsAndShellfish(): void
@@ -93,7 +93,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         $this->assertEqualsCanonicalizing([
             new Allergen(Allergen::EGGS),
             new Allergen(Allergen::SHELLFISH),
-        ], $allergies->getList());
+        ], array_values($allergies->getList()));
     }
 
     public function testIgnoreNonAllergenScorePart(): void
@@ -108,7 +108,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
             new Allergen(Allergen::SHELLFISH),
             new Allergen(Allergen::STRAWBERRIES),
             new Allergen(Allergen::TOMATOES),
-        ], $allergies->getList());
+        ], array_values($allergies->getList()));
     }
 
     /**

--- a/exercises/practice/grade-school/GradeSchoolTest.php
+++ b/exercises/practice/grade-school/GradeSchoolTest.php
@@ -57,7 +57,7 @@ class GradeSchoolTest extends TestCase
         $this->assertCount(3, $students);
         $this->assertEqualsCanonicalizing(
             ['Claire', 'Marc', 'Virginie'],
-            $students
+            array_values($students)
         );
     }
 


### PR DESCRIPTION
This fixes a breaking change introduced by PHPUnit now seeing "uncontinuous indexes as unsortable". The change addressed the "wrong expectation", that array keys don't matter. Arrays were sorted unconditionally, re-indexing the array. And it removed string keys from associative arrays, which usually was *not* intended.