### PR TITLE
ci: Allow for single exercise test exection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Execute the following command to run the tests:
 composer test:run
 ```
 
+This is included in `composer ci` to run the CI checks locally.
+
 ### Run a specific test
 
 If you want to run tests for one specific exercise, you can do it with following cli command.
@@ -48,7 +50,11 @@ composer test:run -- exercise-name
 composer test:run -- book-store
 ```
 
-This is included in `composer ci` to run the CI checks locally.
+If you want to run all starting with let's say 'b' you can run
+
+```shell
+composer test:run -- "b*"
+```
 
 ## Running Style Checker
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Execute the following command to run the tests:
 composer test:run
 ```
 
+### Run a specific test
+
+If you want to run tests for one specific exercise, you can do it with following cli command.
+
+```shell
+composer test:run -- exercise-name
+# e.g
+composer test:run -- book-store
+```
+
 This is included in `composer ci` to run the CI checks locally.
 
 ## Running Style Checker

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -13,18 +13,12 @@ file_ext="php"
 function main {
   has_failures=0
 
-  if [ $# -ge 1 ] && [ -n "$1" ]; then
-    specific_exercise=$(find ./exercises/{practice,concept} -name $1 -type d | sort)
-    for exercise_dir in $specific_exercise; do
-        test "${exercise_dir}" "example"
-        if [[ $? -ne 0 ]]; then
-          has_failures=1
-        fi
-      done
-      return $has_failures
+  name_filter=()
+  if [ -n "$1" ]; then
+    name_filter=("-name" "$1")
   fi
 
-  all_practice_exercise_dirs=$(find ./exercises/practice -maxdepth 1 -mindepth 1 -type d | sort)
+  all_practice_exercise_dirs=$(find ./exercises/practice -maxdepth 1 -mindepth 1 -type d "${name_filter[@]}" | sort)
   for exercise_dir in $all_practice_exercise_dirs; do
     test "${exercise_dir}" "example"
     if [[ $? -ne 0 ]]; then
@@ -32,7 +26,7 @@ function main {
     fi
   done
 
-  all_concept_exercise_dirs=$(find ./exercises/concept -maxdepth 1 -mindepth 1 -type d | sort)
+  all_concept_exercise_dirs=$(find ./exercises/concept -maxdepth 1 -mindepth 1 -type d "${name_filter[@]}" | sort)
   for exercise_dir in $all_concept_exercise_dirs; do
     test "${exercise_dir}" "exemplar"
     if [[ $? -ne 0 ]]; then

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -14,7 +14,7 @@ function main {
   has_failures=0
 
   name_filter=()
-  if [ -n "$1" ]; then
+  if [ $# -ge 1 ] && [ -n "$1" ]; then
     name_filter=("-name" "$1")
   fi
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -13,6 +13,17 @@ file_ext="php"
 function main {
   has_failures=0
 
+  if [ $# -ge 1 ] && [ -n "$1" ]; then
+    specific_exercise=$(find ./exercises/{practice,concept} -name $1 -type d | sort)
+    for exercise_dir in $specific_exercise; do
+        test "${exercise_dir}" "example"
+        if [[ $? -ne 0 ]]; then
+          has_failures=1
+        fi
+      done
+      return $has_failures
+  fi
+
   all_practice_exercise_dirs=$(find ./exercises/practice -maxdepth 1 -mindepth 1 -type d | sort)
   for exercise_dir in $all_practice_exercise_dirs; do
     test "${exercise_dir}" "example"


### PR DESCRIPTION
I often want to execute only one of the tests in the exercises when adjusting tests, to speed up the process. 

This PR will allow me to e.g. run only the tests for exercise `book-store` by adding an additional parameter.

It can be done in more way. 

```sh
composer test:run -- book-store
```

```sh
PHPUNIT_BIN='phpunit' bin/test.sh book-store 
```

I hope this will get accepted as it gives me a better workflow when updating the PHP track. 