### PR TITLE
patch: remove order dependency from anagram test

### DIFF
--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -75,7 +75,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDoesNotDetectNonAnagramsWithIdenticalChecksum(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('mass', ['last']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('mass', ['last'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -45,7 +45,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagram(): void
     {
-        $this->assertEqualsCanonicalizing(['inlets'], detectAnagrams('listen', ['enlists', 'google', 'inlets', 'banana']));
+        $this->assertEqualsCanonicalizing(['inlets'], array_values(detectAnagrams('listen', ['enlists', 'google', 'inlets', 'banana'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -147,7 +147,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsAreNotAnagramsOfThemselvesEvenIfLetterCaseIsCompletelyDifferent(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('BANANA', ['banana']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('BANANA', ['banana'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -15,7 +15,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testNoMatches(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('diaper', ['hello', 'world', 'zombies', 'pants']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('diaper', ['hello', 'world', 'zombies', 'pants'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -120,7 +120,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testAnagramsMustUseAllLettersExactlyOnce(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('tapper', ['patter']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('tapper', ['patter'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -84,7 +84,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagramsCaseInsensitively(): void
     {
-        $this->assertEqualsCanonicalizing(['Carthorse'], detectAnagrams('Orchestra', ['cashregister', 'Carthorse', 'radishes']));
+        $this->assertEqualsCanonicalizing(['Carthorse'], array_values(detectAnagrams('Orchestra', ['cashregister', 'Carthorse', 'radishes'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 class AnagramTest extends PHPUnit\Framework\TestCase
 {

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -138,7 +138,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsAreNotAnagramsOfThemselvesEvenIfLetterCaseIsPartiallyDifferent(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('BANANA', ['Banana']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('BANANA', ['Banana'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -111,7 +111,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDoesNotDetectAAnagramIfTheOriginalWordIsRepeated(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('go', ['goGoGO']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('go', ['goGoGO'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -66,7 +66,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsMultipleAnagramsWithDifferentCase(): void
     {
-        $this->assertEqualsCanonicalizing(['Eons', 'ONES'], detectAnagrams('nose', ['Eons', 'ONES']));
+        $this->assertEqualsCanonicalizing(['Eons', 'ONES'], array_values(detectAnagrams('nose', ['Eons', 'ONES'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 class AnagramTest extends PHPUnit\Framework\TestCase
 {
@@ -15,7 +15,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testNoMatches(): void
     {
-        $this->assertEquals([], detectAnagrams('diaper', ['hello', 'world', 'zombies', 'pants']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('diaper', ['hello', 'world', 'zombies', 'pants']));
     }
 
     /**
@@ -24,7 +24,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsTwoAnagrams(): void
     {
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             ['lemons', 'melons'],
             detectAnagrams('solemn', ['lemons', 'cherry', 'melons'])
         );
@@ -36,7 +36,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDoesNotDetectAnagramSubsets(): void
     {
-        $this->assertEquals([], detectAnagrams('good', ['dog', 'goody']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('good', ['dog', 'goody']));
     }
 
     /**
@@ -45,7 +45,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagram(): void
     {
-        $this->assertEquals(['inlets'], detectAnagrams('listen', ['enlists', 'google', 'inlets', 'banana']));
+        $this->assertEqualsCanonicalizing(['inlets'], detectAnagrams('listen', ['enlists', 'google', 'inlets', 'banana']));
     }
 
     /**
@@ -54,7 +54,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsThreeAnagrams(): void
     {
-        $this->assertEquals(
+        $this->assertEqualsCanonicalizing(
             ['gallery', 'regally', 'largely'],
             detectAnagrams('allergy', ['gallery', 'ballerina', 'regally', 'clergy', 'largely', 'leading'])
         );
@@ -66,7 +66,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsMultipleAnagramsWithDifferentCase(): void
     {
-        $this->assertEquals(['Eons', 'ONES'], detectAnagrams('nose', ['Eons', 'ONES']));
+        $this->assertEqualsCanonicalizing(['Eons', 'ONES'], detectAnagrams('nose', ['Eons', 'ONES']));
     }
 
     /**
@@ -75,7 +75,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDoesNotDetectNonAnagramsWithIdenticalChecksum(): void
     {
-        $this->assertEquals([], detectAnagrams('mass', ['last']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('mass', ['last']));
     }
 
     /**
@@ -84,7 +84,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagramsCaseInsensitively(): void
     {
-        $this->assertEquals(['Carthorse'], detectAnagrams('Orchestra', ['cashregister', 'Carthorse', 'radishes']));
+        $this->assertEqualsCanonicalizing(['Carthorse'], detectAnagrams('Orchestra', ['cashregister', 'Carthorse', 'radishes']));
     }
 
     /**
@@ -93,7 +93,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagramsUsingCaseInsensitiveSubject(): void
     {
-        $this->assertEquals(['carthorse'], detectAnagrams('Orchestra', ['cashregister', 'carthorse', 'radishes']));
+        $this->assertEqualsCanonicalizing(['carthorse'], detectAnagrams('Orchestra', ['cashregister', 'carthorse', 'radishes']));
     }
 
     /**
@@ -102,7 +102,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagramsUsingCaseInsensitvePossibleMatches(): void
     {
-        $this->assertEquals(['Carthorse'], detectAnagrams('orchestra', ['cashregister', 'Carthorse', 'radishes']));
+        $this->assertEqualsCanonicalizing(['Carthorse'], detectAnagrams('orchestra', ['cashregister', 'Carthorse', 'radishes']));
     }
 
     /**
@@ -111,7 +111,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDoesNotDetectAAnagramIfTheOriginalWordIsRepeated(): void
     {
-        $this->assertEquals([], detectAnagrams('go', ['goGoGO']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('go', ['goGoGO']));
     }
 
     /**
@@ -120,7 +120,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testAnagramsMustUseAllLettersExactlyOnce(): void
     {
-        $this->assertEquals([], detectAnagrams('tapper', ['patter']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('tapper', ['patter']));
     }
 
     /**
@@ -129,7 +129,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsAreNotAnagramsOfThemselves(): void
     {
-        $this->assertEquals([], detectAnagrams('BANANA', ['BANANA']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('BANANA', ['BANANA']));
     }
 
     /**
@@ -138,7 +138,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsAreNotAnagramsOfThemselvesEvenIfLetterCaseIsPartiallyDifferent(): void
     {
-        $this->assertEquals([], detectAnagrams('BANANA', ['Banana']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('BANANA', ['Banana']));
     }
 
     /**
@@ -147,7 +147,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsAreNotAnagramsOfThemselvesEvenIfLetterCaseIsCompletelyDifferent(): void
     {
-        $this->assertEquals([], detectAnagrams('BANANA', ['banana']));
+        $this->assertEqualsCanonicalizing([], detectAnagrams('BANANA', ['banana']));
     }
 
     /**
@@ -156,7 +156,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsOtherThanThemselvesCanBeAnagrams(): void
     {
-        $this->assertEquals(['Silent'], detectAnagrams('LISTEN', ['LISTEN', 'Silent']));
+        $this->assertEqualsCanonicalizing(['Silent'], detectAnagrams('LISTEN', ['LISTEN', 'Silent']));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -56,7 +56,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
     {
         $this->assertEqualsCanonicalizing(
             ['gallery', 'regally', 'largely'],
-            detectAnagrams('allergy', ['gallery', 'ballerina', 'regally', 'clergy', 'largely', 'leading'])
+            array_values(detectAnagrams('allergy', ['gallery', 'ballerina', 'regally', 'clergy', 'largely', 'leading']))
         );
     }
 

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -36,7 +36,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDoesNotDetectAnagramSubsets(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('good', ['dog', 'goody']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('good', ['dog', 'goody'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -129,7 +129,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsAreNotAnagramsOfThemselves(): void
     {
-        $this->assertEqualsCanonicalizing([], detectAnagrams('BANANA', ['BANANA']));
+        $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('BANANA', ['BANANA'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -93,7 +93,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagramsUsingCaseInsensitiveSubject(): void
     {
-        $this->assertEqualsCanonicalizing(['carthorse'], detectAnagrams('Orchestra', ['cashregister', 'carthorse', 'radishes']));
+        $this->assertEqualsCanonicalizing(['carthorse'], array_values(detectAnagrams('Orchestra', ['cashregister', 'carthorse', 'radishes'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -156,7 +156,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testWordsOtherThanThemselvesCanBeAnagrams(): void
     {
-        $this->assertEqualsCanonicalizing(['Silent'], detectAnagrams('LISTEN', ['LISTEN', 'Silent']));
+        $this->assertEqualsCanonicalizing(['Silent'], array_values(detectAnagrams('LISTEN', ['LISTEN', 'Silent'])));
     }
 
     /**

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -26,7 +26,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
     {
         $this->assertEqualsCanonicalizing(
             ['lemons', 'melons'],
-            detectAnagrams('solemn', ['lemons', 'cherry', 'melons'])
+            array_values(detectAnagrams('solemn', ['lemons', 'cherry', 'melons']))
         );
     }
 

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -102,7 +102,7 @@ class AnagramTest extends PHPUnit\Framework\TestCase
      */
     public function testDetectsAnagramsUsingCaseInsensitvePossibleMatches(): void
     {
-        $this->assertEqualsCanonicalizing(['Carthorse'], detectAnagrams('orchestra', ['cashregister', 'Carthorse', 'radishes']));
+        $this->assertEqualsCanonicalizing(['Carthorse'], array_values(detectAnagrams('orchestra', ['cashregister', 'Carthorse', 'radishes'])));
     }
 
     /**


### PR DESCRIPTION
It was raised in the [forum](http://forum.exercism.org/t/anagram-exercise-instructions-and-tests-dont-align-on-ordering/14816) that the canonical problem specifications have several flaws:
- vague language
- are not congruent with the existing tests in many tracks

This change list removes the dependency on the order of the returned words that have been validated as candidates.