### PR TITLE
Sync: Two Bucket

### DIFF
--- a/exercises/practice/two-bucket/.docs/instructions.md
+++ b/exercises/practice/two-bucket/.docs/instructions.md
@@ -11,7 +11,7 @@ There are some rules that your solution must follow:
      b) the second bucket is full
   2. Emptying a bucket and doing nothing to the other.
   3. Filling a bucket and doing nothing to the other.
-- After an action, you may not arrive at a state where the starting bucket is empty and the other bucket is full.
+- After an action, you may not arrive at a state where the initial starting bucket is empty and the other bucket is full.
 
 Your program will take as input:
 

--- a/exercises/practice/two-bucket/.meta/example.php
+++ b/exercises/practice/two-bucket/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class TwoBucket

--- a/exercises/practice/two-bucket/TwoBucketTest.php
+++ b/exercises/practice/two-bucket/TwoBucketTest.php
@@ -17,13 +17,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
      */
     public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketOne(): void
     {
-        $buckOne = 3;
-        $buckTwo = 5;
-        $goal = 1;
-        $starterBuck = 'one';
-
         $subject = new TwoBucket();
-        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $solution = $subject->solve(3, 5, 1, 'one');
 
         $this->assertEquals(4, $solution->numberOfActions);
         $this->assertEquals('one', $solution->nameOfBucketWithDesiredLiters);
@@ -36,12 +31,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
      */
     public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketTwo(): void
     {
-        $buckOne = 3;
-        $buckTwo = 5;
-        $goal = 1;
-        $starterBuck = 'two';
         $subject = new TwoBucket();
-        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $solution = $subject->solve(3, 5, 1, 'two');
 
         $this->assertEquals(8, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -54,12 +45,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
      */
     public function testMeasureUsingBucketOneOfSize7AndBucketTwoOfSize11StartWithBucketOne(): void
     {
-        $buckOne = 7;
-        $buckTwo = 11;
-        $goal = 2;
-        $starterBuck = 'one';
         $subject = new TwoBucket();
-        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $solution = $subject->solve(7, 11, 2, 'one');
 
         $this->assertEquals(14, $solution->numberOfActions);
         $this->assertEquals('one', $solution->nameOfBucketWithDesiredLiters);
@@ -72,12 +59,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
      */
     public function testMeasureUsingBucketOneOfSize7AndBucketTwoOfSize11StartWithBucketTwo(): void
     {
-        $buckOne = 7;
-        $buckTwo = 11;
-        $goal = 2;
-        $starterBuck = 'two';
         $subject = new TwoBucket();
-        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $solution = $subject->solve(7, 11, 2, 'two');
 
         $this->assertEquals(18, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -118,12 +101,10 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
      */
     public function testReachabilityNotPossibleToReachGoalStartWithBucketOne(): void
     {
-        $buckOne = 6;
-        $buckTwo = 15;
         $this->expectException(Exception::class);
 
         $subject = new TwoBucket();
-        $subject->solve($buckOne, $buckTwo, 5, 'one');
+        $subject->solve(6, 15, 5, 'one');
     }
 
     /**
@@ -147,6 +128,7 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
     public function testGoalLargerThanBothBucketsIsImpossible(): void
     {
         $this->expectException(Exception::class);
+
         $subject = new TwoBucket();
         $subject->solve(5, 7, 8, 'one');
     }

--- a/exercises/practice/two-bucket/TwoBucketTest.php
+++ b/exercises/practice/two-bucket/TwoBucketTest.php
@@ -130,7 +130,7 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
      * uuid: aac38b7a-77f4-4d62-9b91-8846d533b054
      * @testdox With the same buckets but a different goal, then it is possible
      */
-    public function testReachabilityNotPossibleToReachGoalStartWithBucketOneAndEndWithBucketTwo(): void
+    public function testWithSameBucketsButDifferentGoalItIsPossible(): void
     {
         $subject = new TwoBucket();
         $solution = $subject->solve(6, 15, 9, 'one');

--- a/exercises/practice/two-bucket/TwoBucketTest.php
+++ b/exercises/practice/two-bucket/TwoBucketTest.php
@@ -11,13 +11,9 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
         require_once 'TwoBucket.php';
     }
 
-    protected function setUp(): void
-    {
-        $this->twoBucket = new TwoBucket();
-    }
-
     /**
      * uuid: a6f2b4ba-065f-4dca-b6f0-e3eee51cb661
+     * @testdox Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
      */
     public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketOne(): void
     {
@@ -25,7 +21,9 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
         $buckTwo = 5;
         $goal = 1;
         $starterBuck = 'one';
-        $solution = $this->twoBucket->solve($buckOne, $buckTwo, $goal, $starterBuck);
+
+        $subject = new TwoBucket();
+        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
 
         $this->assertEquals(4, $solution->numberOfActions);
         $this->assertEquals('one', $solution->nameOfBucketWithDesiredLiters);
@@ -34,6 +32,7 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6c4ea451-9678-4926-b9b3-68364e066d40
+     * @testdox Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
      */
     public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketTwo(): void
     {
@@ -41,7 +40,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
         $buckTwo = 5;
         $goal = 1;
         $starterBuck = 'two';
-        $solution = $this->twoBucket->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $subject = new TwoBucket();
+        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
 
         $this->assertEquals(8, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -50,6 +50,7 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3389f45e-6a56-46d5-9607-75aa930502ff
+     * @testdox Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
      */
     public function testMeasureUsingBucketOneOfSize7AndBucketTwoOfSize11StartWithBucketOne(): void
     {
@@ -57,7 +58,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
         $buckTwo = 11;
         $goal = 2;
         $starterBuck = 'one';
-        $solution = $this->twoBucket->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $subject = new TwoBucket();
+        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
 
         $this->assertEquals(14, $solution->numberOfActions);
         $this->assertEquals('one', $solution->nameOfBucketWithDesiredLiters);
@@ -66,6 +68,7 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1
+     * @testdox Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
      */
     public function testMeasureUsingBucketOneOfSize7AndBucketTwoOfSize11StartWithBucketTwo(): void
     {
@@ -73,7 +76,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
         $buckTwo = 11;
         $goal = 2;
         $starterBuck = 'two';
-        $solution = $this->twoBucket->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $subject = new TwoBucket();
+        $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
 
         $this->assertEquals(18, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -82,10 +86,12 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0ee1f57e-da84-44f7-ac91-38b878691602
+     * @testdox Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
      */
     public function testMeasureOneStepUsingBucketOneOfSize1AndBucketTwoOfSize3StartWithBucketTwo(): void
     {
-        $solution = $this->twoBucket->solve(1, 3, 3, 'two');
+        $subject = new TwoBucket();
+        $solution = $subject->solve(1, 3, 3, 'two');
 
         $this->assertEquals(1, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -94,10 +100,12 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: eb329c63-5540-4735-b30b-97f7f4df0f84
+     * @testdox Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
      */
     public function testMeasureUsingBucketOneOfSize2AndBucketTwoOfSize3StartWithBucketOneAndEndWithBucketTwo(): void
     {
-        $solution = $this->twoBucket->solve(2, 3, 3, 'one');
+        $subject = new TwoBucket();
+        $solution = $subject->solve(2, 3, 3, 'one');
 
         $this->assertEquals(2, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -106,6 +114,7 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 449be72d-b10a-4f4b-a959-ca741e333b72
+     * @testdox Not possible to reach the goal
      */
     public function testReachabilityNotPossibleToReachGoalStartWithBucketOne(): void
     {
@@ -113,31 +122,18 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
         $buckTwo = 15;
         $this->expectException(Exception::class);
 
-        $this->twoBucket->solve($buckOne, $buckTwo, 5, 'one');
+        $subject = new TwoBucket();
+        $subject->solve($buckOne, $buckTwo, 5, 'one');
     }
 
     /**
      * uuid: aac38b7a-77f4-4d62-9b91-8846d533b054
+     * @testdox With the same buckets but a different goal, then it is possible
      */
     public function testReachabilityNotPossibleToReachGoalStartWithBucketOneAndEndWithBucketTwo(): void
     {
-        $solution = $this->twoBucket->solve(6, 15, 9, 'one');
-
-        $this->assertEquals(10, $solution->numberOfActions);
-        $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
-        $this->assertEquals(0, $solution->litersLeftInOtherBucket);
-    }
-
-    /**
-     * uuid: aac38b7a-77f4-4d62-9b91-8846d533b054
-     */
-    public function testWithSameBucketsButDifferentGoalItIsPossible(): void
-    {
-        $buckOne = 6;
-        $buckTwo = 15;
-        $goal = 9;
-        $starterBuck = 'one';
-        $solution = $this->twoBucket->solve($buckOne, $buckTwo, $goal, $starterBuck);
+        $subject = new TwoBucket();
+        $solution = $subject->solve(6, 15, 9, 'one');
 
         $this->assertEquals(10, $solution->numberOfActions);
         $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
@@ -146,10 +142,12 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 74633132-0ccf-49de-8450-af4ab2e3b299
+     * @testdox Goal larger than both buckets is impossible
      */
     public function testGoalLargerThanBothBucketsIsImpossible(): void
     {
         $this->expectException(Exception::class);
-        $this->twoBucket->solve(5, 7, 8, 'one');
+        $subject = new TwoBucket();
+        $subject->solve(5, 7, 8, 'one');
     }
 }


### PR DESCRIPTION
Resolves: #807 

I have added the "setup" to each function, but there are still some diffs, to the `arrange, act, assert`. 

Which one do you prefer? or do we go for a 3rd option?

One: 
```php
public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketOne(): void
{
    $buckOne = 3;
    $buckTwo = 5;
    $goal = 1;
    $starterBuck = 'one';
 
    $subject = new TwoBucket();
    $solution = $subject->solve($buckOne, $buckTwo, $goal, $starterBuck);
 
    $this->assertEquals(4, $solution->numberOfActions);
    $this->assertEquals('one', $solution->nameOfBucketWithDesiredLiters);
    $this->assertEquals(5, $solution->litersLeftInOtherBucket);
}
```
Two: 
```php
public function testMeasureOneStepUsingBucketOneOfSize1AndBucketTwoOfSize3StartWithBucketTwo(): void
{
    $subject = new TwoBucket();
    $solution = $subject->solve(1, 3, 3, 'two');

    $this->assertEquals(1, $solution->numberOfActions);
    $this->assertEquals('two', $solution->nameOfBucketWithDesiredLiters);
    $this->assertEquals(0, $solution->litersLeftInOtherBucket);
}
```

As there are 3 assertions, I don't know if you prefer having 

```php
$expectedNumberOfActions = 1;
$expectedBucketName = 'two';
$expectedLitersInOtherBucket = 0;
```

Or keep the assertions as is. 