### PR TITLE
Deprecate deprecated exercises from problem specifications

### DIFF
--- a/bin/checkDeprecatedExercises.php
+++ b/bin/checkDeprecatedExercises.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * By adding type hints and enabling strict type checking, code can become
+ * easier to read, self-documenting and reduce the number of potential bugs.
+ * By default, type declarations are non-strict, which means they will attempt
+ * to change the original type to match the type specified by the
+ * type-declaration.
+ *
+ * In other words, if you pass a string to a function requiring a float,
+ * it will attempt to convert the string value to a float.
+ *
+ * To enable strict mode, a single declare directive must be placed at the top
+ * of the file.
+ * This means that the strictness of typing is configured on a per-file basis.
+ * This directive not only affects the type declarations of parameters, but also
+ * a function's return type.
+ *
+ * For more info review the Concept on strict type checking in the PHP track
+ * <link>.
+ *
+ * To disable strict typing, comment out the directive below.
+ */
+
+declare(strict_types=1);
+
+$deprecatedExercises = [];
+foreach (getExercises() as $exercise) {
+    $headerResponse = get_headers("https://github.com/exercism/problem-specifications/blob/main/exercises/{$exercise}/.deprecated")[0];
+    if (!str_contains($headerResponse, '200 OK')) {
+        continue;
+    }
+
+    $deprecatedExercises[] = $exercise;
+}
+
+var_dump($deprecatedExercises);
+
+function getExercises(): array
+{
+    return [
+        "annalyns-infiltration",
+        "city-office",
+        "language-list",
+        "lasagna",
+        "lucky-numbers",
+        "pizza-pi",
+        "sweethearts",
+        "windowing-system",
+        "accumulate",
+        "acronym",
+        "affine-cipher",
+        "allergies",
+        "all-your-base",
+        "alphametics",
+        "anagram",
+        "armstrong-numbers",
+        "atbash-cipher",
+        "bank-account",
+        "beer-song",
+        "binary",
+        "binary-search",
+        "binary-search-tree",
+        "bob",
+        "book-store",
+        "bowling",
+        "change",
+        "circular-buffer",
+        "clock",
+        "collatz-conjecture",
+        "connect",
+        "crypto-square",
+        "custom-set",
+        "darts",
+        "diamond",
+        "difference-of-squares",
+        "dnd-character",
+        "eliuds-eggs",
+        "etl",
+        "flatten-array",
+        "food-chain",
+        "gigasecond",
+        "grade-school",
+        "grains",
+        "hamming",
+        "hello-world",
+        "high-scores",
+        "house",
+        "isbn-verifier",
+        "isogram",
+        "killer-sudoku-helper",
+        "kindergarten-garden",
+        "knapsack",
+        "largest-series-product",
+        "leap",
+        "linked-list",
+        "list-ops",
+        "luhn",
+        "markdown",
+        "mask-credit-card",
+        "matching-brackets",
+        "matrix",
+        "meetup",
+        "micro-blog",
+        "minesweeper",
+        "nth-prime",
+        "nucleotide-count",
+        "ocr-numbers",
+        "ordinal-number",
+        "palindrome-products",
+        "pangram",
+        "parallel-letter-frequency",
+        "pascals-triangle",
+        "perfect-numbers",
+        "phone-number",
+        "pig-latin",
+        "poker",
+        "prime-factors",
+        "protein-translation",
+        "proverb",
+        "queen-attack",
+        "rail-fence-cipher",
+        "raindrops",
+        "resistor-color",
+        "resistor-color-duo",
+        "resistor-color-trio",
+        "reverse-string",
+        "rna-transcription",
+        "robot-name",
+        "robot-simulator",
+        "roman-numerals",
+        "rotational-cipher",
+        "run-length-encoding",
+        "say",
+        "scale-generator",
+        "scrabble-score",
+        "secret-handshake",
+        "series",
+        "sieve",
+        "simple-cipher",
+        "space-age",
+        "spiral-matrix",
+        "state-of-tic-tac-toe",
+        "strain",
+        "sublist",
+        "sum-of-multiples",
+        "tournament",
+        "transpose",
+        "triangle",
+        "trinary",
+        "twelve-days",
+        "two-bucket",
+        "two-fer",
+        "variable-length-quantity",
+        "word-count",
+        "wordy",
+        "yacht",
+        "zebra-puzzle",
+    ];
+}
+
+

--- a/config.json
+++ b/config.json
@@ -389,6 +389,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
+        "status": "deprecated",
         "topics": [
           "extension_methods",
           "sequences",
@@ -450,6 +451,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
+        "status": "deprecated",
         "topics": [
           "algorithms",
           "text_formatting"
@@ -462,6 +464,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
+        "status": "deprecated",
         "topics": [
           "math"
         ]
@@ -717,6 +720,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
+        "status": "deprecated",
         "topics": [
           "math"
         ]

--- a/contribution/checkDeprecatedExercises.php
+++ b/contribution/checkDeprecatedExercises.php
@@ -1,26 +1,5 @@
+#!/usr/bin/env php
 <?php
-
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
 
 declare(strict_types=1);
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -48,5 +48,6 @@
     <exclude-pattern>*/*Test\.php</exclude-pattern>
     <exclude-pattern>*/.meta/*\.php</exclude-pattern>
     <exclude-pattern>src/*</exclude-pattern>
+    <exclude-pattern>contribution/*.php</exclude-pattern>
   </rule>
 </ruleset>


### PR DESCRIPTION
Resolves #813 

I know the `checkDeprecatedExercises` isn't super nice, but it was the fastest way I knew to get inform about which exercises was deprecated. 

I can look into the `configlet` repository, to see if I can incorporate the functionally there. 

Output from script: 

```php
shell> php checkDeprecatedExercises.php
array(5) {
  [0]=>
  string(10) "accumulate"
  [1]=>
  string(9) "beer-song"
  [2]=>
  string(6) "binary"
  [3]=>
  string(15) "scale-generator"
  [4]=>
  string(7) "trinary"
}
```