### PR TITLE
:recycle: Use PHPUnit's attributes in place of annotations (#884)

### DIFF
--- a/contribution/generator/src/TestGenerator.php
+++ b/contribution/generator/src/TestGenerator.php
@@ -53,7 +53,11 @@ class TestGenerator
             $method = $this->builderFactory->method($methodName)
                 ->makePublic()
                 ->setReturnType('void')
-                ->setDocComment("/**\n * uuid: {$case->uuid}\n * @testdox {$description}\n */")
+                ->setDocComment("/** uuid: {$case->uuid} */")
+                ->addAttribute(new Node\Attribute(
+                    new Node\Name(\PHPUnit\Framework\Attributes\TestDox::class),
+                    [new Node\Arg(new Node\Scalar\String_($description))],
+                ))
                 ->addStmt(
                     $this->builderFactory->funcCall(
                         '$this->markTestIncomplete',

--- a/exercises/concept/annalyns-infiltration/AnnalynsInfiltrationTest.php
+++ b/exercises/concept/annalyns-infiltration/AnnalynsInfiltrationTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AnnalynsInfiltrationTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -8,9 +11,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot fast attack when the knight is awake
      * @task_id 1
      */
+    #[TestDox('cannot fast attack when the knight is awake')]
     public function testCannotFastAttackWhenKnightIsAwake()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -20,9 +23,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can fast attack when the knight is asleep
      * @task_id 1
      */
+    #[TestDox('can fast attack when the knight is asleep')]
     public function testCanFastAttackWhenKnightIsAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -32,9 +35,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot spy when everyone is asleep
      * @task_id 2
      */
+    #[TestDox('cannot spy when everyone is asleep')]
     public function testCannotSpyWhenEveryoneAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -48,9 +51,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when only the prisoner is awake
      * @task_id 2
      */
+    #[TestDox('can spy when only the prisoner is awake')]
     public function testCanSpyWhenOnlyPrisonerAwake()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -64,9 +67,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when only the archer is awake
      * @task_id 2
      */
+    #[TestDox('can spy when only the archer is awake')]
     public function testCanSpyWhenOnlyArcherAwake()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -80,9 +83,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when only the knight is awake
      * @task_id 2
      */
+    #[TestDox('can spy when only the knight is awake')]
     public function testCanSpyWhenOnlyKnightAwake()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -96,9 +99,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when only the knight is asleep
      * @task_id 2
      */
+    #[TestDox('can spy when only the knight is asleep')]
     public function testCanSpyWhenOnlyKnightAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -112,9 +115,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when only the prisoner is asleep
      * @task_id 2
      */
+    #[TestDox('can spy when only the prisoner is asleep')]
     public function testCanSpyWhenOnlyPrisonerAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -128,9 +131,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when only the archer is asleep
      * @task_id 2
      */
+    #[TestDox('can spy when only the archer is asleep')]
     public function testCanSpyWhenOnlyArcherAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -144,9 +147,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can spy when everyone is awake
      * @task_id 2
      */
+    #[TestDox('can spy when everyone is awake')]
     public function testCanSpyWhenEveryoneAwake()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -160,9 +163,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot signal the prisoner when everyone is asleep
      * @task_id 3
      */
+    #[TestDox('cannot signal the prisoner when everyone is asleep')]
     public function testCannotSignalWhenAllAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -175,9 +178,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can signal the prisoner when archer is asleep
      * @task_id 3
      */
+    #[TestDox('can signal the prisoner when archer is asleep')]
     public function testCanSignalWhenArcherAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -190,9 +193,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot signal the prisoner when prisoner is asleep
      * @task_id 3
      */
+    #[TestDox('cannot signal the prisoner when prisoner is asleep')]
     public function testCannotSignalWhenPrisonerAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -205,9 +208,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot signal the prisoner when no one is asleep
      * @task_id 3
      */
+    #[TestDox('cannot signal the prisoner when no one is asleep')]
     public function testCannotSignalWhenNoOneAsleep()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -220,9 +223,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can liberate the prisoner when no one is awake but dog present
      * @task_id 4
      */
+    #[TestDox('can liberate the prisoner when no one is awake but dog present')]
     public function testCanLiberateWhenAllAsleepAndDogPresent()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -237,9 +240,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can liberate the prisoner when prisoner is awake with dog
      * @task_id 4
      */
+    #[TestDox('can liberate the prisoner when prisoner is awake with dog')]
     public function testCanLiberateWhenPrisonerAwakeWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -254,9 +257,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when archer is awake with dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when archer is awake with dog')]
     public function testCannotLiberateWhenArcherAwakeWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -271,9 +274,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can liberate the prisoner when only knight awake with dog
      * @task_id 4
      */
+    #[TestDox('can liberate the prisoner when only knight awake with dog')]
     public function testCanLiberateWhenKnightAwakeWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -288,9 +291,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when prisoner asleep with dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when prisoner asleep with dog')]
     public function testCannotLiberateWhenPrisonerAsleepWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -305,9 +308,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can liberate the prisoner when only archer asleep with dog
      * @task_id 4
      */
+    #[TestDox('can liberate the prisoner when only archer asleep with dog')]
     public function testCanLiberateWhenArcherAsleepWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -322,9 +325,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when knight asleep with dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when knight asleep with dog')]
     public function testCannotLiberateWhenKnightAsleepWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -339,9 +342,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when all awake with dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when all awake with dog')]
     public function testCannotLiberateWhenAllAwakeWithDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -356,9 +359,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when no one is awake and no dog present
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when no one is awake and no dog present')]
     public function testCannotLiberateWhenAllAsleepAndNoDogPresent()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -373,9 +376,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox can liberate the prisoner when prisoner is awake without dog
      * @task_id 4
      */
+    #[TestDox('can liberate the prisoner when prisoner is awake without dog')]
     public function testCanLiberateWhenPrisonerAwakeWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -390,9 +393,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when archer is awake without dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when archer is awake without dog')]
     public function testCannotLiberateWhenArcherAwakeWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -407,9 +410,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when only knight awake without dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when only knight awake without dog')]
     public function testCannotLiberateWhenKnightAwakeWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -424,9 +427,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when prisoner asleep without dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when prisoner asleep without dog')]
     public function testCannotLiberateWhenPrisonerAsleepWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -441,9 +444,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when only archer asleep without dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when only archer asleep without dog')]
     public function testCannotLiberateWhenArcherAsleepWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -458,9 +461,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when knight asleep without dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when knight asleep without dog')]
     public function testCannotLiberateWhenKnightAsleepWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();
@@ -475,9 +478,9 @@ class AnnalynsInfiltrationTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox cannot liberate the prisoner when all awake without dog
      * @task_id 4
      */
+    #[TestDox('cannot liberate the prisoner when all awake without dog')]
     public function testCannotLiberateWhenAllAwakeWithoutDog()
     {
         $infiltration = new AnnalynsInfiltration();

--- a/exercises/concept/bootstrap.sh
+++ b/exercises/concept/bootstrap.sh
@@ -70,17 +70,18 @@ PHP_STUB
 cat <<- PHP_STUB >> "${base_dir}/${test_file}"
 <?php
 
-class ${new_classname}Test extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ${new_classname}Test extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
         require_once '${new_classname}.php';
     }
 
-    /**
-     * @testdox some test stub
-     * @task_id 1
-     */
+    /** @task_id 1 */
+    #[TestDox('some test stub')]
     public function testStub()
     {
         \$class = new ${new_classname}();

--- a/exercises/concept/city-office/CityOfficeTest.php
+++ b/exercises/concept/city-office/CityOfficeTest.php
@@ -1,17 +1,20 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
 require_once 'ReflectionAssertions.php';
 require_once 'Address.php';
 require_once 'Form.php';
 
-class CityOfficeTest extends PHPUnit\Framework\TestCase
+class CityOfficeTest extends TestCase
 {
     use ReflectionAssertions;
 
     /**
-     * @testdox specify a string type for Address::$street
      * @task_id 1
      */
+    #[TestDox('specify a string type for Address::$street')]
     public function testTypeOfAddressStreetProperty()
     {
         $this->assertProperty(
@@ -26,9 +29,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify a string type for Address::$postal_code
      * @task_id 1
      */
+    #[TestDox('specify a string type for Address::$postal_code')]
     public function testTypeOfAddressPostalCodeProperty()
     {
         $this->assertProperty(
@@ -43,9 +46,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify a string type for Address::$city
      * @task_id 1
      */
+    #[TestDox('specify a string type for Address::$city')]
     public function testTypeOfAddressCityProperty()
     {
         $this->assertProperty(
@@ -60,9 +63,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::blanks length parameter
      * @task_id 2
      */
+    #[TestDox('specify an int type for Form::blanks length parameter')]
     public function testParameterTypeOfFormBlanksLengthParameter()
     {
         $this->assertMethodParameter(
@@ -80,9 +83,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::blanks return type
      * @task_id 2
      */
+    #[TestDox('specify an int type for Form::blanks return type')]
     public function testParameterTypeOfFormBlanksReturnType()
     {
         $this->assertMethodReturnType(
@@ -97,9 +100,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::letters word parameter
      * @task_id 3
      */
+    #[TestDox('specify an int type for Form::letters word parameter')]
     public function testParameterTypeOfFormLettersWordParameter()
     {
         $this->assertMethodParameter(
@@ -117,9 +120,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::letters return type
      * @task_id 3
      */
+    #[TestDox('specify an int type for Form::letters return type')]
     public function testParameterTypeOfFormLettersReturnType()
     {
         $this->assertMethodReturnType(
@@ -134,9 +137,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::checkLength word parameter
      * @task_id 4
      */
+    #[TestDox('specify an int type for Form::checkLength word parameter')]
     public function testParameterTypeOfFormCheckLengthWordParameter()
     {
         $this->assertMethodParameter(
@@ -154,9 +157,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::checkLength max_length parameter
      * @task_id 4
      */
+    #[TestDox('specify an int type for Form::checkLength max_length parameter')]
     public function testParameterTypeOfFormCheckLengthMaxLengthParameter()
     {
         $this->assertMethodParameter(
@@ -174,9 +177,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::checkLength return type
      * @task_id 4
      */
+    #[TestDox('specify an int type for Form::checkLength return type')]
     public function testParameterTypeOfFormCheckLengthReturnType()
     {
         $this->assertMethodReturnType(
@@ -191,9 +194,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an Address type for Form::formatAddress address parameter
      * @task_id 5
      */
+    #[TestDox('specify an Address type for Form::formatAddress address parameter')]
     public function testParameterTypeOfFormFormatAddressParameter()
     {
         $this->assertMethodParameter(
@@ -211,9 +214,9 @@ class CityOfficeTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox specify an int type for Form::checkLength return type
      * @task_id 5
      */
+    #[TestDox('specify an int type for Form::checkLength return type')]
     public function testParameterTypeOfFormFormatAddressReturnType()
     {
         $this->assertMethodReturnType(

--- a/exercises/concept/language-list/LanguageListTest.php
+++ b/exercises/concept/language-list/LanguageListTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class LanguageListTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class LanguageListTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -8,9 +11,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox calling language_list without arguments, returns empty array
      * @task_id 1
      */
+    #[TestDox('calling language_list without arguments, returns empty array')]
     public function testEmpty()
     {
         $language_list = language_list();
@@ -18,9 +21,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox variadic call to language_list with 1 arg returns args
      * @task_id 2
      */
+    #[TestDox('variadic call to language_list with 1 arg returns args')]
     public function testVariadicCallWithOne()
     {
         $language_list = language_list('c');
@@ -28,9 +31,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox variadic call to language_list with 2 arg returns args
      * @task_id 2
      */
+    #[TestDox('variadic call to language_list with 2 arg returns args')]
     public function testVariadicCallWithTwo()
     {
         $language_list = language_list('c', 'cpp');
@@ -38,9 +41,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox variadic call to language_list with 2 arg returns args
      * @task_id 2
      */
+    #[TestDox('variadic call to language_list with 2 arg returns args')]
     public function testVariadicCallWithThree()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -48,9 +51,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox push new languages to the back of the list
      * @task_id 3
      */
+    #[TestDox('push new languages to the back of the list')]
     public function testAddingToLanguageList()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -59,9 +62,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox when pushing, original is unchanged
      * @task_id 3
      */
+    #[TestDox('when pushing, original is unchanged')]
     public function testAddingDoesNotMutate()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -70,9 +73,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox remove completed language from the front of the list
      * @task_id 4
      */
+    #[TestDox('remove completed language from the front of the list')]
     public function testCompleteLanguageList()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -81,9 +84,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox when pushing, original is unchanged
      * @task_id 4
      */
+    #[TestDox('when pushing, original is unchanged')]
     public function testPruningDoesNotMutate()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -92,9 +95,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox index and return the first language
      * @task_id 5
      */
+    #[TestDox('index and return the first language')]
     public function testCurrentReturnsTheFirstLanguage()
     {
         $language_list = language_list('php');
@@ -103,9 +106,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox when getting the first language, original is unchanged
      * @task_id 5
      */
+    #[TestDox('when getting the first language, original is unchanged')]
     public function testGettingFirstDoesNotMutate()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -114,9 +117,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox the count of the languages in the language list
      * @task_id 6
      */
+    #[TestDox('the count of the languages in the language list')]
     public function testLanguageListCount()
     {
         $language_list = language_list('c', 'cpp', 'php');
@@ -125,9 +128,9 @@ class LanguageListTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox when getting the language count, original is unchanged
      * @task_id 6
      */
+    #[TestDox('when getting the language count, original is unchanged')]
     public function testLanguageListCountDoesNotMutate()
     {
         $language_list = language_list('c', 'cpp', 'php');

--- a/exercises/concept/lasagna/LasagnaTest.php
+++ b/exercises/concept/lasagna/LasagnaTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
 /**
  * We use `assertEquals()` here for its loose type checking. We don't care if
  * the student returns numeric strings or integers in this exercise.
@@ -10,11 +13,11 @@ declare(strict_types=1);
  * - Do not use calls with named arguments.
  *   Use them only when the exercise requires named arguments (e.g. because the exercise is about named arguments).
  *   Named arguments are in the way of defining argument names the students want (e.g. in their native language).
- * - Add @testdox with a useful test title, e.g. the task heading from `instructions.md`.
+ * - Add `#[TestDox()]` with a useful test title, e.g. the task heading from `instructions.md`.
  *   The online editor shows that to students.
- * - Add fail messages to assertions where helpful to tell students more than @testdox says.
+ * - Add fail messages to assertions where helpful to tell students more than `#[TestDox()]` says.
  */
-class LasagnaTest extends PHPUnit\Framework\TestCase
+class LasagnaTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -22,9 +25,9 @@ class LasagnaTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Returns cooking time in minutes as stated in the cook book
      * @task_id 1
      */
+    #[TestDox('Returns cooking time in minutes as stated in the cook book')]
     public function testExpectedCookTime(): void
     {
         $lasagna = new Lasagna();
@@ -32,9 +35,9 @@ class LasagnaTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Returns how many minutes more the lasagna must be in the oven when it is 20 minutes in the oven already
      * @task_id 2
      */
+    #[TestDox('Returns how many minutes more the lasagna must be in the oven when it is 20 minutes in the oven already')]
     public function testRemainingCookTime(): void
     {
         $lasagna = new Lasagna();
@@ -42,9 +45,9 @@ class LasagnaTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Returns how many minutes more the lasagna must be in the oven when it is 30 minutes in the oven already
      * @task_id 2
      */
+    #[TestDox('Returns how many minutes more the lasagna must be in the oven when it is 30 minutes in the oven already')]
     public function testAnotherRemainingCookTime(): void
     {
         $lasagna = new Lasagna();
@@ -52,9 +55,9 @@ class LasagnaTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Returns how many minutes you spent preparing the lasagna with 7 layers
      * @task_id 3
      */
+    #[TestDox('Returns how many minutes you spent preparing the lasagna with 7 layers')]
     public function testTotalPreparationTime(): void
     {
         $lasagna = new Lasagna();
@@ -62,9 +65,9 @@ class LasagnaTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Returns the total minutes you have worked on the lasagna with 4 layers that is 13 minutes in the oven
      * @task_id 4
      */
+    #[TestDox('Returns the total minutes you have worked on the lasagna with 4 layers that is 13 minutes in the oven')]
     public function testTotalElapsedTime(): void
     {
         $lasagna = new Lasagna();
@@ -72,9 +75,9 @@ class LasagnaTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Returns the message indicating that the lasagna is ready to eat
      * @task_id 5
      */
+    #[TestDox('Returns the message indicating that the lasagna is ready to eat')]
     public function testAlarm(): void
     {
         $lasagna = new Lasagna();

--- a/exercises/concept/lucky-numbers/LuckyNumbersTest.php
+++ b/exercises/concept/lucky-numbers/LuckyNumbersTest.php
@@ -1,6 +1,10 @@
 <?php
 
-class LuckyNumbersTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class LuckyNumbersTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -8,10 +12,10 @@ class LuckyNumbersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Sums up $digitsOfNumber1 and $digitsOfNumber2 to $expected
      * @task_id 1
-     * @dataProvider sumUpTestCases
      */
+    #[DataProvider('sumUpTestCases')]
+    #[TestDox('Sums up $digitsOfNumber1 and $digitsOfNumber2 to $expected')]
     public function testSumUp(
         array $digitsOfNumber1,
         array $digitsOfNumber2,
@@ -38,10 +42,10 @@ class LuckyNumbersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Detects palindromic number $number
      * @task_id 2
-     * @dataProvider isPalindromeTestCases
      */
+    #[DataProvider('isPalindromeTestCases')]
+    #[TestDox('Detects palindromic number $number')]
     public function testIsPalindrome(int $number): void
     {
         $class = new LuckyNumbers();
@@ -63,10 +67,10 @@ class LuckyNumbersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Detects non-palindromic number $number
      * @task_id 2
-     * @dataProvider isNoPalindromeTestCases
      */
+    #[DataProvider('isNoPalindromeTestCases')]
+    #[TestDox('Detects non-palindromic number $number')]
     public function testIsNoPalindrome(int $number): void
     {
         $class = new LuckyNumbers();
@@ -86,9 +90,9 @@ class LuckyNumbersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Error message for empty input
      * @task_id 3
      */
+    #[TestDox('Error message for empty input')]
     public function testErrorMessageForEmptyInput(): void
     {
         $class = new LuckyNumbers();
@@ -99,10 +103,10 @@ class LuckyNumbersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Error message for invalid input $input
      * @task_id 3
-     * @dataProvider invalidInputTestCases
      */
+    #[DataProvider('invalidInputTestCases')]
+    #[TestDox('Error message for invalid input $input')]
     public function testErrorMessageForInvalidInput(
         string $input
     ): void {
@@ -124,10 +128,10 @@ class LuckyNumbersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox Error message for invalid input $input
      * @task_id 3
-     * @dataProvider validInputTestCases
      */
+    #[DataProvider('validInputTestCases')]
+    #[TestDox('Error message for invalid input $input')]
     public function testErrorMessageForValidInput(
         string $input
     ): void {

--- a/exercises/concept/pizza-pi/PizzaPiTest.php
+++ b/exercises/concept/pizza-pi/PizzaPiTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class PizzaPiTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class PizzaPiTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -8,9 +11,9 @@ class PizzaPiTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox determine how much dough is required
      * @task_id 1
      */
+    #[TestDox('determine how much dough is required')]
     public function testCalculateDoughRequirement()
     {
         $pizza_pi = new PizzaPi();
@@ -20,9 +23,9 @@ class PizzaPiTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox determine how many cans of sauce are required
      * @task_id 2
      */
+    #[TestDox('determine how many cans of sauce are required')]
     public function testCalculateSauceRequirement()
     {
         $pizza_pi = new PizzaPi();
@@ -32,9 +35,9 @@ class PizzaPiTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox determine how many pizzas a cube of cheese can cover
      * @task_id 3
      */
+    #[TestDox('determine how many pizzas a cube of cheese can cover')]
     public function testCalculateCheeseCoverage()
     {
         $pizza_pi = new PizzaPi();
@@ -44,9 +47,9 @@ class PizzaPiTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox determine number of pieces remaining when evenly dividing
      * @task_id 4
      */
+    #[TestDox('determine number of pieces remaining when evenly dividing')]
     public function testCalculateLeftOverSlicesWithoutLeftOver()
     {
         $pizza_pi = new PizzaPi();
@@ -56,9 +59,9 @@ class PizzaPiTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox determine number of pieces remaining when not evenly dividing
      * @task_id 4
      */
+    #[TestDox('determine number of pieces remaining when not evenly dividing')]
     public function testCalculateLeftOverSlicesWithLeftOver()
     {
         $pizza_pi = new PizzaPi();

--- a/exercises/concept/sweethearts/HighSchoolSweetheartTest.php
+++ b/exercises/concept/sweethearts/HighSchoolSweetheartTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class HighSchoolSweetheartTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -8,9 +11,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox gets the first letter from a string
      * @task_id 1
      */
+    #[TestDox('gets the first letter from a string')]
     public function testFirstLetter()
     {
         $sweetheart = new HighSchoolSweetheart();
@@ -18,9 +21,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox getting the first letter doesn't change the case
      * @task_id 1
      */
+    #[TestDox("getting the first letter doesn't change the case")]
     public function testFirstLetterDoesNotChangeCase()
     {
         $sweetheart = new HighSchoolSweetheart();
@@ -28,9 +31,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox getting the first letter removes whitespace from the name
      * @task_id 1
      */
+    #[TestDox('getting the first letter removes whitespace from the name')]
     public function testFirstLetterRemovesWhitespace()
     {
         $sweetheart = new HighSchoolSweetheart();
@@ -38,9 +41,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox gets the first letter and appends a dot
      * @task_id 2
      */
+    #[TestDox('gets the first letter and appends a dot')]
     public function testCreatesInitial()
     {
         $sweetheart = new HighSchoolSweetheart();
@@ -48,9 +51,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox creates an uppercase initial
      * @task_id 2
      */
+    #[TestDox('creates an uppercase initial')]
     public function testCreatesUppercaseInitial()
     {
         $sweetheart = new HighSchoolSweetheart();
@@ -58,9 +61,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox creates a set of initials
      * @task_id 3
      */
+    #[TestDox('creates a set of initials')]
     public function testCreatesInitials()
     {
         $sweetheart = new HighSchoolSweetheart();
@@ -68,9 +71,9 @@ class HighSchoolSweetheartTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox creates a set of initials, wrapped in a heart
      * @task_id 4
      */
+    #[TestDox('creates a set of initials, wrapped in a heart')]
     public function testPair()
     {
         $sweetheart = new HighSchoolSweetheart();

--- a/exercises/concept/windowing-system/ProgramWindowTest.php
+++ b/exercises/concept/windowing-system/ProgramWindowTest.php
@@ -1,6 +1,9 @@
 <?php
 
-class ProgramWindowTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ProgramWindowTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -10,9 +13,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow has a $y property
      * @task_id 1
      */
+    #[TestDox('assert ProgramWindow has a $y property')]
     public function testHasPropertyY()
     {
         $reflector = new ReflectionClass(ProgramWindow::class);
@@ -23,9 +26,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow has a $x property
      * @task_id 1
      */
+    #[TestDox('assert ProgramWindow has a $x property')]
     public function testHasPropertyX()
     {
         $reflector = new ReflectionClass(ProgramWindow::class);
@@ -36,9 +39,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow has a $height property
      * @task_id 1
      */
+    #[TestDox('assert ProgramWindow has a $height property')]
     public function testHasPropertyHeight()
     {
         $reflector = new ReflectionClass(ProgramWindow::class);
@@ -49,9 +52,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow has a $width property
      * @task_id 1
      */
+    #[TestDox('assert ProgramWindow has a $width property')]
     public function testHasPropertyWidth()
     {
         $reflector = new ReflectionClass(ProgramWindow::class);
@@ -62,9 +65,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow has a constructor initial values
      * @task_id 2
      */
+    #[TestDox('assert ProgramWindow has a constructor initial values')]
     public function testHasConstructorSettingInitialValues()
     {
         $window = new ProgramWindow();
@@ -75,9 +78,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert Position class exists, with constructor, properties
      * @task_id 3
      */
+    #[TestDox('assert Position class exists, with constructor, properties')]
     public function testSizeHasConstructorSettingInitialValues()
     {
         $size = new Size(300, 700);
@@ -86,9 +89,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow::resize function exists
      * @task_id 3
      */
+    #[TestDox('assert ProgramWindow::resize function exists')]
     public function testProgramWindowResize()
     {
         $window = new ProgramWindow();
@@ -99,9 +102,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert Position class exists, with constructor, properties
      * @task_id 4
      */
+    #[TestDox('assert Position class exists, with constructor, properties')]
     public function testPositionHasConstructorSettingInitialValues()
     {
         $position = new Position(30, 70);
@@ -110,9 +113,9 @@ class ProgramWindowTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @testdox assert ProgramWindow::move function exists
      * @task_id 4
      */
+    #[TestDox('assert ProgramWindow::move function exists')]
     public function testProgramWindowMove()
     {
         $window = new ProgramWindow();

--- a/exercises/practice/accumulate/AccumulateTest.php
+++ b/exercises/practice/accumulate/AccumulateTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class AccumulateTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class AccumulateTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/acronym/AcronymTest.php
+++ b/exercises/practice/acronym/AcronymTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class AcronymTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AcronymTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1e22cceb-c5e4-4562-9afe-aef07ad1eaf4
-     * @testdox Basic
      */
+    #[TestDox('Basic')]
     public function testBasicTitleCase(): void
     {
         $this->assertEquals('PNG', acronym('Portable Network Graphics'));
@@ -20,8 +23,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 79ae3889-a5c0-4b01-baf0-232d31180c08
-     * @testdox Lowercase words
      */
+    #[TestDox('Lowercase words')]
     public function testLowerCaseWord(): void
     {
         $this->assertEquals('ROR', acronym('Ruby on Rails'));
@@ -29,8 +32,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ec7000a7-3931-4a17-890e-33ca2073a548
-     * @testdox Punctuation
      */
+    #[TestDox('Punctuation')]
     public function testPunctuation(): void
     {
         $this->assertEquals('FIFO', acronym('First In, First Out'));
@@ -38,8 +41,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 32dd261c-0c92-469a-9c5c-b192e94a63b0
-     * @testdox All caps word
      */
+    #[TestDox('All caps word')]
     public function testAllCapsWords(): void
     {
         $this->assertEquals('GIMP', acronym('GNU Image Manipulation Program'));
@@ -47,8 +50,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ae2ac9fa-a606-4d05-8244-3bcc4659c1d4
-     * @testdox Punctuation without whitespace
      */
+    #[TestDox('Punctuation without whitespace')]
     public function testHyphenated(): void
     {
         $this->assertEquals('CMOS', acronym('Complementary metal-oxide semiconductor'));
@@ -56,8 +59,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9
-     * @testdox Very long abbreviation
      */
+    #[TestDox('Very long abbreviation')]
     public function testVeryLongAbbreviation(): void
     {
         $this->assertEquals('ROTFLSHTMDCOALM', acronym('Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me'));
@@ -65,8 +68,8 @@ class AcronymTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6a078f49-c68d-4b7b-89af-33a1a98c28cc
-     * @testdox Consecutive delimiters
      */
+    #[TestDox('Consecutive delimiters')]
     public function testConsecutiveDelimiters(): void
     {
         $this->assertEquals('SIMUFTA', acronym('Something - I made up from thin air'));

--- a/exercises/practice/affine-cipher/AffineCipherTest.php
+++ b/exercises/practice/affine-cipher/AffineCipherTest.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
 /**
  * The test are divided into two groups:
  *
  * * Encoding from English to affine cipher,
  * * Decoding from affine cipher to all-lowercase-mashed-together English
  */
-class AffineCipherTest extends PHPUnit\Framework\TestCase
+class AffineCipherTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -18,11 +21,10 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Encoding from English to affine cipher
      */
-
     /**
      * uuid 2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a
-     * @testdox encode yes
      */
+    #[TestDox('encode yes')]
     public function testEncodeYes(): void
     {
         $this->assertEquals('xbt', encode('yes', 5, 7));
@@ -30,8 +32,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 785bade9-e98b-4d4f-a5b0-087ba3d7de4b
-     * @testdox encode no
      */
+    #[TestDox('encode no')]
     public function testEncodeNo(): void
     {
         $this->assertEquals('fu', encode('no', 15, 18));
@@ -39,8 +41,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2854851c-48fb-40d8-9bf6-8f192ed25054
-     * @testdox encode OMG
      */
+    #[TestDox('encode OMG')]
     public function testEncodeOMG(): void
     {
         $this->assertEquals('lvz', encode('OMG', 21, 3));
@@ -48,8 +50,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bc0c1244-b544-49dd-9777-13a770be1bad
-     * @testdox encode O M G
      */
+    #[TestDox('encode O M G')]
     public function testEncodeOMGWithSpaces(): void
     {
         $this->assertEquals('hjp', encode('O M G', 25, 47));
@@ -57,8 +59,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 381a1a20-b74a-46ce-9277-3778625c9e27
-     * @testdox encode mindblowingly
      */
+    #[TestDox('encode mindblowingly')]
     public function testEncodemindblowingly(): void
     {
         $this->assertEquals('rzcwa gnxzc dgt', encode('mindblowingly', 11, 15));
@@ -66,8 +68,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6686f4e2-753b-47d4-9715-876fdc59029d
-     * @testdox encode numbers
      */
+    #[TestDox('encode numbers')]
     public function testEncodenumbers(): void
     {
         $this->assertEquals(
@@ -78,8 +80,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3
-     * @testdox encode deep thought
      */
+    #[TestDox('encode deep thought')]
     public function testEncodeDeepThought(): void
     {
         $this->assertEquals('iynia fdqfb ifje', encode('Truth is fiction.', 5, 17));
@@ -87,8 +89,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c93a8a4d-426c-42ef-9610-76ded6f7ef57
-     * @testdox encode all the letters
      */
+    #[TestDox('encode all the letters')]
     public function testEncodeAllTheLetters(): void
     {
         $this->assertEquals(
@@ -99,8 +101,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0673638a-4375-40bd-871c-fb6a2c28effb
-     * @testdox encode with a not coprime to m
      */
+    #[TestDox('encode with a not coprime to m')]
     public function testEncodeWithANotCoprimeToM(): void
     {
         $this->expectException(Exception::class);
@@ -110,11 +112,10 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Decoding from affine cipher to all-lowercase-mashed-together English
      */
-
     /**
      * uuid 3f0ac7e2-ec0e-4a79-949e-95e414953438
-     * @testdox decode exercism
      */
+    #[TestDox('decode exercism')]
     public function testDecodeExercism(): void
     {
         $this->assertEquals('exercism', decode('tytgn fjr', 3, 7));
@@ -122,8 +123,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 241ee64d-5a47-4092-a5d7-7939d259e077
-     * @testdox decode a sentence
      */
+    #[TestDox('decode a sentence')]
     public function testDecodeASentence(): void
     {
         $this->assertEquals(
@@ -134,8 +135,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 33fb16a1-765a-496f-907f-12e644837f5e
-     * @testdox decode numbers
      */
+    #[TestDox('decode numbers')]
     public function testDecodeNumbers(): void
     {
         $this->assertEquals(
@@ -146,8 +147,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 20bc9dce-c5ec-4db6-a3f1-845c776bcbf7
-     * @testdox decode all the letters
      */
+    #[TestDox('decode all the letters')]
     public function testDecodeAllTheLetters(): void
     {
         $this->assertEquals(
@@ -158,8 +159,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 623e78c0-922d-49c5-8702-227a3e8eaf81
-     * @testdox decode with no spaces in input
      */
+    #[TestDox('decode with no spaces in input')]
     public function testDecodeWithNoSpacesInInput(): void
     {
         $this->assertEquals(
@@ -170,8 +171,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 58fd5c2a-1fd9-4563-a80a-71cff200f26f
-     * @testdox decode with too many spaces
      */
+    #[TestDox('decode with too many spaces')]
     public function testDecodeWithTooManySpaces(): void
     {
         $this->assertEquals(
@@ -182,8 +183,8 @@ class AffineCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b004626f-c186-4af9-a3f4-58f74cdb86d5
-     * @testdox decode with a not coprime to m
      */
+    #[TestDox('decode with a not coprime to m')]
     public function testDecodeWithANotCoprimeToM(): void
     {
         $this->expectException(Exception::class);

--- a/exercises/practice/all-your-base/AllYourBaseTest.php
+++ b/exercises/practice/all-your-base/AllYourBaseTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class AllYourBaseTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AllYourBaseTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5ce422f9-7a4b-4f44-ad29-49c67cb32d2c
-     * @testdox Single bit one to decimal
      */
+    #[TestDox('Single bit one to decimal')]
     public function testSingleBitOneToDecimal(): void
     {
         $this->assertEquals([1], rebase(2, [1], 10));
@@ -20,8 +23,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0cc3fea8-bb79-46ac-a2ab-5a2c93051033
-     * @testdox Binary to single decimal
      */
+    #[TestDox('Binary to single decimal')]
     public function testBinaryToSingleDecimal(): void
     {
         $this->assertEquals([5], rebase(2, [1, 0, 1], 10));
@@ -29,8 +32,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8
-     * @testdox Single decimal to binary
      */
+    #[TestDox('Single decimal to binary')]
     public function testSingleDecimalToBinary(): void
     {
         $this->assertEquals([1, 0, 1], rebase(10, [5], 2));
@@ -38,8 +41,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2c45cf54-6da3-4748-9733-5a3c765d925b
-     * @testdox Binary to multiple decimal
      */
+    #[TestDox('Binary to multiple decimal')]
     public function testBinaryToMultipleDecimal(): void
     {
         $this->assertEquals([4, 2], rebase(2, [1, 0, 1, 0, 1, 0], 10));
@@ -47,8 +50,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 65ddb8b4-8899-4fcc-8618-181b2cf0002d
-     * @testdox Decimal to binary
      */
+    #[TestDox('Decimal to binary')]
     public function testDecimalToBinary(): void
     {
         $this->assertEquals([1, 0, 1, 0, 1, 0], rebase(10, [4, 2], 2));
@@ -56,8 +59,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8d418419-02a7-4824-8b7a-352d33c6987e
-     * @testdox Trinary to hexadecimal
      */
+    #[TestDox('Trinary to hexadecimal')]
     public function testTrinaryToHexadecimal(): void
     {
         $this->assertEquals([2, 10], rebase(3, [1, 1, 2, 0], 16));
@@ -65,8 +68,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d3901c80-8190-41b9-bd86-38d988efa956
-     * @testdox Hexadecimal to trinary
      */
+    #[TestDox('Hexadecimal to trinary')]
     public function testHexadecimalToTrinary(): void
     {
         $this->assertEquals([1, 1, 2, 0], rebase(16, [2, 10], 3));
@@ -74,8 +77,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5d42f85e-21ad-41bd-b9be-a3e8e4258bbf
-     * @testdox 15-bit integer
      */
+    #[TestDox('15-bit integer')]
     public function test15BitIntegers(): void
     {
         $this->assertEquals([6, 10, 45], rebase(97, [3, 46, 60], 73));
@@ -83,8 +86,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d68788f7-66dd-43f8-a543-f15b6d233f83
-     * @testdox Empty list
      */
+    #[TestDox('Empty list')]
     public function testEmptyList(): void
     {
         $this->assertEquals([0], rebase(2, [], 10));
@@ -92,8 +95,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5e27e8da-5862-4c5f-b2a9-26c0382b6be7
-     * @testdox Single zero
      */
+    #[TestDox('Single zero')]
     public function testSingleZero(): void
     {
         $this->assertEquals([0], rebase(10, [0], 2));
@@ -101,8 +104,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2
-     * @testdox Multiple zeros
      */
+    #[TestDox('Multiple zeros')]
     public function testMultipleZeros(): void
     {
         $this->assertEquals([0], rebase(10, [0, 0, 0], 2));
@@ -110,8 +113,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3530cd9f-8d6d-43f5-bc6e-b30b1db9629b
-     * @testdox Leading zeros
      */
+    #[TestDox('Leading zeros')]
     public function testLeadingZeros(): void
     {
         $this->assertEquals([4, 2], rebase(7, [0, 6, 0], 10));
@@ -119,8 +122,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a6b476a1-1901-4f2a-92c4-4d91917ae023
-     * @testdox Input base is one
      */
+    #[TestDox('Input base is one')]
     public function testFirstBaseIsOne(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -131,8 +134,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e21a693a-7a69-450b-b393-27415c26a016
-     * @testdox Input base is zero
      */
+    #[TestDox('Input base is zero')]
     public function testFirstBaseIsZero(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -143,8 +146,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 54a23be5-d99e-41cc-88e0-a650ffe5fcc2
-     * @testdox Input base is negative
      */
+    #[TestDox('Input base is negative')]
     public function testFirstBaseIsNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -155,8 +158,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9eccf60c-dcc9-407b-95d8-c37b8be56bb6
-     * @testdox Negative digit
      */
+    #[TestDox('Negative digit')]
     public function testNegativeDigit(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -167,8 +170,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 232fa4a5-e761-4939-ba0c-ed046cd0676a
-     * @testdox Invalid positive digit
      */
+    #[TestDox('Invalid positive digit')]
     public function testInvalidPositiveDigit(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -179,8 +182,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 14238f95-45da-41dc-95ce-18f860b30ad3
-     * @testdox Output base is one
      */
+    #[TestDox('Output base is one')]
     public function testSecondBaseIsOne(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -191,8 +194,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 73dac367-da5c-4a37-95fe-c87fad0a4047
-     * @testdox Output base is zero
      */
+    #[TestDox('Output base is zero')]
     public function testSecondBaseIsZero(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -203,8 +206,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 13f81f42-ff53-4e24-89d9-37603a48ebd9
-     * @testdox Output base is negative
      */
+    #[TestDox('Output base is negative')]
     public function testSecondBaseIsNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -215,8 +218,8 @@ class AllYourBaseTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0e6c895d-8a5d-4868-a345-309d094cfe8d
-     * @testdox Both bases are negative
      */
+    #[TestDox('Both bases are negative')]
     public function testBothBasesIsNegative(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/practice/allergies/AllergiesTest.php
+++ b/exercises/practice/allergies/AllergiesTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class AllergiesTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class AllergiesTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -10,10 +13,9 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider provideListOfAllergen
-     *
      * @param Allergen $allergen
      */
+    #[DataProvider('provideListOfAllergen')]
     public function testNoAllergiesMeansNotAllergicToAnything($allergen): void
     {
         $allergies = new Allergies(0);
@@ -22,10 +24,9 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider provideListOfAllergen
-     *
      * @param Allergen $allergicTo
      */
+    #[DataProvider('provideListOfAllergen')]
     public function testAllergiesToOneAllergen($allergicTo): void
     {
         $allergies = new Allergies($allergicTo->getScore());
@@ -111,9 +112,7 @@ class AllergiesTest extends PHPUnit\Framework\TestCase
         ], array_values($allergies->getList()));
     }
 
-    /**
-     * @dataProvider provideListOfAllergen
-     */
+    #[DataProvider('provideListOfAllergen')]
     public function testIsAllergicToEverything($allergen): void
     {
         $allergies = new Allergies(255);

--- a/exercises/practice/alphametics/AlphameticsTest.php
+++ b/exercises/practice/alphametics/AlphameticsTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class AlphameticsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AlphameticsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e0c08b07-9028-4d5f-91e1-d178fead8e1a
-     * @testdox puzzle with three letters
      */
+    #[TestDox('puzzle with three letters')]
     public function testSolveThreeLetterPuzzle(): void
     {
         $alphametics = new Alphametics();
@@ -21,8 +24,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a504ee41-cb92-4ec2-9f11-c37e95ab3f25
-     * @testdox solution must have unique value for each letter
      */
+    #[TestDox('solution must have unique value for each letter')]
     public function testSolutionsMustHaveUniqueValuesForLetters(): void
     {
         $alphametics = new Alphametics();
@@ -31,8 +34,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a
-     * @testdox leading zero solution is invalid
      */
+    #[TestDox('leading zero solution is invalid')]
     public function testLeadingZerosAreInvalid(): void
     {
         $alphametics = new Alphametics();
@@ -41,8 +44,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8a3e3168-d1ee-4df7-94c7-b9c54845ac3a
-     * @testdox puzzle with two digits final carry
      */
+    #[TestDox('puzzle with two digits final carry')]
     public function testPuzzleWithTwoDigitsFinalCarry(): void
     {
         $alphametics = new Alphametics();
@@ -52,8 +55,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a9630645-15bd-48b6-a61e-d85c4021cc09
-     * @testdox puzzle with four letters
      */
+    #[TestDox('puzzle with four letters')]
     public function testPuzzleWithFourLetters(): void
     {
         $alphametics = new Alphametics();
@@ -63,8 +66,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3d905a86-5a52-4e4e-bf80-8951535791bd
-     * @testdox puzzle with six letters
      */
+    #[TestDox('puzzle with six letters')]
     public function testPuzzleWithSixLetters(): void
     {
         $alphametics = new Alphametics();
@@ -74,8 +77,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4febca56-e7b7-4789-97b9-530d09ba95f0
-     * @testdox puzzle with seven letters
      */
+    #[TestDox('puzzle with seven letters')]
     public function testPuzzleWithSevenLetter(): void
     {
         $alphametics = new Alphametics();
@@ -85,8 +88,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 12125a75-7284-4f9a-a5fa-191471e0d44f
-     * @testdox puzzle with eight letters
      */
+    #[TestDox('puzzle with eight letters')]
     public function testPuzzleWithEightLetters(): void
     {
         $alphametics = new Alphametics();
@@ -96,8 +99,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fb05955f-38dc-477a-a0b6-5ef78969fffa
-     * @testdox puzzle with ten letters
      */
+    #[TestDox('puzzle with ten letters')]
     public function testPuzzleWithTenLetters(): void
     {
         $alphametics = new Alphametics();
@@ -118,8 +121,8 @@ class AlphameticsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9a101e81-9216-472b-b458-b513a7adacf7
-     * @testdox puzzle with ten letters and 199 addends
      */
+    #[TestDox('puzzle with ten letters and 199 addends')]
     public function testPuzzleWithTenLettersAnd199Addends(): void
     {
         $alphametics = new Alphametics();

--- a/exercises/practice/anagram/AnagramTest.php
+++ b/exercises/practice/anagram/AnagramTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class AnagramTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AnagramTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dd40c4d2-3c8b-44e5-992a-f42b393ec373
-     * @testdox No matches
      */
+    #[TestDox('No matches')]
     public function testNoMatches(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('diaper', ['hello', 'world', 'zombies', 'pants'])));
@@ -20,8 +23,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 03eb9bbe-8906-4ea0-84fa-ffe711b52c8b
-     * @testdox Detects two anagrams
      */
+    #[TestDox('Detects two anagrams')]
     public function testDetectsTwoAnagrams(): void
     {
         $this->assertEqualsCanonicalizing(
@@ -32,8 +35,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a27558ee-9ba0-4552-96b1-ecf665b06556
-     * @testdox Does not detect anagram subsets
      */
+    #[TestDox('Does not detect anagram subsets')]
     public function testDoesNotDetectAnagramSubsets(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('good', ['dog', 'goody'])));
@@ -41,8 +44,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 64cd4584-fc15-4781-b633-3d814c4941a4
-     * @testdox Detects anagram
      */
+    #[TestDox('Detects anagram')]
     public function testDetectsAnagram(): void
     {
         $this->assertEqualsCanonicalizing(['inlets'], array_values(detectAnagrams('listen', ['enlists', 'google', 'inlets', 'banana'])));
@@ -50,8 +53,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 99c91beb-838f-4ccd-b123-935139917283
-     * @testdox Detects three anagrams
      */
+    #[TestDox('Detects three anagrams')]
     public function testDetectsThreeAnagrams(): void
     {
         $this->assertEqualsCanonicalizing(
@@ -62,8 +65,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 78487770-e258-4e1f-a646-8ece10950d90
-     * @testdox Detects multiple anagrams with different case
      */
+    #[TestDox('Detects multiple anagrams with different case')]
     public function testDetectsMultipleAnagramsWithDifferentCase(): void
     {
         $this->assertEqualsCanonicalizing(['Eons', 'ONES'], array_values(detectAnagrams('nose', ['Eons', 'ONES'])));
@@ -71,8 +74,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1d0ab8aa-362f-49b7-9902-3d0c668d557b
-     * @testdox Does not detect non-anagrams with identical checksum
      */
+    #[TestDox('Does not detect non-anagrams with identical checksum')]
     public function testDoesNotDetectNonAnagramsWithIdenticalChecksum(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('mass', ['last'])));
@@ -80,8 +83,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9e632c0b-c0b1-4804-8cc1-e295dea6d8a8
-     * @testdox Detects anagrams case-insensitively
      */
+    #[TestDox('Detects anagrams case-insensitively')]
     public function testDetectsAnagramsCaseInsensitively(): void
     {
         $this->assertEqualsCanonicalizing(['Carthorse'], array_values(detectAnagrams('Orchestra', ['cashregister', 'Carthorse', 'radishes'])));
@@ -89,8 +92,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b248e49f-0905-48d2-9c8d-bd02d8c3e392
-     * @testdox Detects anagrams using case-insensitive subject
      */
+    #[TestDox('Detects anagrams using case-insensitive subject')]
     public function testDetectsAnagramsUsingCaseInsensitiveSubject(): void
     {
         $this->assertEqualsCanonicalizing(['carthorse'], array_values(detectAnagrams('Orchestra', ['cashregister', 'carthorse', 'radishes'])));
@@ -98,8 +101,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5c3d6a8d-7e0b-4b9e-9e1e-6c7d7f8b9c0c
-     * @testdox Detects anagrams using case-insensitive possible matches
      */
+    #[TestDox('Detects anagrams using case-insensitive possible matches')]
     public function testDetectsAnagramsUsingCaseInsensitvePossibleMatches(): void
     {
         $this->assertEqualsCanonicalizing(['Carthorse'], array_values(detectAnagrams('orchestra', ['cashregister', 'Carthorse', 'radishes'])));
@@ -107,8 +110,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 630abb71-a94e-4715-8395-179ec1df9f91
-     * @testdox Does not detect an anagram if the original word is repeated
      */
+    #[TestDox('Does not detect an anagram if the original word is repeated')]
     public function testDoesNotDetectAAnagramIfTheOriginalWordIsRepeated(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('go', ['goGoGO'])));
@@ -116,8 +119,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9878a1c9-d6ea-4235-ae51-3ea2befd6842
-     * @testdox Anagrams must use all letters exactly once
      */
+    #[TestDox('Anagrams must use all letters exactly once')]
     public function testAnagramsMustUseAllLettersExactlyOnce(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('tapper', ['patter'])));
@@ -125,8 +128,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 68934ed0-010b-4ef9-857a-20c9012d1ebf
-     * @testdox Words are not anagrams of themselves
      */
+    #[TestDox('Words are not anagrams of themselves')]
     public function testWordsAreNotAnagramsOfThemselves(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('BANANA', ['BANANA'])));
@@ -134,8 +137,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 589384f3-4c8a-4e7d-9edc-51c3e5f0c90e
-     * @testdox Words are not anagrams of themselves even if letter case is partially different
      */
+    #[TestDox('Words are not anagrams of themselves even if letter case is partially different')]
     public function testWordsAreNotAnagramsOfThemselvesEvenIfLetterCaseIsPartiallyDifferent(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('BANANA', ['Banana'])));
@@ -143,8 +146,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ba53e423-7e02-41ee-9ae2-71f91e6d18e6
-     * @testdox Words are not anagrams of themselves even if letter case is completely different
      */
+    #[TestDox('Words are not anagrams of themselves even if letter case is completely different')]
     public function testWordsAreNotAnagramsOfThemselvesEvenIfLetterCaseIsCompletelyDifferent(): void
     {
         $this->assertEqualsCanonicalizing([], array_values(detectAnagrams('BANANA', ['banana'])));
@@ -152,8 +155,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 33d3f67e-fbb9-49d3-a90e-0beb00861da7
-     * @testdox Words other than themselves can be anagrams
      */
+    #[TestDox('Words other than themselves can be anagrams')]
     public function testWordsOtherThanThemselvesCanBeAnagrams(): void
     {
         $this->assertEqualsCanonicalizing(['Silent'], array_values(detectAnagrams('LISTEN', ['LISTEN', 'Silent'])));
@@ -161,8 +164,8 @@ class AnagramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a6854f66-eec1-4afd-a137-62ef2870c051
-     * @testdox Handles case of greek letters
      */
+    #[TestDox('Handles case of greek letters')]
     public function testHandlesCaseOfGreekLetters(): void
     {
         $this->markTestSkipped('This requires `mbstring` to be installed and thus is optional.');

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ArmstrongNumbersTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c1ed103c-258d-45b2-be73-d8c6d9580c7b
-     * @testdox Zero is an Armstrong number
      */
+    #[TestDox('Zero is an Armstrong number')]
     public function testZero(): void
     {
         $this->assertTrue(isArmstrongNumber(0));
@@ -20,8 +23,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 579e8f03-9659-4b85-a1a2-d64350f6b17a
-     * @testdox Single-digit numbers are Armstrong numbers
      */
+    #[TestDox('Single-digit numbers are Armstrong numbers')]
     public function testSingleDigit(): void
     {
         $this->assertTrue(isArmstrongNumber(5));
@@ -29,8 +32,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2d6db9dc-5bf8-4976-a90b-b2c2b9feba60
-     * @testdox There are no two-digit Armstrong numbers
      */
+    #[TestDox('There are no two-digit Armstrong numbers')]
     public function testDoubleDigit(): void
     {
         $this->assertFalse(isArmstrongNumber(10));
@@ -38,8 +41,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 509c087f-e327-4113-a7d2-26a4e9d18283
-     * @testdox Three-digit number that is an Armstrong number
      */
+    #[TestDox('Three-digit number that is an Armstrong number')]
     public function testThreeDigitIsArmstrongNumber(): void
     {
         $this->assertTrue(isArmstrongNumber(153));
@@ -47,8 +50,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7154547d-c2ce-468d-b214-4cb953b870cf
-     * @testdox Three-digit number that is not an Armstrong number
      */
+    #[TestDox('Three-digit number that is not an Armstrong number')]
     public function testThreeDigitIsNotArmstrongNumber(): void
     {
         $this->assertFalse(isArmstrongNumber(100));
@@ -56,8 +59,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6bac5b7b-42e9-4ecb-a8b0-4832229aa103
-     * @testdox Four-digit number that is an Armstrong number
      */
+    #[TestDox('Four-digit number that is an Armstrong number')]
     public function testFourDigitIsArmstrongNumber(): void
     {
         $this->assertTrue(isArmstrongNumber(9474));
@@ -65,8 +68,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: eed4b331-af80-45b5-a80b-19c9ea444b2e
-     * @testdox Four-digit number that is not an Armstrong number
      */
+    #[TestDox('Four-digit number that is not an Armstrong number')]
     public function testFourDigitIsNotArmstrongNumber(): void
     {
         $this->assertFalse(isArmstrongNumber(9475));
@@ -74,8 +77,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f971ced7-8d68-4758-aea1-d4194900b864
-     * @testdox Seven-digit number that is an Armstrong number
      */
+    #[TestDox('Seven-digit number that is an Armstrong number')]
     public function testSevenDigitIsArmstrongNumber(): void
     {
         $this->assertTrue(isArmstrongNumber(9926315));
@@ -83,8 +86,8 @@ class ArmstrongNumbersTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18
-     * @testdox Seven-digit number that is not an Armstrong number
      */
+    #[TestDox('Seven-digit number that is not an Armstrong number')]
     public function testSevenDigitIsNotArmstrongNumber(): void
     {
         $this->assertFalse(isArmstrongNumber(9926314));

--- a/exercises/practice/atbash-cipher/AtbashCipherTest.php
+++ b/exercises/practice/atbash-cipher/AtbashCipherTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class AtbashCipherTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AtbashCipherTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -12,11 +15,10 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Encoding from English to atbash cipher
      */
-
     /**
      * uuid 2f47ebe1-eab9-4d6b-b3c6-627562a31c77
-     * @testdox encode yes
      */
+    #[TestDox('encode yes')]
     public function testEncodeYes(): void
     {
         $this->assertEquals('bvh', encode('yes'));
@@ -24,8 +26,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b4ffe781-ea81-4b74-b268-cc58ba21c739
-     * @testdox encode no
      */
+    #[TestDox('encode no')]
     public function testEncodeNo(): void
     {
         $this->assertEquals('ml', encode('no'));
@@ -33,8 +35,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 10e48927-24ab-4c4d-9d3f-3067724ace00
-     * @testdox encode OMG
      */
+    #[TestDox('encode OMG')]
     public function testEncodeOmg(): void
     {
         $this->assertEquals('lnt', encode('OMG'));
@@ -42,8 +44,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d59b8bc3-509a-4a9a-834c-6f501b98750b
-     * @testdox encode spaces
      */
+    #[TestDox('encode spaces')]
     public function testEncodeOmgWithSpaces(): void
     {
         $this->assertEquals('lnt', encode('O M G'));
@@ -51,8 +53,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 31d44b11-81b7-4a94-8b43-4af6a2449429
-     * @testdox encode mindblowingly
      */
+    #[TestDox('encode mindblowingly')]
     public function testEncodeLongWord(): void
     {
         $this->assertEquals('nrmwy oldrm tob', encode('mindblowingly'));
@@ -60,8 +62,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d503361a-1433-48c0-aae0-d41b5baa33ff
-     * @testdox encode numbers
      */
+    #[TestDox('encode numbers')]
     public function testEncodeNumbers(): void
     {
         $this->assertEquals('gvhgr mt123 gvhgr mt', encode('Testing, 1 2 3, testing.'));
@@ -69,8 +71,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 79c8a2d5-0772-42d4-b41b-531d0b5da926
-     * @testdox encode deep thought
      */
+    #[TestDox('encode deep thought')]
     public function testEncodeSentence(): void
     {
         $this->assertEquals('gifgs rhurx grlm', encode('Truth is fiction.'));
@@ -78,8 +80,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9ca13d23-d32a-4967-a1fd-6100b8742bab
-     * @testdox encode all the letters
      */
+    #[TestDox('encode all the letters')]
     public function testEncodeAllTheThings(): void
     {
         $plaintext = 'The quick brown fox jumps over the lazy dog.';
@@ -90,11 +92,10 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
     /**
      * Decoding from atbash cipher to all-lowercase-mashed-together English
      */
-
     /**
      * uuid bb50e087-7fdf-48e7-9223-284fe7e69851
-     * @testdox decode exercism
      */
+    #[TestDox('decode exercism')]
     public function testDecodeExercism(): void
     {
         $this->assertEquals('exercism', decode('vcvix rhn'));
@@ -102,8 +103,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ac021097-cd5d-4717-8907-b0814b9e292c
-     * @testdox decode a sentence
      */
+    #[TestDox('decode a sentence')]
     public function testDecodeASentence(): void
     {
         $this->assertEquals(
@@ -114,8 +115,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 18729de3-de74-49b8-b68c-025eaf77f851
-     * @testdox decode numbers
      */
+    #[TestDox('decode numbers')]
     public function testDecodeNumbers(): void
     {
         $this->assertEquals(
@@ -126,8 +127,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0f30325f-f53b-415d-ad3e-a7a4f63de034
-     * @testdox decode all the letters
      */
+    #[TestDox('decode all the letters')]
     public function testDecodeAllTheLetters(): void
     {
         $this->assertEquals(
@@ -138,8 +139,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 39640287-30c6-4c8c-9bac-9d613d1a5674
-     * @testdox decode with too many spaces
      */
+    #[TestDox('decode with too many spaces')]
     public function testDecodeWithTooManySpaces(): void
     {
         $this->assertEquals(
@@ -150,8 +151,8 @@ class AtbashCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b34edf13-34c0-49b5-aa21-0768928000d5
-     * @testdox decode with no spaces
      */
+    #[TestDox('decode with no spaces')]
     public function testDecodeWithNoSpacesInInput(): void
     {
         $this->assertEquals(

--- a/exercises/practice/bank-account/BankAccountTest.php
+++ b/exercises/practice/bank-account/BankAccountTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class BankAccountTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class BankAccountTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 983a1528-4ceb-45e5-8257-8ce01aceb5ed
-     * @testdox Newly opened account has zero balance
      */
+    #[TestDox('Newly opened account has zero balance')]
     public function testNewlyOpenedAccountHasZeroBalance(): void
     {
         $subject = new BankAccount();
@@ -22,8 +25,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e88d4ec3-c6bf-4752-8e59-5046c44e3ba7
-     * @testdox Single deposit
      */
+    #[TestDox('Single deposit')]
     public function testSingleDeposit(): void
     {
         $subject = new BankAccount();
@@ -34,8 +37,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3d9147d4-63f4-4844-8d2b-1fee2e9a2a0d
-     * @testdox Multiple deposits
      */
+    #[TestDox('Multiple deposits')]
     public function testMultipleDeposits(): void
     {
         $subject = new BankAccount();
@@ -47,8 +50,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 08f1af07-27ae-4b38-aa19-770bde558064
-     * @testdox Withdraw once
      */
+    #[TestDox('Withdraw once')]
     public function testWithdrawOnce(): void
     {
         $subject = new BankAccount();
@@ -60,8 +63,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6f6d242f-8c31-4ac6-8995-a90d42cad59f
-     * @testdox Withdraw twice
      */
+    #[TestDox('Withdraw twice')]
     public function testWithdrawTwice(): void
     {
         $subject = new BankAccount();
@@ -74,8 +77,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 45161c94-a094-4c77-9cec-998b70429bda
-     * @testdox Can do multiple operations sequentially
      */
+    #[TestDox('Can do multiple operations sequentially')]
     public function testCanDoMultipleOperationsSequentially(): void
     {
         $subject = new BankAccount();
@@ -90,8 +93,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f9facfaa-d824-486e-8381-48832c4bbffd
-     * @testdox Cannot check balance of closed account
      */
+    #[TestDox('Cannot check balance of closed account')]
     public function testCannotCheckBalanceOfClosedAccount(): void
     {
         $subject = new BankAccount();
@@ -104,8 +107,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7a65ba52-e35c-4fd2-8159-bda2bde6e59c
-     * @testdox Cannot deposit into closed account
      */
+    #[TestDox('Cannot deposit into closed account')]
     public function testCannotDepositIntoClosedAccount(): void
     {
         $subject = new BankAccount();
@@ -118,8 +121,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a0a1835d-faae-4ad4-a6f3-1fcc2121380b
-     * @testdox Cannot deposit into unopened account
      */
+    #[TestDox('Cannot deposit into unopened account')]
     public function testCannotDepositIntoUnopenedAccount(): void
     {
         $subject = new BankAccount();
@@ -130,8 +133,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 570dfaa5-0532-4c1f-a7d3-0f65c3265608
-     * @testdox Cannot withdraw from closed account
      */
+    #[TestDox('Cannot withdraw from closed account')]
     public function testCannotWithdrawFromClosedAccount(): void
     {
         $subject = new BankAccount();
@@ -144,8 +147,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c396d233-1c49-4272-98dc-7f502dbb9470
-     * @testdox Cannot close an account that was not opened
      */
+    #[TestDox('Cannot close an account that was not opened')]
     public function testCannotCloseAnAccountThatWasNotOpened(): void
     {
         $subject = new BankAccount();
@@ -156,8 +159,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c06f534f-bdc2-4a02-a388-1063400684de
-     * @testdox Cannot open an already opened account
      */
+    #[TestDox('Cannot open an already opened account')]
     public function testCannotOpenAnAlreadyOpenedAccount(): void
     {
         $subject = new BankAccount();
@@ -169,8 +172,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0722d404-6116-4f92-ba3b-da7f88f1669c
-     * @testdox Reopened account does not retain balance
      */
+    #[TestDox('Reopened account does not retain balance')]
     public function testReopenedAccountDoesNotRetainBalance(): void
     {
         $subject = new BankAccount();
@@ -183,8 +186,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ec42245f-9361-4341-8231-a22e8d19c52f
-     * @testdox Cannot withdraw more than deposited
      */
+    #[TestDox('Cannot withdraw more than deposited')]
     public function testCannotWithdrawMoreThanDeposited(): void
     {
         $subject = new BankAccount();
@@ -197,8 +200,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 4f381ef8-10ef-4507-8e1d-0631ecc8ee72
-     * @testdox Cannot withdraw negative
      */
+    #[TestDox('Cannot withdraw negative')]
     public function testCannotWithdrawNegative(): void
     {
         $subject = new BankAccount();
@@ -211,8 +214,8 @@ class BankAccountTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d45df9ea-1db0-47f3-b18c-d365db49d938
-     * @testdox Cannot deposit negative
      */
+    #[TestDox('Cannot deposit negative')]
     public function testCannotDepositNegative(): void
     {
         $subject = new BankAccount();

--- a/exercises/practice/beer-song/BeerSongTest.php
+++ b/exercises/practice/beer-song/BeerSongTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class BeerSongTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class BeerSongTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/binary-search-tree/BinarySearchTreeTest.php
+++ b/exercises/practice/binary-search-tree/BinarySearchTreeTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class BinarySearchTreeTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e9c93a78-c536-4750-a336-94583d23fafa
-     * @testdox data is retained
      */
+    #[TestDox('data is retained')]
     public function testDataIsRetained(): void
     {
         $tree = new BinarySearchTree(4);
@@ -21,8 +24,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7a95c9e8-69f6-476a-b0c4-4170cb3f7c91
-     * @testdox smaller number at left node
      */
+    #[TestDox('smaller number at left node')]
     public function testSmallNumberAtLeftNode(): void
     {
         $tree = new BinarySearchTree(4);
@@ -34,8 +37,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 22b89499-9805-4703-a159-1a6e434c1585
-     * @testdox same number at left node
      */
+    #[TestDox('same number at left node')]
     public function testSameNumberLeftNodes(): void
     {
         $tree = new BinarySearchTree(4);
@@ -47,8 +50,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2e85fdde-77b1-41ed-b6ac-26ce6b663e34
-     * @testdox greater number at right node
      */
+    #[TestDox('greater number at right node')]
     public function testGreaterNumberRightNode(): void
     {
         $tree = new BinarySearchTree(4);
@@ -60,8 +63,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dd898658-40ab-41d0-965e-7f145bf66e0b
-     * @testdox can create complex tree
      */
+    #[TestDox('can create complex tree')]
     public function testCreateComplexTree(): void
     {
         $tree = new BinarySearchTree(4);
@@ -83,8 +86,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9e0c06ef-aeca-4202-b8e4-97f1ed057d56
-     * @testdox can sort single number
      */
+    #[TestDox('can sort single number')]
     public function testCanSortSingleNode(): void
     {
         $tree = new BinarySearchTree(2);
@@ -94,8 +97,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 425e6d07-fceb-4681-a4f4-e46920e380bb
-     * @testdox can sort if second number is smaller than first
      */
+    #[TestDox('can sort if second number is smaller than first')]
     public function testCanSortSmallerSecondNumber(): void
     {
         $tree = new BinarySearchTree(2);
@@ -106,8 +109,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bd7532cc-6988-4259-bac8-1d50140079ab
-     * @testdox can sort if second number is same as first
      */
+    #[TestDox('can sort if second number is same as first')]
     public function testCanSortSameNumbers(): void
     {
         $tree = new BinarySearchTree(2);
@@ -118,8 +121,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b6d1b3a5-9d79-44fd-9013-c83ca92ddd36
-     * @testdox can sort if second number is greater than first
      */
+    #[TestDox('can sort if second number is greater than first')]
     public function testCanSortGreaterSecondNumber(): void
     {
         $tree = new BinarySearchTree(2);
@@ -130,8 +133,8 @@ class BinarySearchTreeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d00ec9bd-1288-4171-b968-d44d0808c1c8
-     * @testdox can sort complex tree
      */
+    #[TestDox('can sort complex tree')]
     public function testCanSortComplexTree(): void
     {
         $tree = new BinarySearchTree(2);

--- a/exercises/practice/binary-search/BinarySearchTest.php
+++ b/exercises/practice/binary-search/BinarySearchTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class BinarySearchTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class BinarySearchTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b55c24a9-a98d-4379-a08c-2adcf8ebeee8
-     * @testdox It works with one element
      */
+    #[TestDox('It works with one element')]
     public function testItWorksWithOneElement(): void
     {
         $this->assertEquals(0, find(6, [6]));
@@ -20,8 +23,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 73469346-b0a0-4011-89bf-989e443d503d
-     * @testdox It finds value in the middle
      */
+    #[TestDox('It finds value in the middle')]
     public function testItFindsValueInMiddle(): void
     {
         $this->assertEquals(3, find(6, [1, 3, 4, 6, 8, 9, 11]));
@@ -29,8 +32,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 327bc482-ab85-424e-a724-fb4658e66ddb
-     * @testdox It finds value at the beginning
      */
+    #[TestDox('It finds value at the beginning')]
     public function testItFindsValueInBeginning(): void
     {
         $this->assertEquals(0, find(1, [1, 3, 4, 6, 8, 9, 11]));
@@ -38,8 +41,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f9f94b16-fe5e-472c-85ea-c513804c7d59
-     * @testdox It finds value at the end
      */
+    #[TestDox('It finds value at the end')]
     public function testItFindsValueAtEnd(): void
     {
         $this->assertEquals(6, find(11, [1, 3, 4, 6, 8, 9, 11]));
@@ -47,8 +50,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f0068905-26e3-4342-856d-ad153cadb338
-     * @testdox It finds value in an odd-length array
      */
+    #[TestDox('It finds value in an odd-length array')]
     public function testItFindsValueInOddLengthArray(): void
     {
         $this->assertEquals(9, find(144, [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634]));
@@ -56,8 +59,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fc316b12-c8b3-4f5e-9e89-532b3389de8c
-     * @testdox It finds value in an even-length array
      */
+    #[TestDox('It finds value in an even-length array')]
     public function testItFindsValueInEvenLengthArray(): void
     {
         $this->assertEquals(5, find(21, [1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]));
@@ -65,8 +68,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid da7db20a-354f-49f7-a6a1-650a54998aa6
-     * @testdox It identifies that value is not in array
      */
+    #[TestDox('It identifies that value is not in array')]
     public function testValueNotIncludedInArray(): void
     {
         $this->assertEquals(-1, find(7, [1, 3, 4, 6, 8, 9, 11]));
@@ -74,8 +77,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 95d869ff-3daf-4c79-b622-6e805c675f97
-     * @testdox It does not find a value lower than the lowest value
      */
+    #[TestDox('It does not find a value lower than the lowest value')]
     public function testLowerThanLowestValueNotIn(): void
     {
         $this->assertEquals(-1, find(0, [1, 3, 4, 6, 8, 9, 11]));
@@ -83,8 +86,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba
-     * @testdox It does not find a value larger than the largest value
      */
+    #[TestDox('It does not find a value larger than the largest value')]
     public function testLargerThanLargestValueNotIn(): void
     {
         $this->assertEquals(-1, find(13, [1, 3, 4, 6, 8, 9, 11]));
@@ -92,8 +95,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f439a0fa-cf42-4262-8ad1-64bf41ce566a
-     * @testdox It does not find any value in an empty array
      */
+    #[TestDox('It does not find any value in an empty array')]
     public function testNothingInEmptyArray(): void
     {
         $this->assertEquals(-1, find(1, []));
@@ -101,8 +104,8 @@ class BinarySearchTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2c353967-b56d-40b8-acff-ce43115eed64
-     * @testdox It does not find any value in left and right of array
      */
+    #[TestDox('It does not find any value in left and right of array')]
     public function testNothingFoundInLeftAndRight()
     {
         $this->assertEquals(-1, find(0, [1, 2]));

--- a/exercises/practice/binary/BinaryTest.php
+++ b/exercises/practice/binary/BinaryTest.php
@@ -24,7 +24,10 @@
 
 declare(strict_types=1);
 
-class BinaryTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class BinaryTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -72,9 +75,7 @@ class BinaryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(3, parse_binary('00011'));
     }
 
-    /**
-     * @dataProvider invalidValues
-     */
+    #[DataProvider('invalidValues')]
     public function testItOnlyAcceptsStringsContainingZerosAndOnes($value): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/practice/bob/BobTest.php
+++ b/exercises/practice/bob/BobTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class BobTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class BobTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e162fead-606f-437a-a166-d051915cea8e
-     * @testdox stating something
      */
+    #[TestDox('stating something')]
     public function testStatingSomething(): void
     {
         $input = "Tom-ay-to, tom-aaaah-to.";
@@ -23,8 +26,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 73a966dc-8017-47d6-bb32-cf07d1a5fcd9
-     * @testdox shouting
      */
+    #[TestDox('shouting')]
     public function testShouting(): void
     {
         $input = "WATCH OUT!";
@@ -35,8 +38,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d6c98afd-df35-4806-b55e-2c457c3ab748
-     * @testdox shouting gibberish
      */
+    #[TestDox('shouting gibberish')]
     public function testShoutingGibberish(): void
     {
         $input = "FCECDFCAAB";
@@ -47,8 +50,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8a2e771d-d6f1-4e3f-b6c6-b41495556e37
-     * @testdox asking a question
      */
+    #[TestDox('asking a question')]
     public function testAskingAQuestion(): void
     {
         $input = "Does this cryogenic chamber make me look fat?";
@@ -59,8 +62,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 81080c62-4e4d-4066-b30a-48d8d76920d9
-     * @testdox asking a numeric question
      */
+    #[TestDox('asking a numeric question')]
     public function testAskingANumericQuestion(): void
     {
         $input = "You are, what, like 15?";
@@ -71,8 +74,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2a02716d-685b-4e2e-a804-2adaf281c01e
-     * @testdox asking gibberish
      */
+    #[TestDox('asking gibberish')]
     public function testAskingGibberish(): void
     {
         $input = "fffbbcbeab?";
@@ -83,8 +86,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c02f9179-ab16-4aa7-a8dc-940145c385f7
-     * @testdox talking forcefully
      */
+    #[TestDox('talking forcefully')]
     public function testTalkingForcefully(): void
     {
         $input = "Hi there!";
@@ -95,8 +98,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 153c0e25-9bb5-4ec5-966e-598463658bcd
-     * @testdox using acronyms in regular speech
      */
+    #[TestDox('using acronyms in regular speech')]
     public function testUsingAcronymsInRegularSpeech(): void
     {
         $input = "It's OK if you don't want to go work for NASA.";
@@ -107,8 +110,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a5193c61-4a92-4f68-93e2-f554eb385ec6
-     * @testdox forceful question
      */
+    #[TestDox('forceful question')]
     public function testForcefulQuestion(): void
     {
         $input = "WHAT'S GOING ON?";
@@ -119,8 +122,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a20e0c54-2224-4dde-8b10-bd2cdd4f61bc
-     * @testdox shouting numbers
      */
+    #[TestDox('shouting numbers')]
     public function testShoutingNumbers(): void
     {
         $input = "1, 2, 3 GO!";
@@ -131,8 +134,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f7bc4b92-bdff-421e-a238-ae97f230ccac
-     * @testdox no letters
      */
+    #[TestDox('no letters')]
     public function testOnlyNumbers(): void
     {
         $input = "1, 2, 3";
@@ -143,8 +146,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2
-     * @testdox question with no letters
      */
+    #[TestDox('question with no letters')]
     public function testQuestionWithOnlyNumbers(): void
     {
         $input = "4?";
@@ -155,8 +158,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 496143c8-1c31-4c01-8a08-88427af85c66
-     * @testdox shouting with special characters
      */
+    #[TestDox('shouting with special characters')]
     public function testShoutingWithSpecialCharacters(): void
     {
         $input = "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!";
@@ -167,8 +170,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e6793c1c-43bd-4b8d-bc11-499aea73925f
-     * @testdox shouting with no exclamation mark
      */
+    #[TestDox('shouting with no exclamation mark')]
     public function testShoutingWithNoExclamationMark(): void
     {
         $input = "I HATE THE DENTIST";
@@ -179,8 +182,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: aa8097cc-c548-4951-8856-14a404dd236a
-     * @testdox statement containing question mark
      */
+    #[TestDox('statement containing question mark')]
     public function testStatementContainingQuestionMark(): void
     {
         $input = "Ending with ? means a question.";
@@ -191,8 +194,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9bfc677d-ea3a-45f2-be44-35bc8fa3753e
-     * @testdox non-letters with question
      */
+    #[TestDox('non-letters with question')]
     public function testNonLettersWithQuestion(): void
     {
         $input = ":) ?";
@@ -203,8 +206,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8608c508-f7de-4b17-985b-811878b3cf45
-     * @testdox prattling on
      */
+    #[TestDox('prattling on')]
     public function testPrattlingOn(): void
     {
         $input = "Wait! Hang on. Are you going to be OK?";
@@ -215,8 +218,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bc39f7c6-f543-41be-9a43-fd1c2f753fc0
-     * @testdox silence
      */
+    #[TestDox('silence')]
     public function testSilence(): void
     {
         $input = "";
@@ -227,8 +230,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d6c47565-372b-4b09-b1dd-c40552b8378b
-     * @testdox prolonged silence
      */
+    #[TestDox('prolonged silence')]
     public function testProlongedSilence(): void
     {
         $input = "          ";
@@ -239,8 +242,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 4428f28d-4100-4d85-a902-e5a78cb0ecd3
-     * @testdox alternate silence
      */
+    #[TestDox('alternate silence')]
     public function testAlternateSilence(): void
     {
         $input = "\t\t\t\t\t\t\t\t\t\t";
@@ -251,8 +254,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 5371ef75-d9ea-4103-bcfa-2da973ddec1b
-     * @testdox starting with whitespace
      */
+    #[TestDox('starting with whitespace')]
     public function testStartingWithWhitespace(): void
     {
         $input = "         hmmmmmmm...";
@@ -263,8 +266,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 05b304d6-f83b-46e7-81e0-4cd3ca647900
-     * @testdox ending with whitespace
      */
+    #[TestDox('ending with whitespace')]
     public function testEndingWithWhitespace(): void
     {
         $input = "Okay if like my  spacebar  quite a bit?   ";
@@ -275,8 +278,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 72bd5ad3-9b2f-4931-a988-dce1f5771de2
-     * @testdox other whitespace
      */
+    #[TestDox('other whitespace')]
     public function testOtherWhitespace()
     {
         $input = "\n\r \t";
@@ -287,8 +290,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 12983553-8601-46a8-92fa-fcaa3bc4a2a0
-     * @testdox non-question ending with whitespace
      */
+    #[TestDox('non-question ending with whitespace')]
     public function testNonQuestionEndingWithWhitespace(): void
     {
         $input = "This is a statement ending with whitespace      ";
@@ -299,8 +302,8 @@ class BobTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2c7278ac-f955-4eb4-bf8f-e33eb4116a15
-     * @testdox multiple line question
      */
+    #[TestDox('multiple line question')]
     public function testMultipleLineQuestion(): void
     {
         $input = "\nDoes this cryogenic chamber make\n me look fat?";

--- a/exercises/practice/book-store/BookStoreTest.php
+++ b/exercises/practice/book-store/BookStoreTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
 /**
  * Calculate lowest price for shopping basket only
  * containing books from a single series. There is no
@@ -9,7 +12,7 @@ declare(strict_types=1);
  * any single book in a grouping.
  */
 
-class BookStoreTest extends PHPUnit\Framework\TestCase
+class BookStoreTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -21,8 +24,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1]]
      *
      * uuid 17146bd5-2e80-4557-ab4c-05632b6b0d01
-     * @testdox Only a single book
      */
+    #[TestDox('Only a single book')]
     public function testSingleBook(): void
     {
         $basket = [1];
@@ -34,8 +37,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[2], [2]]
      *
      * uuid cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce
-     * @testdox Two of the same book
      */
+    #[TestDox('Two of the same book')]
     public function testTwoSame(): void
     {
         $basket = [2, 2];
@@ -47,8 +50,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: []
      *
      * uuid 5a86eac0-45d2-46aa-bbf0-266b94393a1a
-     * @testdox Empty basket
      */
+    #[TestDox('Empty basket')]
     public function testEmpty(): void
     {
         $basket = [];
@@ -60,8 +63,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2]]
      *
      * uuid 158bd19a-3db4-4468-ae85-e0638a688990
-     * @testdox Two different books
      */
+    #[TestDox('Two different books')]
     public function testTwoDifferent(): void
     {
         $basket = [1, 2];
@@ -73,8 +76,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3]]
      *
      * uuid f3833f6b-9332-4a1f-ad98-6c3f8e30e163
-     * @testdox Three different books
      */
+    #[TestDox('Three different books')]
     public function testThreeDifferent(): void
     {
         $basket = [1, 2, 3];
@@ -86,8 +89,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4]]
      *
      * uuid 1951a1db-2fb6-4cd1-a69a-f691b6dd30a2
-     * @testdox Four different books
      */
+    #[TestDox('Four different books')]
     public function testFourDifferent(): void
     {
         $basket = [1, 2, 3, 4];
@@ -99,8 +102,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4, 5]]
      *
      * uuid d70f6682-3019-4c3f-aede-83c6a8c647a3
-     * @testdox Five different books
      */
+    #[TestDox('Five different books')]
     public function testFiveDifferent(): void
     {
         $basket = [1, 2, 3, 4, 5];
@@ -117,8 +120,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4], [1, 2, 3, 5]]
      *
      * uuid 78cacb57-911a-45f1-be52-2a5bd428c634
-     * @testdox Two groups of four is cheaper than group of five plus group of three
      */
+    #[TestDox('Two groups of four is cheaper than group of five plus group of three')]
     public function testEight(): void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 5];
@@ -129,8 +132,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target Grouping: [[1, 2, 4, 5], [1, 3, 4, 5]]
      *
      * uuid f808b5a4-e01f-4c0d-881f-f7b90d9739da
-     * @testdox Two groups of four is cheaper than groups of five and three
      */
+    #[TestDox('Two groups of four is cheaper than groups of five and three')]
     public function testTwoGroupsOfFourIsCheaperThanGroupsOfFiveAndThree(): void
     {
         $basket = [1, 1, 2, 3, 4, 4, 5, 5];
@@ -141,8 +144,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target Grouping: [[1, 2, 3, 4], [1, 2]]
      *
      * uuid fe96401c-5268-4be2-9d9e-19b76478007c
-     * @testdox Group of four plus group of two is cheaper than two groups of three
      */
+    #[TestDox('Group of four plus group of two is cheaper than two groups of three')]
     public function testGroupOfFourPlusGroupOfTwoIsCheaperThanTwoGroupsOfThree(): void
     {
         $basket = [1, 1, 2, 2, 3, 4];
@@ -156,8 +159,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4]],
      *
      * uuid 68ea9b78-10ad-420e-a766-836a501d3633
-     * @testdox Two each of first four books and one copy each of rest
      */
+    #[TestDox('Two each of first four books and one copy each of rest')]
     public function testFourPairsPlusOne(): void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5];
@@ -170,8 +173,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]]
      *
      * uuid c0a779d5-a40c-47ae-9828-a340e936b866
-     * @testdox Two copies of each boo
      */
+    #[TestDox('Two copies of each boo')]
     public function testFivePairs(): void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5];
@@ -185,8 +188,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1]]
      *
      * uuid 18fd86fe-08f1-4b68-969b-392b8af20513
-     * @testdox Three copies of first book and two each of remaining
      */
+    #[TestDox('Three copies of first book and two each of remaining')]
     public function testFivePairsPlusOne(): void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1];
@@ -200,8 +203,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target grouping: [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5], [1, 2]]
      *
      * uuid 0b19a24d-e4cf-4ec8-9db2-8899a41af0da
-     * @testdox Three each of first two books and two each of remaining books
      */
+    #[TestDox('Three each of first two books and two each of remaining books')]
     public function testTwelve(): void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2];
@@ -212,8 +215,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target Grouping: [[1, 2, 3, 4], [1, 2, 3, 5], [1, 2, 3, 4], [1, 2, 3, 5]]
      *
      * uuid bb376344-4fb2-49ab-ab85-e38d8354a58d
-     * @testdox Four groups of four are cheaper than two groups each of five and three
      */
+    #[TestDox('Four groups of four are cheaper than two groups each of five and three')]
     public function testFourGroupsOfFourAreCheaperThanTwoGroupsEachOfFiveAndThree(): void
     {
         $basket = [1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5];
@@ -224,8 +227,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target Grouping: [[1, 2, 3, 4], [1, 2, 3, 5], [1, 2, 3, 4], [1, 2, 3, 5], [1, 2, 3], [1, 2, 3]]
      *
      * uuid 5260ddde-2703-4915-b45a-e54dbbac4303
-     * @testdox Check that groups of 4 are created properly even when there are more groups of 3 than groups of 5
      */
+    #[TestDox('Check that groups of 4 are created properly even when there are more groups of 3 than groups of 5')]
     public function testCheckThatGroupsOfFourAreCreatedProperlyEvenWhenThereAreMoreGroupsOfThreeThanGroupsOfFive(): void
     {
         $basket = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 5, 5];
@@ -236,8 +239,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target Grouping: [[1], [1, 2, 3, 4]]
      *
      * uuid b0478278-c551-4747-b0fc-7e0be3158b1f
-     * @testdox One group of one and four is cheaper than one group of two and three
      */
+    #[TestDox('One group of one and four is cheaper than one group of two and three')]
     public function testOneGroupOfOneAndFourIsCheaperThanOneGroupOfTwoAndThree(): void
     {
         $basket = [1, 1, 2, 3, 4];
@@ -248,8 +251,8 @@ class BookStoreTest extends PHPUnit\Framework\TestCase
      * Target Grouping: [[5], [5, 4], [5, 4, 3, 2], [5, 4, 3, 2], [5, 4, 3, 1]]
      *
      * uuid cf868453-6484-4ae1-9dfc-f8ee85bbde01
-     * @testdox One group of one and two plus three groups of four is cheaper than one group of each size
      */
+    #[TestDox('One group of one and two plus three groups of four is cheaper than one group of each size')]
     public function testOneGroupOfOneAndTwoPlusThreeGroupsOfFourIsCheaperThanOneGroupOfEachSize(): void
     {
         $basket = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5];

--- a/exercises/practice/bowling/BowlingTest.php
+++ b/exercises/practice/bowling/BowlingTest.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
 /**
  * Translated from original source:
  * https://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata
  */
-class BowlingTest extends PHPUnit\Framework\TestCase
+class BowlingTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -23,8 +26,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 656ae006-25c2-438c-a549-f338e7ec7441
-     * @testdox should be able to score a game with all zeros
      */
+    #[TestDox('should be able to score a game with all zeros')]
     public function testShouldBeAbleToScoreAGameWithAllZeros(): void
     {
         $this->rollMany(20, 0);
@@ -34,8 +37,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f85dcc56-cd6b-4875-81b3-e50921e3597b
-     * @testdox should be able to score a game with no strikes or spares
      */
+    #[TestDox('should be able to score a game with no strikes or spares')]
     public function testShouldBeAbleToScoreAGameWithNoStrikesOrSpares(): void
     {
         $this->game->roll(3);
@@ -64,8 +67,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d1f56305-3ac2-4fe0-8645-0b37e3073e20
-     * @testdox a spare followed by zeros is worth ten points
      */
+    #[TestDox('a spare followed by zeros is worth ten points')]
     public function testASpareFollowedByZerosIsWorthTenPoints(): void
     {
         $this->game->roll(6);
@@ -77,8 +80,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0b8c8bb7-764a-4287-801a-f9e9012f8be4
-     * @testdox points scored in the roll after a spare are counted twice
      */
+    #[TestDox('points scored in the roll after a spare are counted twice')]
     public function testPointsScoredInTheRollAfterASpareAreCountedTwice(): void
     {
         $this->game->roll(6);
@@ -91,8 +94,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4d54d502-1565-4691-84cd-f29a09c65bea
-     * @testdox consecutive spares each get a one roll bonus
      */
+    #[TestDox('consecutive spares each get a one roll bonus')]
     public function testConsecutiveSparesEachGetAOneRollBonus(): void
     {
         $this->game->roll(5);
@@ -107,8 +110,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e5c9cf3d-abbe-4b74-ad48-34051b2b08c0
-     * @testdox a spare in the last frame gets a one roll bonus that is counted once
      */
+    #[TestDox('a spare in the last frame gets a one roll bonus that is counted once')]
     public function testASpareInTheLastFrameGetsAOneRollBonusThatIsCountedOnce(): void
     {
         $this->rollMany(18, 0);
@@ -121,8 +124,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 75269642-2b34-4b72-95a4-9be28ab16902
-     * @testdox a strike earns ten points in a frame with a single roll
      */
+    #[TestDox('a strike earns ten points in a frame with a single roll')]
     public function testAStrikeEarnsTenPointsInFrameWithASingleRoll(): void
     {
         $this->game->roll(10);
@@ -133,8 +136,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 037f978c-5d01-4e49-bdeb-9e20a2e6f9a6
-     * @testdox points scored in the two rolls after a strike are counted twice as a bonus
      */
+    #[TestDox('points scored in the two rolls after a strike are counted twice as a bonus')]
     public function testPointsScoredInTheTwoRollsAfterAStrikeAreCountedTwiceAsABonus(): void
     {
         $this->game->roll(10);
@@ -147,8 +150,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1635e82b-14ec-4cd1-bce4-4ea14bd13a49
-     * @testdox consecutive strikes each get the two roll bonus
      */
+    #[TestDox('consecutive strikes each get the two roll bonus')]
     public function testConsecutiveStrikesEachGetTheTwoRollBonus(): void
     {
         $this->game->roll(10);
@@ -163,8 +166,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e483e8b6-cb4b-4959-b310-e3982030d766
-     * @testdox a strike in the last frame gets a two roll bonus that is counted once
      */
+    #[TestDox('a strike in the last frame gets a two roll bonus that is counted once')]
     public function testAStrikeInTheLastFrameGetsATwoRollBonusThatIsCountedOnce(): void
     {
         $this->rollMany(18, 0);
@@ -177,8 +180,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9d5c87db-84bc-4e01-8e95-53350c8af1f8
-     * @testdox rolling a spare with the two roll bonus does not get a bonus roll
      */
+    #[TestDox('rolling a spare with the two roll bonus does not get a bonus roll')]
     public function testAStrikeWithTheOneRollBonusAfterASpareInTheLastFrameDoesNotGetABonus(): void
     {
         $this->rollMany(18, 0);
@@ -191,8 +194,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 576faac1-7cff-4029-ad72-c16bcada79b5
-     * @testdox strikes with the two roll bonus do not get bonus rolls
      */
+    #[TestDox('strikes with the two roll bonus do not get bonus rolls')]
     public function testRollingASpareWithTheTwoRollBonusDoesNotGetABonusRoll(): void
     {
         $this->rollMany(18, 0);
@@ -205,8 +208,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid efb426ec-7e15-42e6-9b96-b4fca3ec2359
-     * @testdox last two strikes followed by only last bonus with non strike points
      */
+    #[TestDox('last two strikes followed by only last bonus with non strike points')]
     public function testLastTwoStrikesFollowedByOnlyLastBonusWithNonStrikePoints(): void
     {
         $this->rollMany(16, 0);
@@ -220,8 +223,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 72e24404-b6c6-46af-b188-875514c0377b
-     * @testdox a strike with the one roll bonus after a spare in the last frame does not get a bonus
      */
+    #[TestDox('a strike with the one roll bonus after a spare in the last frame does not get a bonus')]
     public function testStrikesWithTheTwoRollBonusDoNotGetBonusRolls(): void
     {
         $this->rollMany(18, 0);
@@ -234,8 +237,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 62ee4c72-8ee8-4250-b794-234f1fec17b1
-     * @testdox all strikes is a perfect gam
      */
+    #[TestDox('all strikes is a perfect gam')]
     public function testAllStrikesIsAPerfectGame(): void
     {
         $this->rollMany(12, 10);
@@ -245,8 +248,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1245216b-19c6-422c-b34b-6e4012d7459f
-     * @testdox rolls cannot score negative points
      */
+    #[TestDox('rolls cannot score negative points')]
     public function testRollsCanNotScoreNegativePoints(): void
     {
         $this->expectException(Exception::class);
@@ -256,8 +259,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5fcbd206-782c-4faa-8f3a-be5c538ba841
-     * @testdox a roll cannot score more than 10 points
      */
+    #[TestDox('a roll cannot score more than 10 points')]
     public function testARollCanNotScoreMoreThan10Points(): void
     {
         $this->expectException(Exception::class);
@@ -269,8 +272,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fb023c31-d842-422d-ad7e-79ce1db23c21
-     * @testdox two rolls in a frame cannot score more than 10 points
      */
+    #[TestDox('two rolls in a frame cannot score more than 10 points')]
     public function testTwoRollsInAFrameCanNotScoreMoreThan10Points(): void
     {
         $this->expectException(Exception::class);
@@ -283,8 +286,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6082d689-d677-4214-80d7-99940189381b
-     * @testdox bonus roll after a strike in the last frame cannot score more than 10 points
      */
+    #[TestDox('bonus roll after a strike in the last frame cannot score more than 10 points')]
     public function testBonusRollsAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points(): void
     {
         $this->expectException(Exception::class);
@@ -299,8 +302,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e9565fe6-510a-4675-ba6b-733a56767a45
-     * @testdox two bonus rolls after a strike in the last frame cannot score more than 10 points
      */
+    #[TestDox('two bonus rolls after a strike in the last frame cannot score more than 10 points')]
     public function testTwoBonusRollsAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points(): void
     {
         $this->expectException(Exception::class);
@@ -315,8 +318,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2f6acf99-448e-4282-8103-0b9c7df99c3d
-     * @testdox two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike
      */
+    #[TestDox('two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike')]
     public function testTwoBonusRollsAfterAStrikeInTheLastFramCanScoreMoreThan10PointsIfOneIsAStrike(): void
     {
         $this->rollMany(18, 0);
@@ -329,8 +332,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6380495a-8bc4-4cdb-a59f-5f0212dbed01
-     * @testdox the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike
      */
+    #[TestDox('the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike')]
     public function testTheSecondBonusRollsAfterAStrikeInTheLastFrameCannotBeAStrikeIfTheFirstOneIsNotAStrike(): void
     {
         $this->expectException(Exception::class);
@@ -344,8 +347,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2b2976ea-446c-47a3-9817-42777f09fe7e
-     * @testdox second bonus roll after a strike in the last frame cannot score more than 10 points
      */
+    #[TestDox('second bonus roll after a strike in the last frame cannot score more than 10 points')]
     public function testSecondBonusRollAfterAStrikeInTheLastFrameCannotScoreMoreThan10Points(): void
     {
         $this->expectException(Exception::class);
@@ -359,8 +362,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 29220245-ac8d-463d-bc19-98a94cfada8a
-     * @testdox an unstarted game cannot be scored
      */
+    #[TestDox('an unstarted game cannot be scored')]
     public function testAnUnstartedGameCanNotBeScored(): void
     {
         $this->expectException(Exception::class);
@@ -370,8 +373,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4473dc5d-1f86-486f-bf79-426a52ddc955
-     * @testdox an incomplete game cannot be scored
      */
+    #[TestDox('an incomplete game cannot be scored')]
     public function testAnIncompleteGameCanNotBeScored(): void
     {
         $this->expectException(Exception::class);
@@ -383,8 +386,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2ccb8980-1b37-4988-b7d1-e5701c317df3
-     * @testdox cannot roll if game already has ten frames
      */
+    #[TestDox('cannot roll if game already has ten frames')]
     public function testCannotRollIfGameAlreadyHasTenFrames(): void
     {
         $this->expectException(Exception::class);
@@ -396,8 +399,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4864f09b-9df3-4b65-9924-c595ed236f1b
-     * @testdox bonus rolls for a strike in the last frame must be rolled before score can be calculated
      */
+    #[TestDox('bonus rolls for a strike in the last frame must be rolled before score can be calculated')]
     public function testBonusRollsForAStrikeInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated(): void
     {
         $this->expectException(Exception::class);
@@ -409,8 +412,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 537f4e37-4b51-4d1c-97e2-986eb37b2ac1
-     * @testdox both bonus rolls for a strike in the last frame must be rolled before score can be calculated
      */
+    #[TestDox('both bonus rolls for a strike in the last frame must be rolled before score can be calculated')]
     public function testBothBonusRollsForAStrikeInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated(): void
     {
         $this->expectException(Exception::class);
@@ -423,8 +426,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8134e8c1-4201-4197-bf9f-1431afcde4b9
-     * @testdox bonus roll for a spare in the last frame must be rolled before score can be calculated
      */
+    #[TestDox('bonus roll for a spare in the last frame must be rolled before score can be calculated')]
     public function testBonusRollForASpareInTheLastFrameMustBeRolledBeforeScoreCanBeCalculated(): void
     {
         $this->expectException(Exception::class);
@@ -437,8 +440,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9d4a9a55-134a-4bad-bae8-3babf84bd570
-     * @testdox cannot roll after bonus roll for spare
      */
+    #[TestDox('cannot roll after bonus roll for spare')]
     public function testCannotRollAfterBonusRollForSpare(): void
     {
         $this->expectException(Exception::class);
@@ -453,8 +456,8 @@ class BowlingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d3e02652-a799-4ae3-b53b-68582cc604be
-     * @testdox cannot roll after bonus rolls for strike
      */
+    #[TestDox('cannot roll after bonus rolls for strike')]
     public function testCannotRollAfterBonusRollsForStrike(): void
     {
         $this->expectException(Exception::class);

--- a/exercises/practice/change/ChangeTest.php
+++ b/exercises/practice/change/ChangeTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ChangeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ChangeTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d0ebd0e1-9d27-4609-a654-df5c0ba1d83a
-     * @testdox change for 1 cent
      */
+    #[TestDox('change for 1 cent')]
     public function testChangeForOneCent(): void
     {
         $this->assertEquals([1], findFewestCoins([1, 5, 10, 25], 1));
@@ -20,8 +23,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 36887bea-7f92-4a9c-b0cc-c0e886b3ecc8
-     * @testdox single coin change
      */
+    #[TestDox('single coin change')]
     public function testSingleCoinChange(): void
     {
         $this->assertEquals([25], findFewestCoins([1, 5, 10, 25, 100], 25));
@@ -29,8 +32,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cef21ccc-0811-4e6e-af44-f011e7eab6c6
-     * @testdox multiple coin change
      */
+    #[TestDox('multiple coin change')]
     public function testMultipleCoinChange(): void
     {
         $this->assertEquals([5, 10], findFewestCoins([1, 5, 10, 25, 100], 15));
@@ -38,8 +41,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d60952bc-0c1a-4571-bf0c-41be72690cb3
-     * @testdox change with Lilliputian Coins
      */
+    #[TestDox('change with Lilliputian Coins')]
     public function testChangeWithLilliputianCoins(): void
     {
         $this->assertEquals([4, 4, 15], findFewestCoins([1, 4, 15, 20, 50], 23));
@@ -47,8 +50,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 408390b9-fafa-4bb9-b608-ffe6036edb6c
-     * @testdox change with Lower Elbonia Coins
      */
+    #[TestDox('change with Lower Elbonia Coins')]
     public function testChangeWithLowerElboniaCoins(): void
     {
         $this->assertEquals([21, 21, 21], findFewestCoins([1, 5, 10, 21, 25], 63));
@@ -56,8 +59,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7421a4cb-1c48-4bf9-99c7-7f049689132f
-     * @testdox large target values
      */
+    #[TestDox('large target values')]
     public function testWithLargeTargetValue(): void
     {
         $this->assertEquals(
@@ -68,8 +71,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f79d2e9b-0ae3-4d6a-bb58-dc978b0dba28
-     * @testdox possible change without unit coins available
      */
+    #[TestDox('possible change without unit coins available')]
     public function testPossibleChangeWithoutUnitCoinsAvailable(): void
     {
         $this->assertEquals(
@@ -80,8 +83,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9a166411-d35d-4f7f-a007-6724ac266178
-     * @testdox another possible change without unit coins available
      */
+    #[TestDox('another possible change without unit coins available')]
     public function testAnotherPossibleChangeWithoutUnitCoinsAvailable(): void
     {
         $this->assertEquals(
@@ -92,8 +95,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ce0f80d5-51c3-469d-818c-3e69dbd25f75
-     * @testdox a greedy approach is not optimal
      */
+    #[TestDox('a greedy approach is not optimal')]
     public function testAGreedyApproachIsNotOptimal(): void
     {
         $this->assertEquals([10, 10], findFewestCoins([1, 10, 11], 20));
@@ -101,8 +104,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bbbcc154-e9e9-4209-a4db-dd6d81ec26bb
-     * @testdox no coins make 0 change
      */
+    #[TestDox('no coins make 0 change')]
     public function testNoCoinsForZero(): void
     {
         $this->assertEquals([], findFewestCoins([1, 5, 10, 21, 25], 0));
@@ -110,8 +113,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c8b81d5a-49bd-4b61-af73-8ee5383a2ce1
-     * @testdox error testing for change smaller than the smallest of coins
      */
+    #[TestDox('error testing for change smaller than the smallest of coins')]
     public function testForChangeSmallerThanAvailableCoins(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -122,8 +125,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3c43e3e4-63f9-46ac-9476-a67516e98f68
-     * @testdox error if no combination can add up to target
      */
+    #[TestDox('error if no combination can add up to target')]
     public function testErrorIfNoCombinationCanAddUpToTarget(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -134,8 +137,8 @@ class ChangeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8fe1f076-9b2d-4f44-89fe-8a6ccd63c8f3
-     * @testdox cannot find negative change values
      */
+    #[TestDox('cannot find negative change values')]
     public function testChangeValueLessThanZero(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/practice/circular-buffer/CircularBufferTest.php
+++ b/exercises/practice/circular-buffer/CircularBufferTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\TestDox;
+
 require_once 'CircularBuffer.php';
 
 use PHPUnit\Framework\TestCase;
@@ -10,8 +12,8 @@ class CircularBufferTest extends TestCase
 {
     /**
      * uuid: 28268ed4-4ff3-45f3-820e-895b44d53dfa
-     * @testdox reading empty buffer should fail
      */
+    #[TestDox('reading empty buffer should fail')]
     public function testReadingEmptyBufferShouldFail(): void
     {
         $buffer = new CircularBuffer(1);
@@ -21,8 +23,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 2e6db04a-58a1-425d-ade8-ac30b5f318f3
-     * @testdox can read an item just written
      */
+    #[TestDox('can read an item just written')]
     public function testCanReadAnItemJustWritten(): void
     {
         $buffer = new CircularBuffer(1);
@@ -32,8 +34,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 90741fe8-a448-45ce-be2b-de009a24c144
-     * @testdox each item may only be read once
      */
+    #[TestDox('each item may only be read once')]
     public function testEachItemMayOnlyBeReadOnce(): void
     {
         $buffer = new CircularBuffer(1);
@@ -45,8 +47,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: be0e62d5-da9c-47a8-b037-5db21827baa7
-     * @testdox items are read in the order they are written
      */
+    #[TestDox('items are read in the order they are written')]
     public function testItemsAreReadInTheOrderTheyAreWritten(): void
     {
         $buffer = new CircularBuffer(2);
@@ -58,8 +60,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 2af22046-3e44-4235-bfe6-05ba60439d38
-     * @testdox full buffer can't be written to
      */
+    #[TestDox("full buffer can't be written to")]
     public function testFullBufferCantBeWrittenTo(): void
     {
         $buffer = new CircularBuffer(1);
@@ -70,8 +72,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 547d192c-bbf0-4369-b8fa-fc37e71f2393
-     * @testdox a read frees up capacity for another write
      */
+    #[TestDox('a read frees up capacity for another write')]
     public function testAReadFreesUpCapacityForAnotherWrite(): void
     {
         $buffer = new CircularBuffer(1);
@@ -83,8 +85,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 04a56659-3a81-4113-816b-6ecb659b4471
-     * @testdox read position is maintained even across multiple writes
      */
+    #[TestDox('read position is maintained even across multiple writes')]
     public function testReadPositionIsMaintainedEvenAcrossMultipleWrites(): void
     {
         $buffer = new CircularBuffer(3);
@@ -98,8 +100,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 60c3a19a-81a7-43d7-bb0a-f07242b1111f
-     * @testdox items cleared out of buffer can't be read
      */
+    #[TestDox("items cleared out of buffer can't be read")]
     public function testItemsClearedOutOfBufferCantBeRead(): void
     {
         $buffer = new CircularBuffer(1);
@@ -111,8 +113,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 45f3ae89-3470-49f3-b50e-362e4b330a59
-     * @testdox clear frees up capacity for another write
      */
+    #[TestDox('clear frees up capacity for another write')]
     public function testClearFreesUpCapacityForAnotherWrite(): void
     {
         $buffer = new CircularBuffer(1);
@@ -124,8 +126,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: e1ac5170-a026-4725-bfbe-0cf332eddecd
-     * @testdox clear does nothing on empty buffer
      */
+    #[TestDox('clear does nothing on empty buffer')]
     public function testClearDoesNothingOnEmptyBuffer(): void
     {
         $buffer = new CircularBuffer(1);
@@ -136,8 +138,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b
-     * @testdox overwrite acts like write on non-full buffer
      */
+    #[TestDox('overwrite acts like write on non-full buffer')]
     public function testOverwriteActsLikeWriteOnNonFullBuffer(): void
     {
         $buffer = new CircularBuffer(2);
@@ -149,8 +151,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 880f916b-5039-475c-bd5c-83463c36a147
-     * @testdox overwrite replaces the oldest item on full buffer
      */
+    #[TestDox('overwrite replaces the oldest item on full buffer')]
     public function testOverwriteReplacesTheOldestItemOnFullBuffer(): void
     {
         $buffer = new CircularBuffer(2);
@@ -163,8 +165,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: bfecab5b-aca1-4fab-a2b0-cd4af2b053c3
-     * @testdox overwrite replaces the oldest item remaining in buffer following a read
      */
+    #[TestDox('overwrite replaces the oldest item remaining in buffer following a read')]
     public function testOverwriteReplacesTheOldestItemRemainingInBufferFollowingARead(): void
     {
         $buffer = new CircularBuffer(3);
@@ -181,8 +183,8 @@ class CircularBufferTest extends TestCase
 
     /**
      * uuid: 9cebe63a-c405-437b-8b62-e3fdc1ecec5a
-     * @testdox initial clear does not affect wrapping around
      */
+    #[TestDox('initial clear does not affect wrapping around')]
     public function testInitialClearDoesNotAffectWrappingAround(): void
     {
         $buffer = new CircularBuffer(2);

--- a/exercises/practice/clock/ClockTest.php
+++ b/exercises/practice/clock/ClockTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ClockTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ClockTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a577bacc-106b-496e-9792-b3083ea8705e
-     * @testdox Create a new clock with an initial time - on the hour
      */
+    #[TestDox('Create a new clock with an initial time - on the hour')]
     public function testOnTheHour(): void
     {
         $clock = new Clock(8);
@@ -22,8 +25,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b5d0c360-3b88-489b-8e84-68a1c7a4fa23
-     * @testdox past the hour
      */
+    #[TestDox('past the hour')]
     public function testPastTheHour(): void
     {
         $clock = new Clock(11, 9);
@@ -33,8 +36,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 473223f4-65f3-46ff-a9f7-7663c7e59440
-     * @testdox midnight is zero hours
      */
+    #[TestDox('midnight is zero hours')]
     public function testMidnightIsZeroHours(): void
     {
         $clock = new Clock(24, 0);
@@ -43,8 +46,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ca95d24a-5924-447d-9a96-b91c8334725c
-     * @testdox hour rolls over
      */
+    #[TestDox('hour rolls over')]
     public function testHourRollsOver(): void
     {
         $clock = new Clock(25, 0);
@@ -53,8 +56,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f3826de0-0925-4d69-8ac8-89aea7e52b78
-     * @testdox hour rolls over continuously
      */
+    #[TestDox('hour rolls over continuously')]
     public function testHourRollsOverContinuously(): void
     {
         $clock = new Clock(100, 0);
@@ -63,8 +66,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a02f7edf-dfd4-4b11-b21a-86de3cc6a95c
-     * @testdox sixty minutes is next hour
      */
+    #[TestDox('sixty minutes is next hour')]
     public function testSixtyMinutesIsNextHour(): void
     {
         $clock = new Clock(1, 60);
@@ -73,8 +76,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8f520df6-b816-444d-b90f-8a477789beb5
-     * @testdox minutes roll over
      */
+    #[TestDox('minutes roll over')]
     public function testMinutesRollOver(): void
     {
         $clock = new Clock(0, 160);
@@ -83,8 +86,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c75c091b-47ac-4655-8d40-643767fc4eed
-     * @testdox minutes roll over continuously
      */
+    #[TestDox('minutes roll over continuously')]
     public function testMinutesRollOverContinuously(): void
     {
         $clock = new Clock(0, 1723);
@@ -93,8 +96,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 06343ecb-cf39-419d-a3f5-dcbae0cc4c57
-     * @testdox hour and minutes roll over
      */
+    #[TestDox('hour and minutes roll over')]
     public function testHourAndMinutesRollOver(): void
     {
         $clock = new Clock(25, 160);
@@ -103,8 +106,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid be60810e-f5d9-4b58-9351-a9d1e90e660c
-     * @testdox hour and minutes roll over continuously
      */
+    #[TestDox('hour and minutes roll over continuously')]
     public function testHourAndMinutesRollOverContinuously(): void
     {
         $clock = new Clock(201, 3001);
@@ -114,8 +117,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1689107b-0b5c-4bea-aad3-65ec9859368a
-     * @testdox hour and minutes roll over to exactly midnight
      */
+    #[TestDox('hour and minutes roll over to exactly midnight')]
     public function testHourAndMinutesRollOverToExactlyMidnight(): void
     {
         $clock = new Clock(72, 8640);
@@ -124,8 +127,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d3088ee8-91b7-4446-9e9d-5e2ad6219d91
-     * @testdox negative hour
      */
+    #[TestDox('negative hour')]
     public function testNegativeHour(): void
     {
         $clock = new Clock(-1, 15);
@@ -134,8 +137,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 77ef6921-f120-4d29-bade-80d54aa43b54
-     * @testdox negative hour rolls over
      */
+    #[TestDox('negative hour rolls over')]
     public function testNegativeHourRollsOver(): void
     {
         $clock = new Clock(-25, 0);
@@ -144,8 +147,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 359294b5-972f-4546-bb9a-a85559065234
-     * @testdox negative hour rolls over continuously
      */
+    #[TestDox('negative hour rolls over continuously')]
     public function testNegativeHourRollsOverContinuously(): void
     {
         $clock = new Clock(-91, 0);
@@ -154,8 +157,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 509db8b7-ac19-47cc-bd3a-a9d2f30b03c0
-     * @testdox negative minutes
      */
+    #[TestDox('negative minutes')]
     public function testNegativeMinutes(): void
     {
         $clock = new Clock(1, -40);
@@ -164,8 +167,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5d6bb225-130f-4084-84fd-9e0df8996f2a
-     * @testdox negative minutes roll over
      */
+    #[TestDox('negative minutes roll over')]
     public function testNegativeMinutesRollOver(): void
     {
         $clock = new Clock(1, -160);
@@ -174,8 +177,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d483ceef-b520-4f0c-b94a-8d2d58cf0484
-     * @testdox negative minutes roll over continuously
      */
+    #[TestDox('negative minutes roll over continuously')]
     public function testNegativeMinutesRollOverContinuously(): void
     {
         $clock = new Clock(1, -4820);
@@ -184,8 +187,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1cd19447-19c6-44bf-9d04-9f8305ccb9ea
-     * @testdox negative sixty minutes is previous hour
      */
+    #[TestDox('negative sixty minutes is previous hour')]
     public function testNegativeSixtyMinutesIsPreviousHour(): void
     {
         $clock = new Clock(2, -60);
@@ -194,8 +197,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9d3053aa-4f47-4afc-bd45-d67a72cef4dc
-     * @testdox negative hour and minutes both roll over
      */
+    #[TestDox('negative hour and minutes both roll over')]
     public function testNegativeHourAndMinutesBothRollOver(): void
     {
         $clock = new Clock(-25, -160);
@@ -204,8 +207,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 51d41fcf-491e-4ca0-9cae-2aa4f0163ad4
-     * @testdox negative hour and minutes both roll over continuously
      */
+    #[TestDox('negative hour and minutes both roll over continuously')]
     public function testNegativeHourAndMinutesBothRollOverContinuously(): void
     {
         $clock = new Clock(-121, -5810);
@@ -215,8 +218,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d098e723-ad29-4ef9-997a-2693c4c9d89a
-     * @testdox Add minutes - add minutes
      */
+    #[TestDox('Add minutes - add minutes')]
     public function testAddMinutes()
     {
         $clock = new Clock(10, 0);
@@ -226,8 +229,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b6ec8f38-e53e-4b22-92a7-60dab1f485f4
-     * @testdox Add no minutes
      */
+    #[TestDox('Add no minutes')]
     public function testAddNoMinutes()
     {
         $clock = new Clock(6, 41);
@@ -237,8 +240,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid efd349dd-0785-453e-9ff8-d7452a8e7269
-     * @testdox Add to next hour
      */
+    #[TestDox('Add to next hour')]
     public function testAddToNextHour()
     {
         $clock = new Clock(0, 45);
@@ -248,8 +251,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 749890f7-aba9-4702-acce-87becf4ef9fe
-     * @testdox Add more than one hour
      */
+    #[TestDox('Add more than one hour')]
     public function testAddMoreThanOneHour()
     {
         $clock = new Clock(10, 0);
@@ -259,8 +262,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid da63e4c1-1584-46e3-8d18-c9dc802c1713
-     * @testdox Add more than two hours with carry
      */
+    #[TestDox('Add more than two hours with carry')]
     public function testAddMoreThanTwoHoursWithCarry()
     {
         $clock = new Clock(0, 45);
@@ -270,8 +273,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid be167a32-3d33-4cec-a8bc-accd47ddbb71
-     * @testdox Add across midnight
      */
+    #[TestDox('Add across midnight')]
     public function testAddAcrossMidnight()
     {
         $clock = new Clock(23, 59);
@@ -281,8 +284,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6672541e-cdae-46e4-8be7-a820cc3be2a8
-     * @testdox Add more than one day (1500 min = 25 hrs)
      */
+    #[TestDox('Add more than one day (1500 min = 25 hrs)')]
     public function testAddMoreThanOneDay()
     {
         $clock = new Clock(5, 32);
@@ -292,8 +295,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1918050d-c79b-4cb7-b707-b607e2745c7e
-     * @testdox Add more than two days
      */
+    #[TestDox('Add more than two days')]
     public function testAddMoreThanTwoDays()
     {
         $clock = new Clock(1, 1);
@@ -303,8 +306,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 37336cac-5ede-43a5-9026-d426cbe40354
-     * @testdox Subtract minutes - subtract minutes
      */
+    #[TestDox('Subtract minutes - subtract minutes')]
     public function testSubtractMinutes(): void
     {
         $clock = new Clock(10, 3);
@@ -314,8 +317,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b
-     * @testdox subtract to previous hour
      */
+    #[TestDox('subtract to previous hour')]
     public function testSubtractToPreviousHour(): void
     {
         $clock = new Clock(10, 3);
@@ -325,8 +328,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9b4e809c-612f-4b15-aae0-1df0acb801b9
-     * @testdox subtract more than an hour
      */
+    #[TestDox('subtract more than an hour')]
     public function testSubtractMoreThanAnHour(): void
     {
         $clock = new Clock(10, 3);
@@ -336,8 +339,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6
-     * @testdox subtract across midnight
      */
+    #[TestDox('subtract across midnight')]
     public function testSubtractAcrossMidnight(): void
     {
         $clock = new Clock(0, 3);
@@ -347,8 +350,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9
-     * @testdox subtract more than two hours
      */
+    #[TestDox('subtract more than two hours')]
     public function testSubtractMoreThanTwoHours(): void
     {
         $clock = new Clock(0, 0);
@@ -358,8 +361,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 90ac8a1b-761c-4342-9c9c-cdc3ed5db097
-     * @testdox subtract more than two hours with borrow
      */
+    #[TestDox('subtract more than two hours with borrow')]
     public function testSubtractMoreThanTwoHoursWithBorrow(): void
     {
         $clock = new Clock(6, 15);
@@ -369,8 +372,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2149f985-7136-44ad-9b29-ec023a97a2b7
-     * @testdox subtract more than one day (1500 min = 25 hrs)
      */
+    #[TestDox('subtract more than one day (1500 min = 25 hrs)')]
     public function testSubtractMoreThanOneDay(): void
     {
         $clock = new Clock(5, 32);
@@ -380,8 +383,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ba11dbf0-ac27-4acb-ada9-3b853ec08c97
-     * @testdox subtract more than two days
      */
+    #[TestDox('subtract more than two days')]
     public function testSubtractMoreThanTwoDays(): void
     {
         $clock = new Clock(2, 20);
@@ -391,8 +394,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f2fdad51-499f-4c9b-a791-b28c9282e311
-     * @testdox Compare two clocks for equality - clocks with same time
      */
+    #[TestDox('Compare two clocks for equality - clocks with same time')]
     public function testClocksWithSameTime(): void
     {
         $this->assertEquals(new Clock(15, 37), new Clock(15, 37));
@@ -400,8 +403,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5d409d4b-f862-4960-901e-ec430160b768
-     * @testdox clocks a minute apart
      */
+    #[TestDox('clocks a minute apart')]
     public function testClocksAMinuteApart(): void
     {
         $this->assertNotEquals(new Clock(15, 36), new Clock(15, 37));
@@ -409,8 +412,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a6045fcf-2b52-4a47-8bb2-ef10a064cba5
-     * @testdox clocks an hour apart
      */
+    #[TestDox('clocks an hour apart')]
     public function testClocksAnHourApart(): void
     {
         $this->assertNotEquals(new Clock(14, 37), new Clock(15, 37));
@@ -418,8 +421,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 66b12758-0be5-448b-a13c-6a44bce83527
-     * @testdox clocks with hour overflow
      */
+    #[TestDox('clocks with hour overflow')]
     public function testClocksWithHourOverflow(): void
     {
         $this->assertEquals(new Clock(10, 37), new Clock(34, 37));
@@ -427,8 +430,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2b19960c-212e-4a71-9aac-c581592f8111
-     * @testdox clocks with hour overflow by several days
      */
+    #[TestDox('clocks with hour overflow by several days')]
     public function testClocksWithHourOverflowBySeveralDays(): void
     {
         $this->assertEquals(new Clock(3, 11), new Clock(99, 11));
@@ -436,8 +439,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6f8c6541-afac-4a92-b0c2-b10d4e50269f
-     * @testdox clocks with negative hour
      */
+    #[TestDox('clocks with negative hour')]
     public function testClocksWithNegativeHour(): void
     {
         $this->assertEquals(new Clock(22, 40), new Clock(-2, 40));
@@ -445,8 +448,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d
-     * @testdox clocks with negative hour that wraps
      */
+    #[TestDox('clocks with negative hour that wraps')]
     public function testClocksWithNegativeHourThatWraps(): void
     {
         $this->assertEquals(new Clock(17, 3), new Clock(-31, 3));
@@ -454,8 +457,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 56c0326d-565b-4d19-a26f-63b3205778b7
-     * @testdox clocks with negative hour that wraps multiple times
      */
+    #[TestDox('clocks with negative hour that wraps multiple times')]
     public function testClocksWithNegativeHourThatWrapsMultipleTimes(): void
     {
         $this->assertEquals(new Clock(13, 49), new Clock(-83, 49));
@@ -463,8 +466,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c90b9de8-ddff-4ffe-9858-da44a40fdbc2
-     * @testdox clocks with minute overflow
      */
+    #[TestDox('clocks with minute overflow')]
     public function testClocksWithMinuteOverflow(): void
     {
         $this->assertEquals(new Clock(0, 1), new Clock(0, 1441));
@@ -472,8 +475,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 533a3dc5-59a7-491b-b728-a7a34fe325de
-     * @testdox clocks with minute overflow by several days
      */
+    #[TestDox('clocks with minute overflow by several days')]
     public function testClocksWithMinuteOverflowBySeveralDays(): void
     {
         $this->assertEquals(new Clock(2, 2), new Clock(2, 4322));
@@ -481,8 +484,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fff49e15-f7b7-4692-a204-0f6052d62636
-     * @testdox clocks with negative minute
      */
+    #[TestDox('clocks with negative minute')]
     public function testClocksWithNegativeMinute(): void
     {
         $this->assertEquals(new Clock(2, 40), new Clock(3, -20));
@@ -490,8 +493,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 605c65bb-21bd-43eb-8f04-878edf508366
-     * @testdox clocks with negative minute that wraps
      */
+    #[TestDox('clocks with negative minute that wraps')]
     public function testClocksWithNegativeMinuteThatWraps(): void
     {
         $this->assertEquals(new Clock(4, 10), new Clock(5, -1490));
@@ -499,8 +502,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b87e64ed-212a-4335-91fd-56da8421d077
-     * @testdox clocks with negative minute that wraps multiple times
      */
+    #[TestDox('clocks with negative minute that wraps multiple times')]
     public function testClocksWithNegativeMinuteThatWrapsMultipleTimes(): void
     {
         $this->assertEquals(new Clock(6, 15), new Clock(6, -4305));
@@ -508,8 +511,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 822fbf26-1f3b-4b13-b9bf-c914816b53dd
-     * @testdox clocks with negative hours and minutes
      */
+    #[TestDox('clocks with negative hours and minutes')]
     public function testClocksWithNegativeHoursAndMinutes(): void
     {
         $this->assertEquals(new Clock(7, 32), new Clock(-12, -268));
@@ -517,8 +520,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e787bccd-cf58-4a1d-841c-ff80eaaccfaa
-     * @testdox clocks with negative hours and minutes that wrap
      */
+    #[TestDox('clocks with negative hours and minutes that wrap')]
     public function testClocksWithNegativeHoursAndMinutesThatWrap(): void
     {
         $this->assertEquals(new Clock(18, 7), new Clock(-54, -11513));
@@ -526,8 +529,8 @@ class ClockTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 96969ca8-875a-48a1-86ae-257a528c44f5
-     * @testdox full clock and zeroed clock
      */
+    #[TestDox('full clock and zeroed clock')]
     public function testFullClockAndZeroedClock(): void
     {
         $this->assertEquals(new Clock(24, 0), new Clock(0, 0));

--- a/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
+++ b/exercises/practice/collatz-conjecture/CollatzConjectureTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class CollatzConjectureTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class CollatzConjectureTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 540a3d51-e7a6-47a5-92a3-4ad1838f0bfd
-     * @testdox zero steps for one
      */
+    #[TestDox('zero steps for one')]
     public function testZeroStepsForOne(): void
     {
         $this->assertEquals(0, steps(1));
@@ -20,8 +23,8 @@ class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3d76a0a6-ea84-444a-821a-f7857c2c1859
-     * @testdox divide if even
      */
+    #[TestDox('divide if even')]
     public function testDivideIfEven(): void
     {
         $this->assertEquals(4, steps(16));
@@ -29,8 +32,8 @@ class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 754dea81-123c-429e-b8bc-db20b05a87b9
-     * @testdox even and odd steps
      */
+    #[TestDox('even and odd steps')]
     public function testEvenAndOddSteps(): void
     {
         $this->assertEquals(9, steps(12));
@@ -38,8 +41,8 @@ class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ecfd0210-6f85-44f6-8280-f65534892ff6
-     * @testdox large number of even and odd steps
      */
+    #[TestDox('large number of even and odd steps')]
     public function testLargeNumberOfEvenAndOddSteps(): void
     {
         $this->assertEquals(152, steps(1000000));
@@ -47,8 +50,8 @@ class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2187673d-77d6-4543-975e-66df6c50e2da
-     * @testdox zero is an error
      */
+    #[TestDox('zero is an error')]
     public function testZeroIsAnError(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -61,8 +64,8 @@ class CollatzConjectureTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ec11f479-56bc-47fd-a434-bcd7a31a7a2e
-     * @testdox negative value is an error
      */
+    #[TestDox('negative value is an error')]
     public function testNegativeValueIsAnError(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/practice/connect/ConnectTest.php
+++ b/exercises/practice/connect/ConnectTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ConnectTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ConnectTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6eff0df4-3e92-478d-9b54-d3e8b354db56
-     * @testdox an empty board has no winner
      */
+    #[TestDox('an empty board has no winner')]
     public function testEmptyBoardHasNoWinner(): void
     {
         $lines = [
@@ -27,8 +30,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 298b94c0-b46d-45d8-b34b-0fa2ea71f0a4
-     * @testdox X can win on a 1x1 board
      */
+    #[TestDox('X can win on a 1x1 board')]
     public function testOneByOneBoardBlack(): void
     {
         $lines = ["X"];
@@ -37,8 +40,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 763bbae0-cb8f-4f28-bc21-5be16a5722dc
-     * @testdox O can win on a 1x1 board
      */
+    #[TestDox('O can win on a 1x1 board')]
     public function testOneByOneBoardWhite(): void
     {
         $lines = ["O"];
@@ -47,8 +50,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 819fde60-9ae2-485e-a024-cbb8ea68751b
-     * @testdox only edges does not make a winner
      */
+    #[TestDox('only edges does not make a winner')]
     public function testOnlyEgesDoesNotMakeAWinner(): void
     {
         $lines = [
@@ -62,8 +65,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2c56a0d5-9528-41e5-b92b-499dfe08506c
-     * @testdox illegal diagonal does not make a winner
      */
+    #[TestDox('illegal diagonal does not make a winner')]
     public function testIllegalDiagonalDoesNotMakeAWinner(): void
     {
         $lines = [
@@ -78,8 +81,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 41cce3ef-43ca-4963-970a-c05d39aa1cc1
-     * @testdox nobody wins crossing adjacent angles
      */
+    #[TestDox('nobody wins crossing adjacent angles')]
     public function testNobodyWinsCrossingAdjacentAngles(): void
     {
         $lines = [
@@ -94,8 +97,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cd61c143-92f6-4a8d-84d9-cb2b359e226b
-     * @testdox X wins crossing from left to right
      */
+    #[TestDox('X wins crossing from left to right')]
     public function testXWinsCrossingFromLeftToRight(): void
     {
         $lines = [
@@ -110,8 +113,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 73d1eda6-16ab-4460-9904-b5f5dd401d0b
-     * @testdox O wins crossing from top to bottom
      */
+    #[TestDox('O wins crossing from top to bottom')]
     public function testOWinsCrossingFromTopToBottom(): void
     {
         $lines = [
@@ -126,8 +129,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c3a2a550-944a-4637-8b3f-1e1bf1340a3d
-     * @testdox X wins using a convoluted path
      */
+    #[TestDox('X wins using a convoluted path')]
     public function testXWinsUsingAConvolutedPath(): void
     {
         $lines = [
@@ -142,8 +145,8 @@ class ConnectTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 17e76fa8-f731-4db7-92ad-ed2a285d31f3
-     * @testdox X wins using a spiral path
      */
+    #[TestDox('X wins using a spiral path')]
     public function testXWinsUsingASpiralPath(): void
     {
         $lines = [

--- a/exercises/practice/crypto-square/CryptoSquareTest.php
+++ b/exercises/practice/crypto-square/CryptoSquareTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class CryptoSquareTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class CryptoSquareTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 407c3837-9aa7-4111-ab63-ec54b58e8e9f
-     * @testdox empty plaintext results in an empty ciphertext
      */
+    #[TestDox('empty plaintext results in an empty ciphertext')]
     public function testEmptyPlaintextResultsInAnEmptyCiphertext(): void
     {
         $this->assertEquals("", crypto_square(""));
@@ -20,8 +23,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid aad04a25-b8bb-4304-888b-581bea8e0040
-     * @testdox normalization results in empty plaintext
      */
+    #[TestDox('normalization results in empty plaintext')]
     public function testNormalizationResultsInEmptyPlaintext(): void
     {
         $this->assertEquals("", crypto_square("... --- ..."));
@@ -29,8 +32,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 64131d65-6fd9-4f58-bdd8-4a2370fb481d
-     * @testdox Lowercase
      */
+    #[TestDox('Lowercase')]
     public function testLowercase(): void
     {
         $this->assertEquals("a", crypto_square("A"));
@@ -38,8 +41,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 63a4b0ed-1e3c-41ea-a999-f6f26ba447d6
-     * @testdox Remove spaces
      */
+    #[TestDox('Remove spaces')]
     public function testRemoveSpaces(): void
     {
         $this->assertEquals("b", crypto_square("  b "));
@@ -47,8 +50,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1b5348a1-7893-44c1-8197-42d48d18756c
-     * @testdox Remove punctuation
      */
+    #[TestDox('Remove punctuation')]
     public function testRemovePunctuation(): void
     {
         $this->assertEquals("1", crypto_square("@1,%!"));
@@ -56,8 +59,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8574a1d3-4a08-4cec-a7c7-de93a164f41a
-     * @testdox 9 character plaintext results in 3 chunks of 3 characters
      */
+    #[TestDox('9 character plaintext results in 3 chunks of 3 characters')]
     public function test9CharacterPlaintextResultsIn3ChunksOf3Characters(): void
     {
         $this->assertEquals("tsf hiu isn", crypto_square("This is fun!"));
@@ -65,8 +68,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a65d3fa1-9e09-43f9-bcec-7a672aec3eae
-     * @testdox 8 character plaintext results in 3 chunks, the last one with a trailing space
      */
+    #[TestDox('8 character plaintext results in 3 chunks, the last one with a trailing space')]
     public function test8CharacterPlaintextResultsIn3ChunksTheLastOneWithATrailingSpace(): void
     {
         $this->assertEquals("clu hlt io ", crypto_square("Chill out."));
@@ -74,8 +77,8 @@ class CryptoSquareTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 33fd914e-fa44-445b-8f38-ff8fbc9fe6e6
-     * @testdox 54 character plaintext results in 8 chunks, the last two with trailing spaces
      */
+    #[TestDox('54 character plaintext results in 8 chunks, the last two with trailing spaces')]
     public function test54CharacterPlaintextResultsIn7ChunksTheLastTwoWithTrailingSpaces(): void
     {
         $this->assertEquals(

--- a/exercises/practice/darts/Darts.php
+++ b/exercises/practice/darts/Darts.php
@@ -26,5 +26,5 @@ declare(strict_types=1);
 
 function score(float $xAxis, float $yAxis): int
 {
-    throw new BadFunctionCallException("Please implement the __FUNCTION__ function!");
+    throw new \BadFunctionCallException("Please implement the __FUNCTION__ function!");
 }

--- a/exercises/practice/darts/DartsTest.php
+++ b/exercises/practice/darts/DartsTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class DartsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class DartsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9033f731-0a3a-4d9c-b1c0-34a1c8362afb
-     * @testdox Missed target
      */
+    #[TestDox('Missed target')]
     public function testMissedTarget(): void
     {
         $this->assertEquals(0, score(-9.0, 9.0));
@@ -20,8 +23,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba
-     * @testdox On the outer circle
      */
+    #[TestDox('On the outer circle')]
     public function testInOuterCircle(): void
     {
         $this->assertEquals(1, score(0.0, 10.0));
@@ -29,8 +32,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 14378687-ee58-4c9b-a323-b089d5274be8
-     * @testdox On the middle circle
      */
+    #[TestDox('On the middle circle')]
     public function testInMiddleCircle(): void
     {
         $this->assertEquals(5, score(-5.0, 0.0));
@@ -38,8 +41,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 849e2e63-85bd-4fed-bc3b-781ae962e2c9
-     * @testdox On the inner circle
      */
+    #[TestDox('On the inner circle')]
     public function testInInnerCircle(): void
     {
         $this->assertEquals(10, score(0.0, -1.0));
@@ -47,8 +50,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1c5ffd9f-ea66-462f-9f06-a1303de5a226
-     * @testdox Exactly on center
      */
+    #[TestDox('Exactly on center')]
     public function testInCenter(): void
     {
         $this->assertEquals(10, score(0.0, 0.0));
@@ -56,8 +59,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b65abce3-a679-4550-8115-4b74bda06088
-     * @testdox Near the center
      */
+    #[TestDox('Near the center')]
     public function testNearCenter(): void
     {
         $this->assertEquals(10, score(-0.1, -0.1));
@@ -65,8 +68,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 66c29c1d-44f5-40cf-9927-e09a1305b399
-     * @testdox Just within the inner circle
      */
+    #[TestDox('Just within the inner circle')]
     public function testJustInsideCenter(): void
     {
         $this->assertEquals(10, score(0.7, 0.7));
@@ -74,8 +77,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d1012f63-c97c-4394-b944-7beb3d0b141a
-     * @testdox Just outside the inner circle
      */
+    #[TestDox('Just outside the inner circle')]
     public function testJustOutsideCenter(): void
     {
         $this->assertEquals(5, score(0.8, -0.8));
@@ -83,8 +86,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ab2b5666-b0b4-49c3-9b27-205e790ed945
-     * @testdox Just within the middle circle
      */
+    #[TestDox('Just within the middle circle')]
     public function testJustWithinMiddleCircle(): void
     {
         $this->assertEquals(5, score(-3.5, 3.5));
@@ -92,8 +95,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 70f1424e-d690-4860-8caf-9740a52c0161
-     * @testdox Just outside the middle circle
      */
+    #[TestDox('Just outside the middle circle')]
     public function testJustOutsideMiddleCircle(): void
     {
         $this->assertEquals(1, score(-3.6, -3.6));
@@ -101,8 +104,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a7dbf8db-419c-4712-8a7f-67602b69b293
-     * @testdox Just within the outer circle
      */
+    #[TestDox('Just within the outer circle')]
     public function testJustInsideOuterCircle(): void
     {
         $this->assertEquals(1, score(-7.0, 7.0));
@@ -110,8 +113,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e0f39315-9f9a-4546-96e4-a9475b885aa7
-     * @testdox Just outside the outer circle
      */
+    #[TestDox('Just outside the outer circle')]
     public function testJustOutsideOuterCircle(): void
     {
         $this->assertEquals(0, score(7.1, -7.1));
@@ -119,8 +122,8 @@ class DartsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 045d7d18-d863-4229-818e-b50828c75d19
-     * @testdox Asymmetric position between the inner and middle circles
      */
+    #[TestDox('Asymmetric position between the inner and middle circles')]
     public function testAsymmetricPositionBetweenInnerAndOuterCircles(): void
     {
         $this->assertEquals(5, score(0.5, -4));

--- a/exercises/practice/diamond/DiamondTest.php
+++ b/exercises/practice/diamond/DiamondTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class DiamondTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class DiamondTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class DiamondTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 202fb4cc-6a38-4883-9193-a29d5cb92076
-     * @testdox Degenerate case with a single 'A' row
      */
+    #[TestDox("Degenerate case with a single 'A' row")]
     public function testDegenerateCaseWithASingleARow(): void
     {
         $this->assertEquals(["A"], diamond("A"));
@@ -20,8 +23,8 @@ class DiamondTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bd6a6d78-9302-42e9-8f60-ac1461e9abae
-     * @testdox Degenerate case with no row containing 3 distinct groups of spaces
      */
+    #[TestDox('Degenerate case with no row containing 3 distinct groups of spaces')]
     public function testDegenerateCaseWithNoRowContaining3DistinctGroupsOfSpaces(): void
     {
         $this->assertEquals(
@@ -36,8 +39,8 @@ class DiamondTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: af8efb49-14ed-447f-8944-4cc59ce3fd76
-     * @testdox Smallest non-degenerate case with odd diamond side length
      */
+    #[TestDox('Smallest non-degenerate case with odd diamond side length')]
     public function testSmallestNonDegenerateCaseWithOddDiamondSideLength(): void
     {
         $this->assertEquals(
@@ -54,8 +57,8 @@ class DiamondTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e0c19a95-9888-4d05-86a0-fa81b9e70d1d
-     * @testdox Smallest non-degenerate case with even diamond side length
      */
+    #[TestDox('Smallest non-degenerate case with even diamond side length')]
     public function testSmallestNonDegenerateCaseWithEvenDiamondSideLength(): void
     {
         $this->assertEquals(
@@ -74,8 +77,8 @@ class DiamondTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 82ea9aa9-4c0e-442a-b07e-40204e925944
-     * @testdox Largest possible diamond
      */
+    #[TestDox('Largest possible diamond')]
     public function testLargestPossibleDiamond(): void
     {
         $this->assertEquals(

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class DifferenceOfSquaresTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e46c542b-31fc-4506-bcae-6b62b3268537
-     * @testdox Square of sum 1
      */
+    #[TestDox('Square of sum 1')]
     public function testSquareOfSumTo1(): void
     {
         $this->assertEquals(1, squareOfSum(1));
@@ -20,8 +23,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9b3f96cb-638d-41ee-99b7-b4f9c0622948
-     * @testdox Square of sum 5
      */
+    #[TestDox('Square of sum 5')]
     public function testSquareOfSumTo5(): void
     {
         $this->assertEquals(225, squareOfSum(5));
@@ -29,8 +32,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 54ba043f-3c35-4d43-86ff-3a41625d5e86
-     * @testdox Square of sum 100
      */
+    #[TestDox('Square of sum 100')]
     public function testSquareOfSumTo100(): void
     {
         $this->assertEquals(25502500, squareOfSum(100));
@@ -38,8 +41,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 01d84507-b03e-4238-9395-dd61d03074b5
-     * @testdox Sum of squares 1
      */
+    #[TestDox('Sum of squares 1')]
     public function testSumOfSquaresTo1(): void
     {
         $this->assertEquals(1, sumOfSquares(1));
@@ -47,8 +50,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c93900cd-8cc2-4ca4-917b-dd3027023499
-     * @testdox Sum of squares 5
      */
+    #[TestDox('Sum of squares 5')]
     public function testSumOfSquaresTo5(): void
     {
         $this->assertEquals(55, sumOfSquares(5));
@@ -56,8 +59,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 94807386-73e4-4d9e-8dec-69eb135b19e4
-     * @testdox Sum of squares 100
      */
+    #[TestDox('Sum of squares 100')]
     public function testSumOfSquaresTo100(): void
     {
         $this->assertEquals(338350, sumOfSquares(100));
@@ -65,8 +68,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 44f72ae6-31a7-437f-858d-2c0837adabb6
-     * @testdox Difference of squares 1
      */
+    #[TestDox('Difference of squares 1')]
     public function testDifferenceOfSumTo1(): void
     {
         $this->assertEquals(0, difference(1));
@@ -74,8 +77,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 005cb2bf-a0c8-46f3-ae25-924029f8b00b
-     * @testdox Difference of squares 5
      */
+    #[TestDox('Difference of squares 5')]
     public function testDifferenceOfSumTo5(): void
     {
         $this->assertEquals(170, difference(5));
@@ -83,8 +86,8 @@ class DifferenceOfSquaresTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b1bf19de-9a16-41c0-a62b-1f02ecc0b036
-     * @testdox Difference of squares 100
      */
+    #[TestDox('Difference of squares 100')]
     public function testDifferenceOfSumTo100(): void
     {
         $this->assertEquals(25164150, difference(100));

--- a/exercises/practice/dnd-character/DndCharacter.php
+++ b/exercises/practice/dnd-character/DndCharacter.php
@@ -28,7 +28,7 @@ class DndCharacter
 {
     public function __construct()
     {
-        throw new BadFunctionCallException("Please implement the DndCharacter class!");
+        throw new \BadFunctionCallException("Please implement the DndCharacter class!");
     }
 
     // Add methods as expected by the tests

--- a/exercises/practice/dnd-character/DndCharacterTest.php
+++ b/exercises/practice/dnd-character/DndCharacterTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class DndCharacterTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class DndCharacterTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1e9ae1dc-35bd-43ba-aa08-e4b94c20fa37
-     * @testdox Ability modifier - ability modifier for score 3 is -4
      */
+    #[TestDox('Ability modifier - ability modifier for score 3 is -4')]
     public function testAbilityModifierFor3IsNegative4()
     {
         $this->assertEquals(-4, DndCharacter::modifier(3));
@@ -20,8 +23,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cc9bb24e-56b8-4e9e-989d-a0d1a29ebb9c
-     * @testdox Ability modifier - ability modifier for score 4 is -3
      */
+    #[TestDox('Ability modifier - ability modifier for score 4 is -3')]
     public function testAbilityModifierFor4IsNegative3()
     {
         $this->assertEquals(-3, DndCharacter::modifier(4));
@@ -29,8 +32,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5b519fcd-6946-41ee-91fe-34b4f9808326
-     * @testdox Ability modifier - ability modifier for score 5 is -3
      */
+    #[TestDox('Ability modifier - ability modifier for score 5 is -3')]
     public function testAbilityModifierFor5IsNegative3()
     {
         $this->assertEquals(-3, DndCharacter::modifier(5));
@@ -38,8 +41,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dc2913bd-6d7a-402e-b1e2-6d568b1cbe21
-     * @testdox Ability modifier - ability modifier for score 6 is -2
      */
+    #[TestDox('Ability modifier - ability modifier for score 6 is -2')]
     public function testAbilityModifierFor6IsNegative2()
     {
         $this->assertEquals(-2, DndCharacter::modifier(6));
@@ -47,8 +50,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 099440f5-0d66-4b1a-8a10-8f3a03cc499f
-     * @testdox Ability modifier - ability modifier for score 7 is -2
      */
+    #[TestDox('Ability modifier - ability modifier for score 7 is -2')]
     public function testAbilityModifierFor7IsNegative2()
     {
         $this->assertEquals(-2, DndCharacter::modifier(7));
@@ -56,8 +59,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cfda6e5c-3489-42f0-b22b-4acb47084df0
-     * @testdox Ability modifier - ability modifier for score 8 is -1
      */
+    #[TestDox('Ability modifier - ability modifier for score 8 is -1')]
     public function testAbilityModifierFor8IsNegative1()
     {
         $this->assertEquals(-1, DndCharacter::modifier(8));
@@ -65,8 +68,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c70f0507-fa7e-4228-8463-858bfbba1754
-     * @testdox Ability modifier - ability modifier for score 9 is -1
      */
+    #[TestDox('Ability modifier - ability modifier for score 9 is -1')]
     public function testAbilityModifierFor9IsNegative1()
     {
         $this->assertEquals(-1, DndCharacter::modifier(9));
@@ -74,8 +77,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6f4e6c88-1cd9-46a0-92b8-db4a99b372f7
-     * @testdox Ability modifier - ability modifier for score 10 is 0
      */
+    #[TestDox('Ability modifier - ability modifier for score 10 is 0')]
     public function testAbilityModifierFor10Is0()
     {
         $this->assertEquals(0, DndCharacter::modifier(10));
@@ -83,8 +86,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e00d9e5c-63c8-413f-879d-cd9be9697097
-     * @testdox Ability modifier - ability modifier for score 11 is 0
      */
+    #[TestDox('Ability modifier - ability modifier for score 11 is 0')]
     public function testAbilityModifierFor11Is0()
     {
         $this->assertEquals(0, DndCharacter::modifier(11));
@@ -92,8 +95,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid eea06f3c-8de0-45e7-9d9d-b8cab4179715
-     * @testdox Ability modifier - ability modifier for score 12 is +1
      */
+    #[TestDox('Ability modifier - ability modifier for score 12 is +1')]
     public function testAbilityModifierFor12Is1()
     {
         $this->assertEquals(1, DndCharacter::modifier(12));
@@ -101,8 +104,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9c51f6be-db72-4af7-92ac-b293a02c0dcd
-     * @testdox Ability modifier - ability modifier for score 13 is +1
      */
+    #[TestDox('Ability modifier - ability modifier for score 13 is +1')]
     public function testAbilityModifierFor13Is1()
     {
         $this->assertEquals(1, DndCharacter::modifier(13));
@@ -110,8 +113,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 94053a5d-53b6-4efc-b669-a8b5098f7762
-     * @testdox Ability modifier - ability modifier for score 14 is +2
      */
+    #[TestDox('Ability modifier - ability modifier for score 14 is +2')]
     public function testAbilityModifierFor14Is2()
     {
         $this->assertEquals(2, DndCharacter::modifier(14));
@@ -119,8 +122,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8c33e7ca-3f9f-4820-8ab3-65f2c9e2f0e2
-     * @testdox Ability modifier - ability modifier for score 15 is +2
      */
+    #[TestDox('Ability modifier - ability modifier for score 15 is +2')]
     public function testAbilityModifierFor15Is2()
     {
         $this->assertEquals(2, DndCharacter::modifier(15));
@@ -128,8 +131,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c3ec871e-1791-44d0-b3cc-77e5fb4cd33d
-     * @testdox Ability modifier - ability modifier for score 16 is +3
      */
+    #[TestDox('Ability modifier - ability modifier for score 16 is +3')]
     public function testAbilityModifierFor16Is3()
     {
         $this->assertEquals(3, DndCharacter::modifier(16));
@@ -137,8 +140,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3d053cee-2888-4616-b9fd-602a3b1efff4
-     * @testdox Ability modifier - ability modifier for score 17 is +3
      */
+    #[TestDox('Ability modifier - ability modifier for score 17 is +3')]
     public function testAbilityModifierFor17Is3()
     {
         $this->assertEquals(3, DndCharacter::modifier(17));
@@ -146,8 +149,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bafd997a-e852-4e56-9f65-14b60261faee
-     * @testdox Ability modifier - ability modifier for score 18 is +4
      */
+    #[TestDox('Ability modifier - ability modifier for score 18 is +4')]
     public function testAbilityModifierFor18is4()
     {
         $this->assertEquals(4, DndCharacter::modifier(18));
@@ -155,8 +158,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4f28f19c-2e47-4453-a46a-c0d365259c14
-     * @testdox Random ability is within range
      */
+    #[TestDox('Random ability is within range')]
     public function testRandomAbilityIsInRange()
     {
         for ($i = 0; $i < 10; $i++) {
@@ -167,8 +170,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 385d7e72-864f-4e88-8279-81a7d75b04ad
-     * @testdox Random character is valid
      */
+    #[TestDox('Random character is valid')]
     public function testRandomCharacterIsValid()
     {
         for ($i = 0; $i < 10; $i++) {
@@ -192,8 +195,8 @@ class DndCharacterTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dca2b2ec-f729-4551-84b9-078876bb4808
-     * @testdox Each ability is only calculated once
      */
+    #[TestDox('Each ability is only calculated once')]
     public function testEachAbilityIsCalculatedOnce()
     {
         for ($i = 0; $i < 10; $i++) {

--- a/exercises/practice/eliuds-eggs/EliudsEggsTest.php
+++ b/exercises/practice/eliuds-eggs/EliudsEggsTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class EliudsEggsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class EliudsEggsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class EliudsEggsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 559e789d-07d1-4422-9004-3b699f83bca3
-     * @testdox 0 eggs
      */
+    #[TestDox('0 eggs')]
     public function test0Eggs()
     {
         $eliudsEggs = new EliudsEggs();
@@ -21,8 +24,8 @@ class EliudsEggsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 97223282-f71e-490c-92f0-b3ec9e275aba
-     * @testdox 1 eggs
      */
+    #[TestDox('1 eggs')]
     public function test1Eggs()
     {
         $eliudsEggs = new EliudsEggs();
@@ -31,8 +34,8 @@ class EliudsEggsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1f8fd18f-26e9-4144-9a0e-57cdfc4f4ff5
-     * @testdox 4 eggs
      */
+    #[TestDox('4 eggs')]
     public function test4Eggs()
     {
         $eliudsEggs = new EliudsEggs();
@@ -41,8 +44,8 @@ class EliudsEggsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0c18be92-a498-4ef2-bcbb-28ac4b06cb81
-     * @testdox 13 eggs
      */
+    #[TestDox('13 eggs')]
     public function test13Eggs()
     {
         $eliudsEggs = new EliudsEggs();

--- a/exercises/practice/etl/EtlTest.php
+++ b/exercises/practice/etl/EtlTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class EtlTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class EtlTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class EtlTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 78a7a9f9-4490-4a47-8ee9-5a38bb47d28f
-     * @testdox single letter
      */
+    #[TestDox('single letter')]
     public function testTransformOneValue(): void
     {
         $old = ['1' => ['A']];
@@ -22,8 +25,8 @@ class EtlTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 60dbd000-451d-44c7-bdbb-97c73ac1f497
-     * @testdox single score with multiple letters
      */
+    #[TestDox('single score with multiple letters')]
     public function testTransformMoreValues(): void
     {
         $old = [1 => ['A', 'E', 'I', 'O', 'U']];
@@ -33,8 +36,8 @@ class EtlTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f5c5de0c-301f-4fdd-a0e5-df97d4214f54
-     * @testdox multiple scores with multiple letters
      */
+    #[TestDox('multiple scores with multiple letters')]
     public function testTransformMoreKeys(): void
     {
         $old = [1 => ['A', 'E'], 2 => ['D', 'G']];
@@ -44,8 +47,8 @@ class EtlTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5db8ea89-ecb4-4dcd-902f-2b418cc87b9d
-     * @testdox multiple scores with differing numbers of letters
      */
+    #[TestDox('multiple scores with differing numbers of letters')]
     public function testTransformFullDataset(): void
     {
         $old = [

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class FlattenArrayTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class FlattenArrayTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/flower-field/FlowerFieldTest.php
+++ b/exercises/practice/flower-field/FlowerFieldTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class FlowerFieldTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class FlowerFieldTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0c5ec4bd-dea7-4138-8651-1203e1cb9f44
-     * @testdox No rows
      */
+    #[TestDox('No rows')]
     public function testNoRows(): void
     {
         $garden = [];
@@ -26,8 +29,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 650ac4c0-ad6b-4b41-acde-e4ea5852c3b8
-     * @testdox No columns
      */
+    #[TestDox('No columns')]
     public function testNoColumns(): void
     {
         $garden = [""];
@@ -41,8 +44,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6fbf8f6d-a03b-42c9-9a58-b489e9235478
-     * @testdox No flowers
      */
+    #[TestDox('No flowers')]
     public function testNoFlowers(): void
     {
         $garden = [
@@ -64,8 +67,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 61aff1c4-fb31-4078-acad-cd5f1e635655
-     * @testdox Flowerfield with only flowers
      */
+    #[TestDox('Flowerfield with only flowers')]
     public function testFlowerfieldWithOnlyFlowers(): void
     {
         $garden = [
@@ -87,8 +90,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 84167147-c504-4896-85d7-246b01dea7c5
-     * @testdox Flower surrounded by spaces
      */
+    #[TestDox('Flower surrounded by spaces')]
     public function testFlowerSurroundedBySpaces(): void
     {
         $garden = [
@@ -110,8 +113,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cb878f35-43e3-4c9d-93d9-139012cccc4a
-     * @testdox Space surrounded by flowers
      */
+    #[TestDox('Space surrounded by flowers')]
     public function testSpaceSurroundedByFlowers(): void
     {
         $garden = [
@@ -133,8 +136,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7037f483-ddb4-4b35-b005-0d0f4ef4606f
-     * @testdox Horizontal line
      */
+    #[TestDox('Horizontal line')]
     public function testHorizontalLine(): void
     {
         $garden = [" * * "];
@@ -148,8 +151,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid uuid
-     * @testdox Horizontal line, flowers at edges
      */
+    #[TestDox('Horizontal line, flowers at edges')]
     public function testHorizontalLineFlowersAtEdges(): void
     {
         $garden = ["*   *"];
@@ -163,8 +166,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c5198b50-804f-47e9-ae02-c3b42f7ce3ab
-     * @testdox Vertical line
      */
+    #[TestDox('Vertical line')]
     public function testVerticalLine(): void
     {
         $garden = [
@@ -190,8 +193,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0c79a64d-703d-4660-9e90-5adfa5408939
-     * @testdox Vertical line, flowers at edges
      */
+    #[TestDox('Vertical line, flowers at edges')]
     public function testVerticalLineFlowersAtEdges(): void
     {
         $garden = [
@@ -217,8 +220,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4b098563-b7f3-401c-97c6-79dd1b708f34
-     * @testdox Cross
      */
+    #[TestDox('Cross')]
     public function testCross(): void
     {
         $garden = [
@@ -244,8 +247,8 @@ class FlowerFieldTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 04a260f1-b40a-4e89-839e-8dd8525abe0e
-     * @testdox Large garden
      */
+    #[TestDox('Large garden')]
     public function testLargeFlowerfield(): void
     {
         $garden = [

--- a/exercises/practice/food-chain/FoodChainTest.php
+++ b/exercises/practice/food-chain/FoodChainTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class FoodChainTest extends TestCase
@@ -15,8 +16,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 751dce68-9412-496e-b6e8-855998c56166
-     * @testdox fly
      */
+    #[TestDox('fly')]
     public function testFly(): void
     {
         $foodChain = new FoodChain();
@@ -29,8 +30,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 6c56f861-0c5e-4907-9a9d-b2efae389379
-     * @testdox spider
      */
+    #[TestDox('spider')]
     public function testSpider(): void
     {
         $foodChain = new FoodChain();
@@ -45,8 +46,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 3edf5f33-bef1-4e39-ae67-ca5eb79203fa
-     * @testdox bird
      */
+    #[TestDox('bird')]
     public function testBird(): void
     {
         $foodChain = new FoodChain();
@@ -62,8 +63,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: e866a758-e1ff-400e-9f35-f27f28cc288f
-     * @testdox cat
      */
+    #[TestDox('cat')]
     public function testCat(): void
     {
         $foodChain = new FoodChain();
@@ -80,8 +81,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 3f02c30e-496b-4b2a-8491-bc7e2953cafb
-     * @testdox dog
      */
+    #[TestDox('dog')]
     public function testDog(): void
     {
         $foodChain = new FoodChain();
@@ -99,8 +100,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 4b3fd221-01ea-46e0-825b-5734634fbc59
-     * @testdox goat
      */
+    #[TestDox('goat')]
     public function testGoat(): void
     {
         $foodChain = new FoodChain();
@@ -119,8 +120,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 1b707da9-7001-4fac-941f-22ad9c7a65d4
-     * @testdox cow
      */
+    #[TestDox('cow')]
     public function testCow(): void
     {
         $foodChain = new FoodChain();
@@ -140,8 +141,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 3cb10d46-ae4e-4d2c-9296-83c9ffc04cdc
-     * @testdox horse
      */
+    #[TestDox('horse')]
     public function testHorse(): void
     {
         $foodChain = new FoodChain();
@@ -154,8 +155,8 @@ class FoodChainTest extends TestCase
 
     /**
      * uuid: 22b863d5-17e4-4d1e-93e4-617329a5c050
-     * @testdox multiple verses
      */
+    #[TestDox('multiple verses')]
     public function testMultipleVerses(): void
     {
         $foodChain = new FoodChain();
@@ -178,8 +179,8 @@ class FoodChainTest extends TestCase
     }
     /**
      * uuid: e626b32b-745c-4101-bcbd-3b13456893db
-     * @testdox full song
      */
+    #[TestDox('full song')]
     public function testFullSong(): void
     {
         $foodChain = new FoodChain();

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -24,7 +24,10 @@
 
 declare(strict_types=1);
 
-class GigasecondTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class GigasecondTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -60,10 +63,10 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider inputAndExpectedDates
      * @param string $inputDate
      * @param string $expected
      */
+    #[DataProvider('inputAndExpectedDates')]
     public function testFrom(string $inputDate, string $expected): void
     {
         $date = $this->dateSetup($inputDate);
@@ -73,9 +76,9 @@ class GigasecondTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider inputDates
      * @param string $inputDate
      */
+    #[DataProvider('inputDates')]
     public function testFromReturnType(string $inputDate): void
     {
         $date = $this->dateSetup($inputDate);

--- a/exercises/practice/grade-school/GradeSchoolTest.php
+++ b/exercises/practice/grade-school/GradeSchoolTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class GradeSchoolTest extends TestCase
@@ -13,8 +14,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: a3f0fb58-f240-4723-8ddc-e644666b85cc
-     * @testdox Roster is empty when no student is added
      */
+    #[TestDox('Roster is empty when no student is added')]
     public function testRosterIsEmptyWhenNoStudentIsAdded(): void
     {
         $subject = new GradeSchool();
@@ -24,8 +25,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 9337267f-7793-4b90-9b4a-8e3978408824
-     * @testdox Add a student
      */
+    #[TestDox('Add a student')]
     public function testAddAStudent(): void
     {
         $subject = new GradeSchool();
@@ -38,8 +39,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 6d0a30e4-1b4e-472e-8e20-c41702125667
-     * @testdox Student is added to the roster
      */
+    #[TestDox('Student is added to the roster')]
     public function testStudentIsAddedToTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -52,8 +53,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 73c3ca75-0c16-40d7-82f5-ed8fe17a8e4a
-     * @testdox Adding multiple students in the same grade in the roster
      */
+    #[TestDox('Adding multiple students in the same grade in the roster')]
     public function testAddMultipleStudentsInSameGrade(): void
     {
         $subject = new GradeSchool();
@@ -68,8 +69,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 233be705-dd58-4968-889d-fb3c7954c9cc
-     * @testdox Multiple students in the same grade are added to the roster
      */
+    #[TestDox('Multiple students in the same grade are added to the roster')]
     public function testMultipleStudentsInSameGradeAreAddedToTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -88,8 +89,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 87c871c1-6bde-4413-9c44-73d59a259d83
-     * @testdox Cannot add student to same grade in the roster more than once
      */
+    #[TestDox('Cannot add student to same grade in the roster more than once')]
     public function testCannotAddStudentToSameGradeMoreThanOnce(): void
     {
         $subject = new GradeSchool();
@@ -105,8 +106,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: d7982c4f-1602-49f6-a651-620f2614243a
-     * @testdox Student not added to same grade in the roster more than once
      */
+    #[TestDox('Student not added to same grade in the roster more than once')]
     public function testStudentNotAddedToSameGradeInTheRosterMoreThanOnce(): void
     {
         $subject = new GradeSchool();
@@ -126,8 +127,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: e70d5d8f-43a9-41fd-94a4-1ea0fa338056
-     * @testdox Adding students in multiple grades
      */
+    #[TestDox('Adding students in multiple grades')]
     public function testAddingStudentsInMultipleGrades(): void
     {
         $subject = new GradeSchool();
@@ -141,8 +142,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 75a51579-d1d7-407c-a2f8-2166e984e8ab
-     * @testdox Students in multiple grades are added to the roster
      */
+    #[TestDox('Students in multiple grades are added to the roster')]
     public function testStudentsInMultipleGradesAreAddedToTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -159,8 +160,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 7df542f1-57ce-433c-b249-ff77028ec479
-     * @testdox Cannot add same student to multiple grades in the roster
      */
+    #[TestDox('Cannot add same student to multiple grades in the roster')]
     public function testCannotAddSameStudentToMultipleGrades(): void
     {
         $subject = new GradeSchool();
@@ -176,8 +177,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5
-     * @testdox Student not added to multiple grades in the roster
      */
+    #[TestDox('Student not added to multiple grades in the roster')]
     public function testStudentNotAddedToMultipleGradesInTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -197,8 +198,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: d9af4f19-1ba1-48e7-94d0-dabda4e5aba6
-     * @testdox Students are sorted by grades in the roster
      */
+    #[TestDox('Students are sorted by grades in the roster')]
     public function testStudentsAreSortedByGradesInTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -217,8 +218,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: d9fb5bea-f5aa-4524-9d61-c158d8906807
-     * @testdox Students are sorted by name in the roster
      */
+    #[TestDox('Students are sorted by name in the roster')]
     public function testStudentsAreSortedByNameInTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -237,8 +238,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 180a8ff9-5b94-43fc-9db1-d46b4a8c93b6
-     * @testdox Students are sorted by grades and then by name in the roster
      */
+    #[TestDox('Students are sorted by grades and then by name in the roster')]
     public function testStudentsAreSortedByGradeThenByNameInTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -265,8 +266,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 5e67aa3c-a3c6-4407-a183-d8fe59cd1630
-     * @testdox Grade is empty if no students in the roster
      */
+    #[TestDox('Grade is empty if no students in the roster')]
     public function testGradeIsEmptyWhenNoStudentsInTheRoster(): void
     {
         $subject = new GradeSchool();
@@ -276,8 +277,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 1e0cf06b-26e0-4526-af2d-a2e2df6a51d6
-     * @testdox Grade is empty if no students in that grade
      */
+    #[TestDox('Grade is empty if no students in that grade')]
     public function testGradeIsEmptyWhenNoStudentsInThatGrade(): void
     {
         $subject = new GradeSchool();
@@ -292,8 +293,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 2bfc697c-adf2-4b65-8d0f-c46e085f796e
-     * @testdox Student not added to same grade more than once
      */
+    #[TestDox('Student not added to same grade more than once')]
     public function testStudentNotAddedToSameGradeMoreThanOnce(): void
     {
         $subject = new GradeSchool();
@@ -313,8 +314,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 66c8e141-68ab-4a04-a15a-c28bc07fe6b9
-     * @testdox Student not added to multiple grades
      */
+    #[TestDox('Student not added to multiple grades')]
     public function testStudentNotAddedToMultipleGrades(): void
     {
         $subject = new GradeSchool();
@@ -333,8 +334,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: c9c1fc2f-42e0-4d2c-b361-99271f03eda7
-     * @testdox Student not added to other grade for multiple grades
      */
+    #[TestDox('Student not added to other grade for multiple grades')]
     public function testStudentNotAddedToOtherGradeForMultipleGrades(): void
     {
         $subject = new GradeSchool();
@@ -352,8 +353,8 @@ class GradeSchoolTest extends TestCase
 
     /**
      * uuid: 1bfbcef1-e4a3-49e8-8d22-f6f9f386187e
-     * @testdox Students are sorted by name in a grade
      */
+    #[TestDox('Students are sorted by name in a grade')]
     public function testStudentsAreSortedByNameInAGrade(): void
     {
         $subject = new GradeSchool();

--- a/exercises/practice/grains/GrainsTest.php
+++ b/exercises/practice/grains/GrainsTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class GrainsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class GrainsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/hamming/HammingTest.php
+++ b/exercises/practice/hamming/HammingTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class HammingTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class HammingTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f6dcb64f-03b0-4b60-81b1-3c9dbf47e887
-     * @testdox Empty strands
      */
+    #[TestDox('Empty strands')]
     public function testEmptyStrands(): void
     {
         $this->assertEquals(0, distance('', ''));
@@ -20,8 +23,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 54681314-eee2-439a-9db0-b0636c656156
-     * @testdox Single letter identical strands
      */
+    #[TestDox('Single letter identical strands')]
     public function testSingleLetterIdenticalStrands(): void
     {
         $this->assertEquals(0, distance('A', 'A'));
@@ -29,8 +32,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 294479a3-a4c8-478f-8d63-6209815a827b
-     * @testdox Single letter different strands
      */
+    #[TestDox('Single letter different strands')]
     public function testSingleLetterDifferentStrands(): void
     {
         $this->assertEquals(1, distance('G', 'T'));
@@ -38,8 +41,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9aed5f34-5693-4344-9b31-40c692fb5592
-     * @testdox Long identical strands
      */
+    #[TestDox('Long identical strands')]
     public function testLongIdenticalStrands(): void
     {
         $this->assertEquals(0, distance(
@@ -50,8 +53,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: cd2273a5-c576-46c8-a52b-dee251c3e6e5
-     * @testdox Long different strands
      */
+    #[TestDox('Long different strands')]
     public function testLongDifferentStrand(): void
     {
         $this->assertEquals(9, distance(
@@ -62,8 +65,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b9228bb1-465f-4141-b40f-1f99812de5a8
-     * @testdox Disallow first strand longer
      */
+    #[TestDox('Disallow first strand longer')]
     public function testDisallowFirstStrandLonger(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -73,8 +76,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: dab38838-26bb-4fff-acbe-3b0a9bfeba2d
-     * @testdox: Disallow second strand longer
      */
+    #[TestDox(': Disallow second strand longer')]
     public function testDisallowSecondStrandLonger(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -84,8 +87,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b764d47c-83ff-4de2-ab10-6cfe4b15c0f3
-     * @testdox: Disallow empty first strand
      */
+    #[TestDox(': Disallow empty first strand')]
     public function testDisallowEmptyFirstStrand(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -95,8 +98,8 @@ class HammingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9ab9262f-3521-4191-81f5-0ed184a5aa89
-     * @testdox: Disallow empty second strand
      */
+    #[TestDox(': Disallow empty second strand')]
     public function testDisallowEmptySecondStrand(): void
     {
         $this->expectException('InvalidArgumentException');

--- a/exercises/practice/hello-world/HelloWorldTest.php
+++ b/exercises/practice/hello-world/HelloWorldTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class HelloWorldTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class HelloWorldTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/high-scores/HighScoresTest.php
+++ b/exercises/practice/high-scores/HighScoresTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class HighScoresTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class HighScoresTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/house/HouseTest.php
+++ b/exercises/practice/house/HouseTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class HouseTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class HouseTest extends TestCase
 {
     private House $house;
 

--- a/exercises/practice/isbn-verifier/IsbnVerifierTest.php
+++ b/exercises/practice/isbn-verifier/IsbnVerifierTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class IsbnVerifierTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class IsbnVerifierTest extends TestCase
 {
     private IsbnVerifier $isbnVerifier;
 

--- a/exercises/practice/isogram/IsogramTest.php
+++ b/exercises/practice/isogram/IsogramTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class IsogramTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class IsogramTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a0e97d2d-669e-47c7-8134-518a1e2c4555
-     * @testdox empty string
      */
+    #[TestDox('empty string')]
     public function testEmptyString(): void
     {
         $this->assertTrue(isIsogram(''));
@@ -20,8 +23,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9a001b50-f194-4143-bc29-2af5ec1ef652
-     * @testdox isogram with only lower case characters
      */
+    #[TestDox('isogram with only lower case characters')]
     public function testIsogramWithOnlyLowercaseCharacters(): void
     {
         $this->assertTrue(isIsogram('isogram'));
@@ -29,8 +32,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8ddb0ca3-276e-4f8b-89da-d95d5bae78a4
-     * @testdox word with one duplicated character
      */
+    #[TestDox('word with one duplicated character')]
     public function testWordWithOneDuplicatedCharacter(): void
     {
         $this->assertFalse(isIsogram('eleven'));
@@ -38,8 +41,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6450b333-cbc2-4b24-a723-0b459b34fe18
-     * @testdox word with one duplicated character from the end of the alphabet
      */
+    #[TestDox('word with one duplicated character from the end of the alphabet')]
     public function testWordWithOneDuplicatedCharacterFromTheEndOfTheAlphabet(): void
     {
         $this->assertFalse(isIsogram('zzyzx'));
@@ -47,8 +50,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a15ff557-dd04-4764-99e7-02cc1a385863
-     * @testdox longest reported english isogram
      */
+    #[TestDox('longest reported english isogram')]
     public function testLongestReportedEnglishIsogram(): void
     {
         $this->assertTrue(isIsogram('subdermatoglyphic'));
@@ -56,8 +59,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f1a7f6c7-a42f-4915-91d7-35b2ea11c92e
-     * @testdox word with duplicated character in mixed case
      */
+    #[TestDox('word with duplicated character in mixed case')]
     public function testWordWithDuplicatedCharacterInMixedCase(): void
     {
         $this->assertFalse(isIsogram('Alphabet'));
@@ -65,8 +68,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 14a4f3c1-3b47-4695-b645-53d328298942
-     * @testdox word with duplicated character in mixed case, lowercase first
      */
+    #[TestDox('word with duplicated character in mixed case, lowercase first')]
     public function testWordWithDuplicatedCharacterInMixedCaseLowercaseFirst(): void
     {
         $this->assertFalse(isIsogram('alphAbet'));
@@ -74,8 +77,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 423b850c-7090-4a8a-b057-97f1cadd7c42
-     * @testdox hypothetical isogrammic word with hyphen
      */
+    #[TestDox('hypothetical isogrammic word with hyphen')]
     public function testHypotheticalIsogrammicWordWithHyphen(): void
     {
         $this->assertTrue(isIsogram('thumbscrew-japingly'));
@@ -83,8 +86,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2
-     * @testdox hypothetical word with duplicated character following hyphen
      */
+    #[TestDox('hypothetical word with duplicated character following hyphen')]
     public function testHypotheticalWordWithDuplicatedCharacterFollowingHyphen(): void
     {
         $this->assertFalse(isIsogram('thumbscrew-jappingly'));
@@ -92,8 +95,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 36b30e5c-173f-49c6-a515-93a3e825553f
-     * @testdox isogram with duplicated hyphen
      */
+    #[TestDox('isogram with duplicated hyphen')]
     public function testIsogramWithDuplicatedHyphen(): void
     {
         $this->assertTrue(isIsogram('six-year-old'));
@@ -101,8 +104,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cdabafa0-c9f4-4c1f-b142-689c6ee17d93
-     * @testdox made-up name that is an isogram
      */
+    #[TestDox('made-up name that is an isogram')]
     public function testMadeupNameThatIsAnIsogram(): void
     {
         $this->assertTrue(isIsogram('Emily Jung Schwartzkopf'));
@@ -110,8 +113,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5fc61048-d74e-48fd-bc34-abfc21552d4d
-     * @testdox duplicated character in the middle
      */
+    #[TestDox('duplicated character in the middle')]
     public function testDuplicatedCharacterInTheMiddle(): void
     {
         $this->assertFalse(isIsogram('accentor'));
@@ -119,8 +122,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 310ac53d-8932-47bc-bbb4-b2b94f25a83e
-     * @testdox same first and last characters
      */
+    #[TestDox('same first and last characters')]
     public function testSameFirstAndLastCharacters(): void
     {
         $this->assertFalse(isIsogram('angola'));
@@ -128,10 +131,8 @@ class IsogramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0d0b8644-0a1e-4a31-a432-2b3ee270d847
-     * @testdox word with duplicated character and with two hyphens
-     *
-     * This test aims to catch buggy implementations that check for duplicate spaces or hyphens.
      */
+    #[TestDox('word with duplicated character and with two hyphens')]
     public function testWordWithDuplicatedCharacterAndWithTwoHyphens(): void
     {
         $this->assertFalse(isIsogram('up-to-date'));

--- a/exercises/practice/killer-sudoku-helper/KillerSudokuHelperTest.php
+++ b/exercises/practice/killer-sudoku-helper/KillerSudokuHelperTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class KillerSudokuHelperTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class KillerSudokuHelperTest extends TestCase
 {
     private KillerSudokuHelper $killerSudokuHelper;
 

--- a/exercises/practice/kindergarten-garden/KindergartenGardenTest.php
+++ b/exercises/practice/kindergarten-garden/KindergartenGardenTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class KindergartenGardenTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class KindergartenGardenTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1fc316ed-17ab-4fba-88ef-3ae78296b692
-     * @testdox partial garden -> garden with single student
      */
+    #[TestDox('partial garden -> garden with single student')]
     public function testGardenSingleStudent(): void
     {
         $garden = new KindergartenGarden("RC\nGG");
@@ -21,8 +24,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: acd19dc1-2200-4317-bc2a-08f021276b40
-     * @testdox partial garden -> different garden with single student
      */
+    #[TestDox('partial garden -> different garden with single student')]
     public function testDifferentGardenSingleStudent(): void
     {
         $garden = new KindergartenGarden("VC\nRC");
@@ -31,8 +34,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c376fcc8-349c-446c-94b0-903947315757
-     * @testdox partial garden -> garden with two students
      */
+    #[TestDox('partial garden -> garden with two students')]
     public function testGardenWithTwoStudents(): void
     {
         $garden = new KindergartenGarden("VVCG\nVVRC");
@@ -41,8 +44,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2d620f45-9617-4924-9d27-751c80d17db9
-     * @testdox partial garden -> multiple students for the same garden with three students -> second student's garden
      */
+    #[TestDox("partial garden -> multiple students for the same garden with three students -> second student's garden")]
     public function testSecondStudentsGarden(): void
     {
         $garden = new KindergartenGarden("VVCCGG\nVVCCGG");
@@ -51,8 +54,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 57712331-4896-4364-89f8-576421d69c44
-     * @testdox partial garden -> multiple students for the same garden with three students -> third student's garden
      */
+    #[TestDox("partial garden -> multiple students for the same garden with three students -> third student's garden")]
     public function testThirdStudentsGarden(): void
     {
         $garden = new KindergartenGarden("VVCCGG\nVVCCGG");
@@ -61,8 +64,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 149b4290-58e1-40f2-8ae4-8b87c46e765b
-     * @testdox full garden -> for Alice, first student's garden
      */
+    #[TestDox("full garden -> for Alice, first student's garden")]
     public function testFullGardenForAlice(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -71,8 +74,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ba25dbbc-10bd-4a37-b18e-f89ecd098a5e
-     * @testdox full garden -> for Bob, second student's garden
      */
+    #[TestDox("full garden -> for Bob, second student's garden")]
     public function testFullGardenForBob(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -81,8 +84,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 566b621b-f18e-4c5f-873e-be30544b838c
-     * @testdox full garden -> for Charlie
      */
+    #[TestDox('full garden -> for Charlie')]
     public function testFullGardenForCharlie(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -91,8 +94,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3ad3df57-dd98-46fc-9269-1877abf612aa
-     * @testdox full garden -> for David
      */
+    #[TestDox('full garden -> for David')]
     public function testFullGardenForDavid(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -101,8 +104,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0f0a55d1-9710-46ed-a0eb-399ba8c72db2
-     * @testdox full garden -> for Eve
      */
+    #[TestDox('full garden -> for Eve')]
     public function testFullGardenForEve(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -111,8 +114,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a7e80c90-b140-4ea1-aee3-f4625365c9a4
-     * @testdox full garden -> for Fred
      */
+    #[TestDox('full garden -> for Fred')]
     public function testFullGardenForFred(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -121,8 +124,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9d94b273-2933-471b-86e8-dba68694c615
-     * @testdox full garden -> for Ginny
      */
+    #[TestDox('full garden -> for Ginny')]
     public function testFullGardenForGinny(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -131,8 +134,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f55bc6c2-ade8-4844-87c4-87196f1b7258
-     * @testdox full garden -> for Harriet
      */
+    #[TestDox('full garden -> for Harriet')]
     public function testFullGardenForHarriet(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -141,8 +144,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 759070a3-1bb1-4dd4-be2c-7cce1d7679ae
-     * @testdox full garden -> for Ileana
      */
+    #[TestDox('full garden -> for Ileana')]
     public function testFullGardenForIleana(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -151,8 +154,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 78578123-2755-4d4a-9c7d-e985b8dda1c6
-     * @testdox full garden -> for Joseph
      */
+    #[TestDox('full garden -> for Joseph')]
     public function testFullGardenForJoseph(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -161,8 +164,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6bb66df7-f433-41ab-aec2-3ead6e99f65b
-     * @testdox full garden -> for Kincaid, second to last student's garden
      */
+    #[TestDox("full garden -> for Kincaid, second to last student's garden")]
     public function testFullGardenForKincaid(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");
@@ -171,8 +174,8 @@ class KindergartenGardenTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d7edec11-6488-418a-94e6-ed509e0fa7eb
-     * @testdox full garden -> for Larry, last student's garden
      */
+    #[TestDox("full garden -> for Larry, last student's garden")]
     public function testFullGardenForLarry(): void
     {
         $garden = new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV");

--- a/exercises/practice/knapsack/KnapsackTest.php
+++ b/exercises/practice/knapsack/KnapsackTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class KnapsackTest extends TestCase
@@ -20,8 +21,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: 3993a824-c20e-493d-b3c9-ee8a7753ee59
-     * @testdox No Items
      */
+    #[TestDox('No Items')]
     public function testNoItems(): void
     {
         $expected = 0;
@@ -36,8 +37,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: 1d39e98c-6249-4a8b-912f-87cb12e506b0
-     * @testdox One item, too heavy
      */
+    #[TestDox('One item, too heavy')]
     public function testOneItemTooHeavy(): void
     {
         $expected = 0;
@@ -52,8 +53,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: 833ea310-6323-44f2-9d27-a278740ffbd8
-     * @testdox Five items (cannot be greedy by weight)
      */
+    #[TestDox('Five items (cannot be greedy by weight)')]
     public function testFiveItemsCannotBeGreedyByWeight(): void
     {
         $expected = 21;
@@ -74,8 +75,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: 277cdc52-f835-4c7d-872b-bff17bab2456
-     * @testdox Five items (cannot be greedy by value)
      */
+    #[TestDox('Five items (cannot be greedy by value)')]
     public function testFiveItemsCannotBeGreedyByValue(): void
     {
         $expected = 80;
@@ -96,8 +97,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: 81d8e679-442b-4f7a-8a59-7278083916c9
-     * @testdox Example knapsack
      */
+    #[TestDox('Example knapsack')]
     public function testExampleKnapsack(): void
     {
         $expected = 90;
@@ -117,8 +118,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: f23a2449-d67c-4c26-bf3e-cde020f27ecc
-     * @testdox 8 items
      */
+    #[TestDox('8 items')]
     public function testEightItems(): void
     {
         $expected = 900;
@@ -142,8 +143,8 @@ class KnapsackTest extends TestCase
 
     /**
      * uuid: 7c682ae9-c385-4241-a197-d2fa02c81a11
-     * @testdox 15 items
      */
+    #[TestDox('15 items')]
     public function testFifteenItems(): void
     {
         $expected = 1458;

--- a/exercises/practice/largest-series-product/LargestSeriesProductTest.php
+++ b/exercises/practice/largest-series-product/LargestSeriesProductTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class LargestSeriesProductTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -13,11 +16,10 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
      * Since PHP can only support Integers between +/- 9223372036854775807
      * We will deal with the series of digits as strings to avoid having them cast to floats.
      */
-
     /**
      * uuid: 7c82f8b7-e347-48ee-8a22-f672323324d4
-     * @testdox finds the largest product if span equals length
      */
+    #[TestDox('finds the largest product if span equals length')]
     public function testFindsTheLargestProductIfSpanEqualsLength(): void
     {
         $series = new Series("29");
@@ -26,8 +28,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 88523f65-21ba-4458-a76a-b4aaf6e4cb5e
-     * @testdox can find the largest product of 2 with numbers in order
      */
+    #[TestDox('can find the largest product of 2 with numbers in order')]
     public function testCanFindTheLargestProductOf2WithNumbersInOrder(): void
     {
         // The number starts with a 0, qualifying it to be an octal
@@ -38,8 +40,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f1376b48-1157-419d-92c2-1d7e36a70b8a
-     * @testdox can find the largest product of 2
      */
+    #[TestDox('can find the largest product of 2')]
     public function testCanFindTheLargestProductOf2(): void
     {
         $series = new Series("576802143");
@@ -48,8 +50,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 46356a67-7e02-489e-8fea-321c2fa7b4a4
-     * @testdox can find the largest product of 3 with numbers in order
      */
+    #[TestDox('can find the largest product of 3 with numbers in order')]
     public function testCanFindTheLargestProductOf3WithNumbersInOrder(): void
     {
         $series = new Series("0123456789");
@@ -58,8 +60,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a2dcb54b-2b8f-4993-92dd-5ce56dece64a
-     * @testdox can find the largest product of 3
      */
+    #[TestDox('can find the largest product of 3')]
     public function testCanFindTheLargestProductOf3(): void
     {
         $series = new Series("1027839564");
@@ -68,8 +70,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 673210a3-33cd-4708-940b-c482d7a88f9d
-     * @testdox can find the largest product of 5 with numbers in order
      */
+    #[TestDox('can find the largest product of 5 with numbers in order')]
     public function testCanFindTheLargestProductOf5WithNumbersInOrder(): void
     {
         $series = new Series("0123456789");
@@ -78,8 +80,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 02acd5a6-3bbf-46df-8282-8b313a80a7c9
-     * @testdox can get the largest product of a big number
      */
+    #[TestDox('can get the largest product of a big number')]
     public function testCanGetTheLargestProductOfABigNumber(): void
     {
         $series = new Series("73167176531330624919225119674426574742355349194934");
@@ -88,8 +90,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 76dcc407-21e9-424c-a98e-609f269622b5
-     * @testdox reports zero if the only digits are zero
      */
+    #[TestDox('reports zero if the only digits are zero')]
     public function testReportsZeroIfTheOnlyDigitsAreZero(): void
     {
         $series = new Series("0000");
@@ -98,8 +100,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6ef0df9f-52d4-4a5d-b210-f6fae5f20e19
-     * @testdox reports zero if all spans include zero
      */
+    #[TestDox('reports zero if all spans include zero')]
     public function testReportsZeroIfAllSpansIncludeZero(): void
     {
         $series = new Series("99099");
@@ -108,8 +110,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0ae1ce53-d9ba-41bb-827f-2fceb64f058b
-     * @testdox rejects span longer than string length
      */
+    #[TestDox('rejects span longer than string length')]
     public function testRejectsSpanLongerThanStringLength(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -120,8 +122,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 06bc8b90-0c51-4c54-ac22-3ec3893a079e
-     * @testdox reports 1 for empty string and empty product (0 span)
      */
+    #[TestDox('reports 1 for empty string and empty product (0 span)')]
     public function testReportsOneForEmptyStringAndEmptyProductSpanZero(): void
     {
         $series = new Series("");
@@ -130,8 +132,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3ec0d92e-f2e2-4090-a380-70afee02f4c0
-     * @testdox reports 1 for nonempty string and empty product (0 span)
      */
+    #[TestDox('reports 1 for nonempty string and empty product (0 span)')]
     public function testReportsOneForNonemptyStringAndEmptyProductSpanZero(): void
     {
         $series = new Series("123");
@@ -140,8 +142,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6cf66098-a6af-4223-aab1-26aeeefc7402
-     * @testdox rejects empty string and nonzero span
      */
+    #[TestDox('rejects empty string and nonzero span')]
     public function testRejectsEmptyStringAndNonzeroSpan(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -152,8 +154,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74
-     * @testdox rejects invalid character in digits
      */
+    #[TestDox('rejects invalid character in digits')]
     public function testRejectsInvalidCharacterInDigits(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -164,8 +166,8 @@ class LargestSeriesProductTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c859f34a-9bfe-4897-9c2f-6d7f8598e7f0
-     * @testdox rejects negative span
      */
+    #[TestDox('rejects negative span')]
     public function testRejectsNegativeSpan(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/practice/leap/LeapTest.php
+++ b/exercises/practice/leap/LeapTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class LeapTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class LeapTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6466b30d-519c-438e-935d-388224ab5223
-     * @testdox Year not divisible by 4 in common year
      */
+    #[TestDox('Year not divisible by 4 in common year')]
     public function testCommonYearNotDivisibleBy4(): void
     {
         $this->assertFalse(isLeap(2015));
@@ -20,8 +23,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ac227e82-ee82-4a09-9eb6-4f84331ffdb0
-     * @testdox Year divisible by 2, not divisible by 4 in common year
      */
+    #[TestDox('Year divisible by 2, not divisible by 4 in common year')]
     public function testCommonYearDivisibleBy2Not4(): void
     {
         $this->assertFalse(isLeap(1970));
@@ -29,8 +32,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4fe9b84c-8e65-489e-970b-856d60b8b78e
-     * @testdox Year divisible by 4, not divisible by 100 in leap year
      */
+    #[TestDox('Year divisible by 4, not divisible by 100 in leap year')]
     public function testLeapYearDivisibleBy4Not100(): void
     {
         $this->assertTrue(isLeap(1996));
@@ -38,8 +41,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7fc6aed7-e63c-48f5-ae05-5fe182f60a5d
-     * @testdox Year divisible by 4 and 5 is still a leap year
      */
+    #[TestDox('Year divisible by 4 and 5 is still a leap year')]
     public function testLeapYearDivisibleBy4And5(): void
     {
         $this->assertTrue(isLeap(1960));
@@ -47,8 +50,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 78a7848f-9667-4192-ae53-87b30c9a02dd
-     * @testdox Year divisible by 100, not divisible by 400 in common year
      */
+    #[TestDox('Year divisible by 100, not divisible by 400 in common year')]
     public function testCommonYearDivisibleBy100Not400(): void
     {
         $this->assertFalse(isLeap(2100));
@@ -56,8 +59,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9d70f938-537c-40a6-ba19-f50739ce8bac
-     * @testdox Year divisible by 100 but not by 3 is still not a leap year
      */
+    #[TestDox('Year divisible by 100 but not by 3 is still not a leap year')]
     public function testCommonYearDivisibleBy100Not3(): void
     {
         $this->assertFalse(isLeap(1900));
@@ -65,8 +68,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 42ee56ad-d3e6-48f1-8e3f-c84078d916fc
-     * @testdox Year divisible by 400 is leap year
      */
+    #[TestDox('Year divisible by 400 is leap year')]
     public function testLeapYearDivisibleBy400(): void
     {
         $this->assertTrue(isLeap(2000));
@@ -74,8 +77,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 57902c77-6fe9-40de-8302-587b5c27121e
-     * @testdox Year divisible by 400 but not by 125 is still a leap year
      */
+    #[TestDox('Year divisible by 400 but not by 125 is still a leap year')]
     public function testLeapYearDivisibleBy400Not125(): void
     {
         $this->assertTrue(isLeap(2400));
@@ -83,8 +86,8 @@ class LeapTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c30331f6-f9f6-4881-ad38-8ca8c12520c1
-     * @testdox Year divisible by 200, not divisible by 400 in common year
      */
+    #[TestDox('Year divisible by 200, not divisible by 400 in common year')]
     public function testCommonYearDivisibleBy200Not400(): void
     {
         $this->assertFalse(isLeap(1800));

--- a/exercises/practice/linked-list/LinkedList.php
+++ b/exercises/practice/linked-list/LinkedList.php
@@ -28,6 +28,6 @@ class LinkedList
 {
     public function __construct()
     {
-        throw new BadFunctionCallException("Please implement the LinkedList class!");
+        throw new \BadFunctionCallException("Please implement the LinkedList class!");
     }
 }

--- a/exercises/practice/linked-list/LinkedListTest.php
+++ b/exercises/practice/linked-list/LinkedListTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class LinkedListTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class LinkedListTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/list-ops/ListOpsTest.php
+++ b/exercises/practice/list-ops/ListOpsTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
 
-class ListOpsTest extends PHPUnit\Framework\TestCase
+class ListOpsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -13,8 +14,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 485b9452-bf94-40f7-a3db-c3cf4850066a
-     * @testdox append entries to a list and return the new list -> empty lists
      */
+    #[TestDox('append entries to a list and return the new list -> empty lists')]
     public function testAppendEmptyLists()
     {
         $listOps = new ListOps();
@@ -23,8 +24,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2c894696-b609-4569-b149-8672134d340a
-     * @testdox append entries to a list and return the new list -> list to empty list
      */
+    #[TestDox('append entries to a list and return the new list -> list to empty list')]
     public function testAppendNonEmptyListToEmptyList()
     {
         $listOps = new ListOps();
@@ -33,8 +34,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e842efed-3bf6-4295-b371-4d67a4fdf19c
-     * @testdox append entries to a list and return the new list -> empty list to list
      */
+    #[TestDox('append entries to a list and return the new list -> empty list to list')]
     public function testAppendEmptyListToNonEmptyList()
     {
         $listOps = new ListOps();
@@ -43,8 +44,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 71dcf5eb-73ae-4a0e-b744-a52ee387922f
-     * @testdox append entries to a list and return the new list -> non-empty lists
      */
+    #[TestDox('append entries to a list and return the new list -> non-empty lists')]
     public function testAppendNonEmptyLists()
     {
         $listOps = new ListOps();
@@ -53,8 +54,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 28444355-201b-4af2-a2f6-5550227bde21
-     * @testdox concatenate a list of lists -> empty list
      */
+    #[TestDox('concatenate a list of lists -> empty list')]
     public function testConcatEmptyLists()
     {
         $listOps = new ListOps();
@@ -63,8 +64,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 331451c1-9573-42a1-9869-2d06e3b389a9
-     * @testdox concatenate a list of lists -> list of lists
      */
+    #[TestDox('concatenate a list of lists -> list of lists')]
     public function testConcatLists()
     {
         $listOps = new ListOps();
@@ -73,8 +74,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d6ecd72c-197f-40c3-89a4-aa1f45827e09
-     * @testdox concatenate a list of lists -> list of nested lists
      */
+    #[TestDox('concatenate a list of lists -> list of nested lists')]
     public function testConcatNestedLists()
     {
         $listOps = new ListOps();
@@ -83,8 +84,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0524fba8-3e0f-4531-ad2b-f7a43da86a16
-     * @testdox filter list returning only values that satisfy the filter function -> empty list
      */
+    #[TestDox('filter list returning only values that satisfy the filter function -> empty list')]
     public function testFilterEmptyList()
     {
         $listOps = new ListOps();
@@ -96,8 +97,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 88494bd5-f520-4edb-8631-88e415b62d24
-     * @testdox filter list returning only values that satisfy the filter function -> non empty list
      */
+    #[TestDox('filter list returning only values that satisfy the filter function -> non empty list')]
     public function testFilterNonEmptyList()
     {
         $listOps = new ListOps();
@@ -109,8 +110,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad
-     * @testdox returns the length of a list -> empty list
      */
+    #[TestDox('returns the length of a list -> empty list')]
     public function testLengthEmptyList()
     {
         $listOps = new ListOps();
@@ -119,8 +120,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e
-     * @testdox returns the length of a list -> non-empty list
      */
+    #[TestDox('returns the length of a list -> non-empty list')]
     public function testLengthNonEmptyList()
     {
         $listOps = new ListOps();
@@ -129,8 +130,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c0bc8962-30e2-4bec-9ae4-668b8ecd75aa
-     * @testdox returns a list of elements whose values equal the list value transformed by the mapping function -> empty list
      */
+    #[TestDox('returns a list of elements whose values equal the list value transformed by the mapping function -> empty list')]
     public function testMapEmptyList()
     {
         $listOps = new ListOps();
@@ -142,8 +143,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 11e71a95-e78b-4909-b8e4-60cdcaec0e91
-     * @testdox returns a list of elements whose values equal the list value transformed by the mapping function -> non-empty list
      */
+    #[TestDox('returns a list of elements whose values equal the list value transformed by the mapping function -> non-empty list')]
     public function testMapNonEmptyList()
     {
         $listOps = new ListOps();
@@ -155,8 +156,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 36549237-f765-4a4c-bfd9-5d3a8f7b07d2
-     * @testdox folds (reduces) the given list from the left with a function -> empty list
      */
+    #[TestDox('folds (reduces) the given list from the left with a function -> empty list')]
     public function testFoldlEmptyList()
     {
         $listOps = new ListOps();
@@ -168,8 +169,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7a626a3c-03ec-42bc-9840-53f280e13067
-     * @testdox folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list
      */
+    #[TestDox('folds (reduces) the given list from the left with a function -> direction independent function applied to non-empty list')]
     public function testFoldlDirectionIndependentNonEmptyList()
     {
         $listOps = new ListOps();
@@ -181,8 +182,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d7fcad99-e88e-40e1-a539-4c519681f390
-     * @testdox folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list
      */
+    #[TestDox('folds (reduces) the given list from the left with a function -> direction dependent function applied to non-empty list')]
     public function testFoldlDirectionDependentNonEmptyList()
     {
         $listOps = new ListOps();
@@ -194,8 +195,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid aeb576b9-118e-4a57-a451-db49fac20fdc
-     * @testdox folds (reduces) the given list from the right with a function -> empty list
      */
+    #[TestDox('folds (reduces) the given list from the right with a function -> empty list')]
     public function testFoldrEmptyList()
     {
         $listOps = new ListOps();
@@ -207,8 +208,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd
-     * @testdox folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list
      */
+    #[TestDox('folds (reduces) the given list from the right with a function -> direction independent function applied to non-empty list')]
     public function testFoldrDirectionIndependentNonEmptyList()
     {
         $listOps = new ListOps();
@@ -220,8 +221,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8066003b-f2ff-437e-9103-66e6df474844
-     * @testdox folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list
      */
+    #[TestDox('folds (reduces) the given list from the right with a function -> direction dependent function applied to non-empty list')]
     public function testFoldrDirectionDependentNonEmptyList()
     {
         $listOps = new ListOps();
@@ -233,8 +234,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 94231515-050e-4841-943d-d4488ab4ee30
-     * @testdox reverse the elements of a list -> empty list
      */
+    #[TestDox('reverse the elements of a list -> empty list')]
     public function testReverseEmptyList()
     {
         $listOps = new ListOps();
@@ -243,8 +244,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fcc03d1e-42e0-4712-b689-d54ad761f360
-     * @testdox reverse the elements of a list -> non-empty list
      */
+    #[TestDox('reverse the elements of a list -> non-empty list')]
     public function testReverseNonEmptyList()
     {
         $listOps = new ListOps();
@@ -253,8 +254,8 @@ class ListOpsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 40872990-b5b8-4cb8-9085-d91fc0d05d26
-     * @testdox reverse the elements of a list -> list of lists is not flattened
      */
+    #[TestDox('reverse the elements of a list -> list of lists is not flattened')]
     public function testReverseNonEmptyListIsNotFlattened()
     {
         $listOps = new ListOps();

--- a/exercises/practice/luhn/LuhnTest.php
+++ b/exercises/practice/luhn/LuhnTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class LuhnTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class LuhnTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 792a7082-feb7-48c7-b88b-bbfec160865e
-     * @testdox Single digit strings can not be valid
      */
+    #[TestDox('Single digit strings can not be valid')]
     public function testSingleDigitStringsCanNotBeValid(): void
     {
         $this->assertFalse(isValid("1"));
@@ -20,8 +23,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 698a7924-64d4-4d89-8daa-32e1aadc271e
-     * @testdox A single zero is invalid
      */
+    #[TestDox('A single zero is invalid')]
     public function testASingleZeroIsInvalid(): void
     {
         $this->assertFalse(isValid("0"));
@@ -29,8 +32,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 73c2f62b-9b10-4c9f-9a04-83cee7367965
-     * @testdox A simple valid SIN that remains valid if reversed
      */
+    #[TestDox('A simple valid SIN that remains valid if reversed')]
     public function testASimpleValidSINThatRemainsValidIfReversed(): void
     {
         $this->assertTrue(isValid("059"));
@@ -38,8 +41,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9369092e-b095-439f-948d-498bd076be11
-     * @testdox A simple valid SIN that becomes invalid if reversed
      */
+    #[TestDox('A simple valid SIN that becomes invalid if reversed')]
     public function testASimpleValidSINThatBecomesInvalidIfReversed(): void
     {
         $this->assertTrue(isValid("59"));
@@ -47,8 +50,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8f9f2350-1faf-4008-ba84-85cbb93ffeca
-     * @testdox A valid Canadian SIN
      */
+    #[TestDox('A valid Canadian SIN')]
     public function testAValidCanadianSIN(): void
     {
         $this->assertTrue(isValid("055 444 285"));
@@ -56,8 +59,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1cdcf269-6560-44fc-91f6-5819a7548737
-     * @testdox Invalid Canadian SIN
      */
+    #[TestDox('Invalid Canadian SIN')]
     public function testInvalidCanadianSIN(): void
     {
         $this->assertFalse(isValid("055 444 286"));
@@ -65,8 +68,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 656c48c1-34e8-4e60-9a5a-aad8a367810a
-     * @testdox Invalid credit card
      */
+    #[TestDox('Invalid credit card')]
     public function testInvalidCreditCard(): void
     {
         $this->assertFalse(isValid("8273 1232 7352 0569"));
@@ -74,8 +77,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 20e67fad-2121-43ed-99a8-14b5b856adb9
-     * @testdox Invalid long number with an even remainder
      */
+    #[TestDox('Invalid long number with an even remainder')]
     public function testInvalidLongNumberWithAnEvenRemainder(): void
     {
         $this->assertFalse(isValid("1 2345 6789 1234 5678 9012"));
@@ -83,8 +86,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7e7c9fc1-d994-457c-811e-d390d52fba5e
-     * @testdox Invalid long number with a remainder divisible by 5
      */
+    #[TestDox('Invalid long number with a remainder divisible by 5')]
     public function testInvalidLongNumberWithARemainderDivisibleBy5(): void
     {
         $this->assertFalse(isValid("1 2345 6789 1234 5678 9013"));
@@ -92,8 +95,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa
-     * @testdox Valid number with an even amount of digits
      */
+    #[TestDox('Valid number with an even amount of digits')]
     public function testValidNumberWithAnEvenAmountOfDigits(): void
     {
         $this->assertTrue(isValid("095 245 88"));
@@ -101,8 +104,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ef081c06-a41f-4761-8492-385e13c8202d
-     * @testdox Valid number with an odd amount of spaces
      */
+    #[TestDox('Valid number with an odd amount of spaces')]
     public function testValidNumberWithAnOddAmountOfSpaces(): void
     {
         $this->assertTrue(isValid("234 567 891 234"));
@@ -110,8 +113,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bef66f64-6100-4cbb-8f94-4c9713c5e5b2
-     * @testdox Valid strings with a non-digit added at the end become invalid
      */
+    #[TestDox('Valid strings with a non-digit added at the end become invalid')]
     public function testValidStringsWithANonDigitAddedAtTheEndBecomeInvalid(): void
     {
         $this->assertFalse(isValid("059a"));
@@ -119,8 +122,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2177e225-9ce7-40f6-b55d-fa420e62938e
-     * @testdox Valid strings with punctuation included become invalid
      */
+    #[TestDox('Valid strings with punctuation included become invalid')]
     public function testValidStringsWithPunctuationIncludedBecomeInvalid(): void
     {
         $this->assertFalse(isValid("055-444-285"));
@@ -128,8 +131,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ebf04f27-9698-45e1-9afe-7e0851d0fe8d
-     * @testdox Valid strings with symbols included become invalid
      */
+    #[TestDox('Valid strings with symbols included become invalid')]
     public function testValidStringsWithSymbolsIncludedBecomeInvalid(): void
     {
         $this->assertFalse(isValid("055# 444$ 285"));
@@ -137,8 +140,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 08195c5e-ce7f-422c-a5eb-3e45fece68ba
-     * @testdox Single zero with space is invalid
      */
+    #[TestDox('Single zero with space is invalid')]
     public function testSingleZeroWithSpaceIsInvalid(): void
     {
         $this->assertFalse(isValid(" 0"));
@@ -146,8 +149,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 12e63a3c-f866-4a79-8c14-b359fc386091
-     * @testdox More than a single zero is valid
      */
+    #[TestDox('More than a single zero is valid')]
     public function testMoreThanASingleZeroIsValid(): void
     {
         $this->assertTrue(isValid("0000 0"));
@@ -155,8 +158,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ab56fa80-5de8-4735-8a4a-14dae588663e
-     * @testdox Input digit 9 is correctly converted to output digit 9
      */
+    #[TestDox('Input digit 9 is correctly converted to output digit 9')]
     public function testInputDigit9IsCorrectlyConvertedToOutputDigit9(): void
     {
         $this->assertTrue(isValid("091"));
@@ -164,8 +167,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b9887ee8-8337-46c5-bc45-3bcab51bc36f
-     * @testdox Very long input is valid
      */
+    #[TestDox('Very long input is valid')]
     public function testVeryLongInputIsValid(): void
     {
         $this->assertTrue(isValid("9999999999 9999999999 9999999999 9999999999"));
@@ -173,8 +176,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8a7c0e24-85ea-4154-9cf1-c2db90eabc08
-     * @testdox valid luhn with an odd number of digits and non zero first digit
      */
+    #[TestDox('valid luhn with an odd number of digits and non zero first digit')]
     public function testValidLuhnWithAnOddNumberOfDigitsAndNonZeroFirstDigit(): void
     {
         $this->assertTrue(isValid("109"));
@@ -182,8 +185,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 39a06a5a-5bad-4e0f-b215-b042d46209b1
-     * @testdox using ascii value for non-doubled non-digit isn't allowed
      */
+    #[TestDox("using ascii value for non-doubled non-digit isn't allowed")]
     public function testUsingAsciiValueForNonDoubledNonDigitIsntAllowed(): void
     {
         $this->assertFalse(isValid("055b 444 285"));
@@ -191,8 +194,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f94cf191-a62f-4868-bc72-7253114aa157
-     * @testdox using ascii value for doubled non-digit isn't allowed
      */
+    #[TestDox("using ascii value for doubled non-digit isn't allowed")]
     public function testUsingAsciiValueForDoubledNonDigitIsntAllowed(): void
     {
         $this->assertFalse(isValid(":9"));
@@ -200,8 +203,8 @@ class LuhnTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8b72ad26-c8be-49a2-b99c-bcc3bf631b33
-     * @testdox non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed
      */
+    #[TestDox("non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed")]
     public function testNonNumericNonSpaceCharInMiddleWithSumDivisibleBy10IsntAllowed(): void
     {
         $this->assertFalse(isValid("59%59"));

--- a/exercises/practice/markdown/MarkdownTest.php
+++ b/exercises/practice/markdown/MarkdownTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class MarkdownTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class MarkdownTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/mask-credit-card/MaskCreditCardTest.php
+++ b/exercises/practice/mask-credit-card/MaskCreditCardTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class MaskCreditCardTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class MaskCreditCardTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/matching-brackets/MatchingBracketsTest.php
+++ b/exercises/practice/matching-brackets/MatchingBracketsTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class MatchingBracketsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class MatchingBracketsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 81ec11da-38dd-442a-bcf9-3de7754609a5
-     * @testdox Paired square brackets
      */
+    #[TestDox('Paired square brackets')]
     public function testPairedSquareBrackets(): void
     {
         $this->assertTrue(brackets_match('[]'));
@@ -20,8 +23,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 287f0167-ac60-4b64-8452-a0aa8f4e5238
-     * @testdox Empty string
      */
+    #[TestDox('Empty string')]
     public function testEmptyString(): void
     {
         $this->assertTrue(brackets_match(''));
@@ -29,8 +32,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6c3615a3-df01-4130-a731-8ef5f5d78dac
-     * @testdox Unpaired brackets
      */
+    #[TestDox('Unpaired brackets')]
     public function testUnpairedBrackets(): void
     {
         $this->assertFalse(brackets_match('[['));
@@ -38,8 +41,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9d414171-9b98-4cac-a4e5-941039a97a77
-     * @testdox Wrong ordered brackets
      */
+    #[TestDox('Wrong ordered brackets')]
     public function testWrongOrderedBrackets(): void
     {
         $this->assertFalse(brackets_match('}{'));
@@ -47,8 +50,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f0f97c94-a149-4736-bc61-f2c5148ffb85
-     * @testdox Wrong closing bracket
      */
+    #[TestDox('Wrong closing bracket')]
     public function testWrongClosingBracket(): void
     {
         $this->assertFalse(brackets_match('{]'));
@@ -56,8 +59,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 754468e0-4696-4582-a30e-534d47d69756
-     * @testdox Paired with whitespace
      */
+    #[TestDox('Paired with whitespace')]
     public function testPairedWithWhitespace(): void
     {
         $this->assertTrue(brackets_match('{ }'));
@@ -65,8 +68,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ba84f6ee-8164-434a-9c3e-b02c7f8e8545
-     * @testdox Partially paired brackets
      */
+    #[TestDox('Partially paired brackets')]
     public function testPartiallyPairedBrackets(): void
     {
         $this->assertFalse(brackets_match('{[])'));
@@ -74,8 +77,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3c86c897-5ff3-4a2b-ad9b-47ac3a30651d
-     * @testdox Simple nested brackets
      */
+    #[TestDox('Simple nested brackets')]
     public function testSimpleNestedBrackets(): void
     {
         $this->assertTrue(brackets_match('{[]}'));
@@ -83,8 +86,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2d137f2c-a19e-4993-9830-83967a2d4726
-     * @testdox Several paired brackets
      */
+    #[TestDox('Several paired brackets')]
     public function testSeveralPairedBrackets(): void
     {
         $this->assertTrue(brackets_match('{}[]'));
@@ -92,8 +95,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2e1f7b56-c137-4c92-9781-958638885a44
-     * @testdox Paired and nested brackets
      */
+    #[TestDox('Paired and nested brackets')]
     public function testPairedAndNestedBrackets(): void
     {
         $this->assertTrue(brackets_match('([{}({}[])])'));
@@ -101,8 +104,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 84f6233b-e0f7-4077-8966-8085d295c19b
-     * @testdox Unopened closing brackets
      */
+    #[TestDox('Unopened closing brackets')]
     public function testUnopenedClosingBrackets(): void
     {
         $this->assertFalse(brackets_match('{[)][]}'));
@@ -110,8 +113,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9b18c67d-7595-4982-b2c5-4cb949745d49
-     * @testdox Unpaired and nested brackets
      */
+    #[TestDox('Unpaired and nested brackets')]
     public function testUnpairedAndNestedBrackets(): void
     {
         $this->assertFalse(brackets_match('([{])'));
@@ -119,8 +122,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a0205e34-c2ac-49e6-a88a-899508d7d68e
-     * @testdox Paired and wrong nested brackets
      */
+    #[TestDox('Paired and wrong nested brackets')]
     public function testPairedAndWrongNestedBrackets(): void
     {
         $this->assertFalse(brackets_match('[({]})'));
@@ -128,8 +131,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1d5c093f-fc84-41fb-8c2a-e052f9581602
-     * @testdox Paired and wrong nested brackets but innermost are correct
      */
+    #[TestDox('Paired and wrong nested brackets but innermost are correct')]
     public function testPairedAndWrongNestedBracketsButInnermostAreCorrect(): void
     {
         $this->assertFalse(brackets_match('[({}])'));
@@ -137,8 +140,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ef47c21b-bcfd-4998-844c-7ad5daad90a8
-     * @testdox Paired and incomplete brackets
      */
+    #[TestDox('Paired and incomplete brackets')]
     public function testPairedAndIncompleteBrackets(): void
     {
         $this->assertFalse(brackets_match('{}['));
@@ -146,8 +149,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a4675a40-a8be-4fc2-bc47-2a282ce6edbe
-     * @testdox Too many closing brackets
      */
+    #[TestDox('Too many closing brackets')]
     public function testTooManyClosingBrackets(): void
     {
         $this->assertFalse(brackets_match('[]]'));
@@ -155,8 +158,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a345a753-d889-4b7e-99ae-34ac85910d1a
-     * @testdox Early unexpected brackets
      */
+    #[TestDox('Early unexpected brackets')]
     public function testEarlyUnexpectedBrackets(): void
     {
         $this->assertFalse(brackets_match(')()'));
@@ -164,8 +167,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 21f81d61-1608-465a-b850-baa44c5def83
-     * @testdox Early mismatched brackets
      */
+    #[TestDox('Early mismatched brackets')]
     public function testEarlyMismatchedBrackets(): void
     {
         $this->assertFalse(brackets_match('{)()'));
@@ -173,8 +176,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 99255f93-261b-4435-a352-02bdecc9bdf2
-     * @testdox Math expression
      */
+    #[TestDox('Math expression')]
     public function testMathExpression(): void
     {
         $this->assertTrue(brackets_match('(((185 + 223.85) * 15) - 543)/2'));
@@ -182,8 +185,8 @@ class MatchingBracketsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8e357d79-f302-469a-8515-2561877256a1
-     * @testdox Complex latex expression
      */
+    #[TestDox('Complex latex expression')]
     public function testComplexLatexExpression(): void
     {
         $this->assertTrue(brackets_match(

--- a/exercises/practice/matrix/Matrix.php
+++ b/exercises/practice/matrix/Matrix.php
@@ -28,16 +28,16 @@ class Matrix
 {
     public function __construct(string $matrix)
     {
-        throw new BadFunctionCallException("Please implement the Matrix class!");
+        throw new \BadFunctionCallException("Please implement the Matrix class!");
     }
 
     public function getRow(int $rowId): array
     {
-        throw new BadFunctionCallException("Please implement the getRow method!");
+        throw new \BadFunctionCallException("Please implement the getRow method!");
     }
 
     public function getColumn(int $columnId): array
     {
-        throw new BadFunctionCallException("Please implement the getColumn method!");
+        throw new \BadFunctionCallException("Please implement the getColumn method!");
     }
 }

--- a/exercises/practice/matrix/MatrixTest.php
+++ b/exercises/practice/matrix/MatrixTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class MatrixTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class MatrixTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/meetup/MeetupTest.php
+++ b/exercises/practice/meetup/MeetupTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class MeetupTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class MeetupTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
       /**
      * uuid: d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8
-     * @testdox when teenth Monday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Monday is the 13th, the first day of the teenth week')]
     public function testMonteenthOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/13");
@@ -24,8 +27,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f78373d1-cd53-4a7f-9d37-e15bf8a456b4
-     * @testdox when teenth Monday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Monday is the 19th, the last day of the teenth week')]
     public function testMonteenthOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/19");
@@ -37,8 +40,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8c78bea7-a116-425b-9c6b-c9898266d92a
-     * @testdox when teenth Monday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Monday is some day in the middle of the teenth week')]
     public function testMonteenthOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/16");
@@ -50,8 +53,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: cfef881b-9dc9-4d0b-8de4-82d0f39fc271
-     * @testdox when teenth Tuesday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Tuesday is the 19th, the last day of the teenth week')]
     public function testTuesteenthOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/19");
@@ -63,8 +66,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 69048961-3b00-41f9-97ee-eb6d83a8e92b
-     * @testdox when teenth Tuesday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Tuesday is some day in the middle of the teenth week')]
     public function testTuesteenthOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/16");
@@ -76,8 +79,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d30bade8-3622-466a-b7be-587414e0caa6
-     * @testdox when teenth Tuesday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Tuesday is the 13th, the first day of the teenth week')]
     public function testTuesteenthOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/13");
@@ -89,8 +92,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8db4b58b-92f3-4687-867b-82ee1a04f851
-     * @testdox when teenth Wednesday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Wednesday is some day in the middle of the teenth week')]
     public function testWednesteenthOfJanuary2013(): void
     {
         $expected = new DateTimeImmutable("2013/1/16");
@@ -102,8 +105,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6c27a2a2-28f8-487f-ae81-35d08c4664f7
-     * @testdox when teenth Wednesday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Wednesday is the 13th, the first day of the teenth week')]
     public function testWednesteenthOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/13");
@@ -115,8 +118,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 008a8674-1958-45b5-b8e6-c2c9960d973a
-     * @testdox when teenth Wednesday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Wednesday is the 19th, the last day of the teenth week')]
     public function testWednesteenthOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/19");
@@ -128,8 +131,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e4abd5e3-57cb-4091-8420-d97e955c0dbd
-     * @testdox when teenth Thursday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Thursday is some day in the middle of the teenth week')]
     public function testThursteenthOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/16");
@@ -141,8 +144,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 85da0b0f-eace-4297-a6dd-63588d5055b4
-     * @testdox when teenth Thursday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Thursday is the 13th, the first day of the teenth week')]
     public function testThursteenthOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/13");
@@ -154,8 +157,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ecf64f9b-8413-489b-bf6e-128045f70bcc
-     * @testdox when teenth Thursday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Thursday is the 19th, the last day of the teenth week')]
     public function testThursteenthOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/19");
@@ -167,8 +170,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ac4e180c-7d0a-4d3d-b05f-f564ebb584ca
-     * @testdox when teenth Friday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Friday is the 19th, the last day of the teenth week')]
     public function testFriteenthOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/19");
@@ -180,8 +183,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b79101c7-83ad-4f8f-8ec8-591683296315
-     * @testdox when teenth Friday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Friday is some day in the middle of the teenth week')]
     public function testFriteenthOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/16");
@@ -193,8 +196,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8
-     * @testdox when teenth Friday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Friday is the 13th, the first day of the teenth week')]
     public function testFriteenthOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/13");
@@ -206,8 +209,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: dfae03ed-9610-47de-a632-655ab01e1e7c
-     * @testdox when teenth Saturday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Saturday is some day in the middle of the teenth week')]
     public function testSaturteenthOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/16");
@@ -219,8 +222,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ec02e3e1-fc72-4a3c-872f-a53fa8ab358e
-     * @testdox when teenth Saturday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Saturday is the 13th, the first day of the teenth week')]
     public function testSaturteenthOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/13");
@@ -232,8 +235,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d983094b-7259-4195-b84e-5d09578c89d9
-     * @testdox when teenth Saturday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Saturday is the 19th, the last day of the teenth week')]
     public function testSaturteenthOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/19");
@@ -245,8 +248,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d84a2a2e-f745-443a-9368-30051be60c2e
-     * @testdox when teenth Sunday is the 19th, the last day of the teenth week
      */
+    #[TestDox('when teenth Sunday is the 19th, the last day of the teenth week')]
     public function testSunteenthOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/19");
@@ -258,8 +261,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0e64bc53-92a3-4f61-85b2-0b7168c7ce5a
-     * @testdox when teenth Sunday is some day in the middle of the teenth week
      */
+    #[TestDox('when teenth Sunday is some day in the middle of the teenth week')]
     public function testSunteenthOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/16");
@@ -271,8 +274,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: de87652c-185e-4854-b3ae-04cf6150eead
-     * @testdox when teenth Sunday is the 13th, the first day of the teenth week
      */
+    #[TestDox('when teenth Sunday is the 13th, the first day of the teenth week')]
     public function testSunteenthOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/13");
@@ -284,8 +287,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411
-     * @testdox when first Monday is some day in the middle of the first week
      */
+    #[TestDox('when first Monday is some day in the middle of the first week')]
     public function testFirstMondayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/4");
@@ -297,8 +300,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a6168c7c-ed95-4bb3-8f92-c72575fc64b0
-     * @testdox when first Monday is the 1st, the first day of the first week
      */
+    #[TestDox('when first Monday is the 1st, the first day of the first week')]
     public function testFirstMondayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/1");
@@ -310,8 +313,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1bfc620f-1c54-4bbd-931f-4a1cd1036c20
-     * @testdox when first Tuesday is the 7th, the last day of the first week
      */
+    #[TestDox('when first Tuesday is the 7th, the last day of the first week')]
     public function testFirstTuesdayOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/7");
@@ -323,8 +326,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 12959c10-7362-4ca0-a048-50cf1c06e3e2
-     * @testdox when first Tuesday is some day in the middle of the first week
      */
+    #[TestDox('when first Tuesday is some day in the middle of the first week')]
     public function testFirstTuesdayOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/4");
@@ -336,8 +339,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1033dc66-8d0b-48a1-90cb-270703d59d1d
-     * @testdox when first Wednesday is some day in the middle of the first week
      */
+    #[TestDox('when first Wednesday is some day in the middle of the first week')]
     public function testFirstWednesdayOfJuly2013(): void
     {
         $expected = new DateTimeImmutable("2013/7/3");
@@ -349,8 +352,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b89185b9-2f32-46f4-a602-de20b09058f6
-     * @testdox when first Wednesday is the 7th, the last day of the first week
      */
+    #[TestDox('when first Wednesday is the 7th, the last day of the first week')]
     public function testFirstWednesdayOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/7");
@@ -362,8 +365,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5
-     * @testdox when first Thursday is some day in the middle of the first week
      */
+    #[TestDox('when first Thursday is some day in the middle of the first week')]
     public function testFirstThursdayOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/5");
@@ -375,8 +378,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b420a7e3-a94c-4226-870a-9eb3a92647f0
-     * @testdox when first Thursday is another day in the middle of the first week
      */
+    #[TestDox('when first Thursday is another day in the middle of the first week')]
     public function testFirstThursdayOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/3");
@@ -388,8 +391,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 61df3270-28b4-4713-bee2-566fa27302ca
-     * @testdox when first Friday is the 1st, the first day of the first week
      */
+    #[TestDox('when first Friday is the 1st, the first day of the first week')]
     public function testFirstFridayOfNovember2013(): void
     {
         $expected = new DateTimeImmutable("2013/11/1");
@@ -401,8 +404,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: cad33d4d-595c-412f-85cf-3874c6e07abf
-     * @testdox when first Friday is some day in the middle of the first week
      */
+    #[TestDox('when first Friday is some day in the middle of the first week')]
     public function testFirstFridayOfDecember2013(): void
     {
         $expected = new DateTimeImmutable("2013/12/6");
@@ -414,8 +417,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a2869b52-5bba-44f0-a863-07bd1f67eadb
-     * @testdox when first Saturday is some day in the middle of the first week
      */
+    #[TestDox('when first Saturday is some day in the middle of the first week')]
     public function testFirstSaturdayOfJanuary2013(): void
     {
         $expected = new DateTimeImmutable("2013/1/5");
@@ -427,8 +430,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3585315a-d0db-4ea1-822e-0f22e2a645f5
-     * @testdox when first Saturday is another day in the middle of the first week
      */
+    #[TestDox('when first Saturday is another day in the middle of the first week')]
     public function testFirstSaturdayOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/2");
@@ -440,8 +443,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1
-     * @testdox when first Sunday is some day in the middle of the first week
      */
+    #[TestDox('when first Sunday is some day in the middle of the first week')]
     public function testFirstSundayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/3");
@@ -453,8 +456,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1513328b-df53-4714-8677-df68c4f9366c
-     * @testdox when first Sunday is the 7th, the last day of the first week
      */
+    #[TestDox('when first Sunday is the 7th, the last day of the first week')]
     public function testFirstSundayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/7");
@@ -466,8 +469,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 49e083af-47ec-4018-b807-62ef411efed7
-     * @testdox when second Monday is some day in the middle of the second week
      */
+    #[TestDox('when second Monday is some day in the middle of the second week')]
     public function testSecondMondayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/11");
@@ -479,8 +482,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6cb79a73-38fe-4475-9101-9eec36cf79e5
-     * @testdox when second Monday is the 8th, the first day of the second week
      */
+    #[TestDox('when second Monday is the 8th, the first day of the second week')]
     public function testSecondMondayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/8");
@@ -492,8 +495,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 4c39b594-af7e-4445-aa03-bf4f8effd9a1
-     * @testdox when second Tuesday is the 14th, the last day of the second week
      */
+    #[TestDox('when second Tuesday is the 14th, the last day of the second week')]
     public function testSecondTuesdayOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/14");
@@ -505,8 +508,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 41b32c34-2e39-40e3-b790-93539aaeb6dd
-     * @testdox when second Tuesday is some day in the middle of the second week
      */
+    #[TestDox('when second Tuesday is some day in the middle of the second week')]
     public function testSecondTuesdayOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/11");
@@ -518,8 +521,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 90a160c5-b5d9-4831-927f-63a78b17843d
-     * @testdox when second Wednesday is some day in the middle of the second week
      */
+    #[TestDox('when second Wednesday is some day in the middle of the second week')]
     public function testSecondWednesdayOfJuly2013(): void
     {
         $expected = new DateTimeImmutable("2013/7/10");
@@ -531,8 +534,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 23b98ce7-8dd5-41a1-9310-ef27209741cb
-     * @testdox when second Wednesday is the 14th, the last day of the second week
      */
+    #[TestDox('when second Wednesday is the 14th, the last day of the second week')]
     public function testSecondWednesdayOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/14");
@@ -544,8 +547,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 447f1960-27ca-4729-bc3f-f36043f43ed0
-     * @testdox when second Thursday is some day in the middle of the second week
      */
+    #[TestDox('when second Thursday is some day in the middle of the second week')]
     public function testSecondThursdayOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/12");
@@ -557,8 +560,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c9aa2687-300c-4e79-86ca-077849a81bde
-     * @testdox when second Thursday is another day in the middle of the second week
      */
+    #[TestDox('when second Thursday is another day in the middle of the second week')]
     public function testSecondThursdayOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/10");
@@ -570,8 +573,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a7e11ef3-6625-4134-acda-3e7195421c09
-     * @testdox when second Friday is the 8th, the first day of the second week
      */
+    #[TestDox('when second Friday is the 8th, the first day of the second week')]
     public function testSecondFridayOfNovember2013(): void
     {
         $expected = new DateTimeImmutable("2013/11/8");
@@ -583,8 +586,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8b420e5f-9290-4106-b5ae-022f3e2a3e41
-     * @testdox when second Friday is some day in the middle of the second week
      */
+    #[TestDox('when second Friday is some day in the middle of the second week')]
     public function testSecondFridayOfDecember2013(): void
     {
         $expected = new DateTimeImmutable("2013/12/13");
@@ -596,8 +599,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 80631afc-fc11-4546-8b5f-c12aaeb72b4f
-     * @testdox when second Saturday is some day in the middle of the second week
      */
+    #[TestDox('when second Saturday is some day in the middle of the second week')]
     public function testSecondSaturdayOfJanuary2013(): void
     {
         $expected = new DateTimeImmutable("2013/1/12");
@@ -609,8 +612,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e34d43ac-f470-44c2-aa5f-e97b78ecaf83
-     * @testdox when second Saturday is another day in the middle of the second week
      */
+    #[TestDox('when second Saturday is another day in the middle of the second week')]
     public function testSecondSaturdayOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/9");
@@ -622,8 +625,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a57d59fd-1023-47ad-b0df-a6feb21b44fc
-     * @testdox when second Sunday is some day in the middle of the second week
      */
+    #[TestDox('when second Sunday is some day in the middle of the second week')]
     public function testSecondSundayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/10");
@@ -635,8 +638,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a829a8b0-abdd-4ad1-b66c-5560d843c91a
-     * @testdox when second Sunday is the 14th, the last day of the second week
      */
+    #[TestDox('when second Sunday is the 14th, the last day of the second week')]
     public function testSecondSundayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/14");
@@ -648,8 +651,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 501a8a77-6038-4fc0-b74c-33634906c29d
-     * @testdox when third Monday is some day in the middle of the third week
      */
+    #[TestDox('when third Monday is some day in the middle of the third week')]
     public function testThirdMondayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/18");
@@ -661,8 +664,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 49e4516e-cf32-4a58-8bbc-494b7e851c92
-     * @testdox when third Monday is the 15th, the first day of the third week
      */
+    #[TestDox('when third Monday is the 15th, the first day of the third week')]
     public function testThirdMondayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/15");
@@ -674,8 +677,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 4db61095-f7c7-493c-85f1-9996ad3012c7
-     * @testdox when third Tuesday is the 21st, the last day of the third week
      */
+    #[TestDox('when third Tuesday is the 21st, the last day of the third week')]
     public function testThirdTuesdayOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/21");
@@ -687,8 +690,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 714fc2e3-58d0-4b91-90fd-61eefd2892c0
-     * @testdox when third Tuesday is some day in the middle of the third week
      */
+    #[TestDox('when third Tuesday is some day in the middle of the third week')]
     public function testThirdTuesdayOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/18");
@@ -700,8 +703,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b08a051a-2c80-445b-9b0e-524171a166d1
-     * @testdox when third Wednesday is some day in the middle of the third week
      */
+    #[TestDox('when third Wednesday is some day in the middle of the third week')]
     public function testThirdWednesdayOfJuly2013(): void
     {
         $expected = new DateTimeImmutable("2013/7/17");
@@ -713,8 +716,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 80bb9eff-3905-4c61-8dc9-bb03016d8ff8
-     * @testdox when third Wednesday is the 21st, the last day of the third week
      */
+    #[TestDox('when third Wednesday is the 21st, the last day of the third week')]
     public function testThirdWednesdayOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/21");
@@ -726,8 +729,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: fa52a299-f77f-4784-b290-ba9189fbd9c9
-     * @testdox when third Thursday is some day in the middle of the third week
      */
+    #[TestDox('when third Thursday is some day in the middle of the third week')]
     public function testThirdThursdayOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/19");
@@ -739,8 +742,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f74b1bc6-cc5c-4bf1-ba69-c554a969eb38
-     * @testdox when third Thursday is another day in the middle of the third week
      */
+    #[TestDox('when third Thursday is another day in the middle of the third week')]
     public function testThirdThursdayOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/17");
@@ -752,8 +755,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8900f3b0-801a-466b-a866-f42d64667abd
-     * @testdox when third Friday is the 15th, the first day of the third week
      */
+    #[TestDox('when third Friday is the 15th, the first day of the third week')]
     public function testThirdFridayOfNovember2013(): void
     {
         $expected = new DateTimeImmutable("2013/11/15");
@@ -765,8 +768,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 538ac405-a091-4314-9ccd-920c4e38e85e
-     * @testdox when third Friday is some day in the middle of the third week
      */
+    #[TestDox('when third Friday is some day in the middle of the third week')]
     public function testThirdFridayOfDecember2013(): void
     {
         $expected = new DateTimeImmutable("2013/12/20");
@@ -778,8 +781,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 244db35c-2716-4fa0-88ce-afd58e5cf910
-     * @testdox when third Saturday is some day in the middle of the third week
      */
+    #[TestDox('when third Saturday is some day in the middle of the third week')]
     public function testThirdSaturdayOfJanuary2013(): void
     {
         $expected = new DateTimeImmutable("2013/1/19");
@@ -791,8 +794,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e
-     * @testdox when third Saturday is another day in the middle of the third week
      */
+    #[TestDox('when third Saturday is another day in the middle of the third week')]
     public function testThirdSaturdayOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/16");
@@ -804,8 +807,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: be71dcc6-00d2-4b53-a369-cbfae55b312f
-     * @testdox when third Sunday is some day in the middle of the third week
      */
+    #[TestDox('when third Sunday is some day in the middle of the third week')]
     public function testThirdSundayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/17");
@@ -817,8 +820,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b7d2da84-4290-4ee6-a618-ee124ae78be7
-     * @testdox when third Sunday is the 21st, the last day of the third week
      */
+    #[TestDox('when third Sunday is the 21st, the last day of the third week')]
     public function testThirdSundayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/21");
@@ -830,8 +833,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 4276dc06-a1bd-4fc2-b6c2-625fee90bc88
-     * @testdox when fourth Monday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Monday is some day in the middle of the fourth week')]
     public function testFourthMondayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/25");
@@ -843,8 +846,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ddbd7976-2deb-4250-8a38-925ac1a8e9a2
-     * @testdox when fourth Monday is the 22nd, the first day of the fourth week
      */
+    #[TestDox('when fourth Monday is the 22nd, the first day of the fourth week')]
     public function testFourthMondayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/22");
@@ -856,8 +859,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: eb714ef4-1656-47cc-913c-844dba4ebddd
-     * @testdox when fourth Tuesday is the 28th, the last day of the fourth week
      */
+    #[TestDox('when fourth Tuesday is the 28th, the last day of the fourth week')]
     public function testFourthTuesdayOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/28");
@@ -869,8 +872,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 16648435-7937-4d2d-b118-c3e38fd084bd
-     * @testdox when fourth Tuesday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Tuesday is some day in the middle of the fourth week')]
     public function testFourthTuesdayOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/25");
@@ -882,8 +885,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: de062bdc-9484-437a-a8c5-5253c6f6785a
-     * @testdox when fourth Wednesday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Wednesday is some day in the middle of the fourth week')]
     public function testFourthWednesdayOfJuly2013(): void
     {
         $expected = new DateTimeImmutable("2013/7/24");
@@ -895,8 +898,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c2ce6821-169c-4832-8d37-690ef5d9514a
-     * @testdox when fourth Wednesday is the 28th, the last day of the fourth week
      */
+    #[TestDox('when fourth Wednesday is the 28th, the last day of the fourth week')]
     public function testFourthWednesdayOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/28");
@@ -908,8 +911,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: d462c631-2894-4391-a8e3-dbb98b7a7303
-     * @testdox when fourth Thursday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Thursday is some day in the middle of the fourth week')]
     public function testFourthThursdayOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/26");
@@ -921,8 +924,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9ff1f7b6-1b72-427d-9ee9-82b5bb08b835
-     * @testdox when fourth Thursday is another day in the middle of the fourth week
      */
+    #[TestDox('when fourth Thursday is another day in the middle of the fourth week')]
     public function testFourthThursdayOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/24");
@@ -934,8 +937,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 83bae8ba-1c49-49bc-b632-b7c7e1d7e35f
-     * @testdox when fourth Friday is the 22nd, the first day of the fourth week
      */
+    #[TestDox('when fourth Friday is the 22nd, the first day of the fourth week')]
     public function testFourthFridayOfNovember2013(): void
     {
         $expected = new DateTimeImmutable("2013/11/22");
@@ -947,8 +950,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: de752d2a-a95e-48d2-835b-93363dac3710
-     * @testdox when fourth Friday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Friday is some day in the middle of the fourth week')]
     public function testFourthFridayOfDecember2013(): void
     {
         $expected = new DateTimeImmutable("2013/12/27");
@@ -960,8 +963,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: eedd90ad-d581-45db-8312-4c6dcf9cf560
-     * @testdox when fourth Saturday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Saturday is some day in the middle of the fourth week')]
     public function testFourthSaturdayOfJanuary2013(): void
     {
         $expected = new DateTimeImmutable("2013/1/26");
@@ -973,8 +976,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 669fedcd-912e-48c7-a0a1-228b34af91d0
-     * @testdox when fourth Saturday is another day in the middle of the fourth week
      */
+    #[TestDox('when fourth Saturday is another day in the middle of the fourth week')]
     public function testFourthSaturdayOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/23");
@@ -986,8 +989,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 648e3849-ea49-44a5-a8a3-9f2a43b3bf1b
-     * @testdox when fourth Sunday is some day in the middle of the fourth week
      */
+    #[TestDox('when fourth Sunday is some day in the middle of the fourth week')]
     public function testFourthSundayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/24");
@@ -999,8 +1002,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f81321b3-99ab-4db6-9267-69c5da5a7823
-     * @testdox when fourth Sunday is the 28th, the last day of the fourth week
      */
+    #[TestDox('when fourth Sunday is the 28th, the last day of the fourth week')]
     public function testFourthSundayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/28");
@@ -1012,8 +1015,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1af5e51f-5488-4548-aee8-11d7d4a730dc
-     * @testdox last Monday in a month with four Mondays
      */
+    #[TestDox('last Monday in a month with four Mondays')]
     public function testLastMondayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/25");
@@ -1025,8 +1028,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f29999f2-235e-4ec7-9dab-26f137146526
-     * @testdox last Monday in a month with five Mondays
      */
+    #[TestDox('last Monday in a month with five Mondays')]
     public function testLastMondayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/29");
@@ -1038,8 +1041,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 31b097a0-508e-48ac-bf8a-f63cdcf6dc41
-     * @testdox last Tuesday in a month with four Tuesdays
      */
+    #[TestDox('last Tuesday in a month with four Tuesdays')]
     public function testLastTuesdayOfMay2013(): void
     {
         $expected = new DateTimeImmutable("2013/5/28");
@@ -1051,8 +1054,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8c022150-0bb5-4a1f-80f9-88b2e2abcba4
-     * @testdox last Tuesday in another month with four Tuesdays
      */
+    #[TestDox('last Tuesday in another month with four Tuesdays')]
     public function testLastTuesdayOfJune2013(): void
     {
         $expected = new DateTimeImmutable("2013/6/25");
@@ -1064,8 +1067,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0e762194-672a-4bdf-8a37-1e59fdacef12
-     * @testdox last Wednesday in a month with five Wednesdays
      */
+    #[TestDox('last Wednesday in a month with five Wednesdays')]
     public function testLastWednesdayOfJuly2013(): void
     {
         $expected = new DateTimeImmutable("2013/7/31");
@@ -1077,8 +1080,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 5016386a-f24e-4bd7-b439-95358f491b66
-     * @testdox last Wednesday in a month with four Wednesdays
      */
+    #[TestDox('last Wednesday in a month with four Wednesdays')]
     public function testLastWednesdayOfAugust2013(): void
     {
         $expected = new DateTimeImmutable("2013/8/28");
@@ -1090,8 +1093,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 12ead1a5-cdf9-4192-9a56-2229e93dd149
-     * @testdox last Thursday in a month with four Thursdays
      */
+    #[TestDox('last Thursday in a month with four Thursdays')]
     public function testLastThursdayOfSeptember2013(): void
     {
         $expected = new DateTimeImmutable("2013/9/26");
@@ -1103,8 +1106,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7
-     * @testdox last Thursday in a month with five Thursdays
      */
+    #[TestDox('last Thursday in a month with five Thursdays')]
     public function testLastThursdayOfOctober2013(): void
     {
         $expected = new DateTimeImmutable("2013/10/31");
@@ -1116,8 +1119,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e47a739e-b979-460d-9c8a-75c35ca2290b
-     * @testdox last Friday in a month with five Fridays
      */
+    #[TestDox('last Friday in a month with five Fridays')]
     public function testLastFridayOfNovember2013(): void
     {
         $expected = new DateTimeImmutable("2013/11/29");
@@ -1129,8 +1132,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec
-     * @testdox last Friday in a month with four Fridays
      */
+    #[TestDox('last Friday in a month with four Fridays')]
     public function testLastFridayOfDecember2013(): void
     {
         $expected = new DateTimeImmutable("2013/12/27");
@@ -1142,8 +1145,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 61e54cba-76f3-4772-a2b1-bf443fda2137
-     * @testdox last Saturday in a month with four Saturdays
      */
+    #[TestDox('last Saturday in a month with four Saturdays')]
     public function testLastSaturdayOfJanuary2013(): void
     {
         $expected = new DateTimeImmutable("2013/1/26");
@@ -1155,8 +1158,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f
-     * @testdox last Saturday in another month with four Saturdays
      */
+    #[TestDox('last Saturday in another month with four Saturdays')]
     public function testLastSaturdayOfFebruary2013(): void
     {
         $expected = new DateTimeImmutable("2013/2/23");
@@ -1168,8 +1171,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0b63e682-f429-4d19-9809-4a45bd0242dc
-     * @testdox last Sunday in a month with five Sundays
      */
+    #[TestDox('last Sunday in a month with five Sundays')]
     public function testLastSundayOfMarch2013(): void
     {
         $expected = new DateTimeImmutable("2013/3/31");
@@ -1181,8 +1184,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 5232307e-d3e3-4afc-8ba6-4084ad987c00
-     * @testdox last Sunday in a month with four Sundays
      */
+    #[TestDox('last Sunday in a month with four Sundays')]
     public function testLastSundayOfApril2013(): void
     {
         $expected = new DateTimeImmutable("2013/4/28");
@@ -1194,8 +1197,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0bbd48e8-9773-4e81-8e71-b9a51711e3c5
-     * @testdox last Wednesday in February in a leap year is the 29th
      */
+    #[TestDox('last Wednesday in February in a leap year is the 29th')]
     public function testLastWednesdayOfFebruary2012(): void
     {
         $expected = new DateTimeImmutable("2012/2/29");
@@ -1207,8 +1210,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: fe0936de-7eee-4a48-88dd-66c07ab1fefc
-     * @testdox last Wednesday in December that is also the last day of the year
      */
+    #[TestDox('last Wednesday in December that is also the last day of the year')]
     public function testLastWednesdayOfDecember2014(): void
     {
         $expected = new DateTimeImmutable("2014/12/31");
@@ -1220,8 +1223,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2ccf2488-aafc-4671-a24e-2b6effe1b0e2
-     * @testdox last Sunday in February in a non-leap year is not the 29th
      */
+    #[TestDox('last Sunday in February in a non-leap year is not the 29th')]
     public function testLastSundayOfFebruary2015(): void
     {
         $expected = new DateTimeImmutable("2015/2/22");
@@ -1233,8 +1236,8 @@ class MeetupTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 00c3ce9f-cf36-4b70-90d8-92b32be6830e
-     * @testdox when first Friday is the 7th, the last day of the first week
      */
+    #[TestDox('when first Friday is the 7th, the last day of the first week')]
     public function testFirstFridayOfDecember2012(): void
     {
         $expected = new DateTimeImmutable("2012/12/7");

--- a/exercises/practice/micro-blog/MicroBlogTest.php
+++ b/exercises/practice/micro-blog/MicroBlogTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class MicroBlogTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class MicroBlogTest extends TestCase
 {
     private MicroBlog $microBlog;
 

--- a/exercises/practice/minesweeper/MinesweeperTest.php
+++ b/exercises/practice/minesweeper/MinesweeperTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class MinesweeperTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class MinesweeperTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0c5ec4bd-dea7-4138-8651-1203e1cb9f44
-     * @testdox No rows
      */
+    #[TestDox('No rows')]
     public function testNoRows(): void
     {
         $minefield = [];
@@ -26,8 +29,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 650ac4c0-ad6b-4b41-acde-e4ea5852c3b8
-     * @testdox No columns
      */
+    #[TestDox('No columns')]
     public function testNoColumns(): void
     {
         $minefield = [""];
@@ -41,8 +44,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6fbf8f6d-a03b-42c9-9a58-b489e9235478
-     * @testdox No mines
      */
+    #[TestDox('No mines')]
     public function testNoMines(): void
     {
         $minefield = [
@@ -64,8 +67,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 61aff1c4-fb31-4078-acad-cd5f1e635655
-     * @testdox Minefield with only mines
      */
+    #[TestDox('Minefield with only mines')]
     public function testMinefieldWithOnlyMines(): void
     {
         $minefield = [
@@ -87,8 +90,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 84167147-c504-4896-85d7-246b01dea7c5
-     * @testdox Mine surrounded by spaces
      */
+    #[TestDox('Mine surrounded by spaces')]
     public function testMineSurroundedBySpaces(): void
     {
         $minefield = [
@@ -110,8 +113,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cb878f35-43e3-4c9d-93d9-139012cccc4a
-     * @testdox Space surrounded by mines
      */
+    #[TestDox('Space surrounded by mines')]
     public function testSpaceSurroundedByMines(): void
     {
         $minefield = [
@@ -133,8 +136,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7037f483-ddb4-4b35-b005-0d0f4ef4606f
-     * @testdox Horizontal line
      */
+    #[TestDox('Horizontal line')]
     public function testHorizontalLine(): void
     {
         $minefield = [" * * "];
@@ -148,8 +151,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid uuid
-     * @testdox Horizontal line, mines at edges
      */
+    #[TestDox('Horizontal line, mines at edges')]
     public function testHorizontalLineMinesAtEdges(): void
     {
         $minefield = ["*   *"];
@@ -163,8 +166,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c5198b50-804f-47e9-ae02-c3b42f7ce3ab
-     * @testdox Vertical line
      */
+    #[TestDox('Vertical line')]
     public function testVerticalLine(): void
     {
         $minefield = [
@@ -190,8 +193,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0c79a64d-703d-4660-9e90-5adfa5408939
-     * @testdox Vertical line, mines at edges
      */
+    #[TestDox('Vertical line, mines at edges')]
     public function testVerticalLineMinesAtEdges(): void
     {
         $minefield = [
@@ -217,8 +220,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4b098563-b7f3-401c-97c6-79dd1b708f34
-     * @testdox Cross
      */
+    #[TestDox('Cross')]
     public function testCross(): void
     {
         $minefield = [
@@ -244,8 +247,8 @@ class MinesweeperTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 04a260f1-b40a-4e89-839e-8dd8525abe0e
-     * @testdox Large minefield
      */
+    #[TestDox('Large minefield')]
     public function testLargeMinefield(): void
     {
         $minefield = [

--- a/exercises/practice/nth-prime/NthPrimeTest.php
+++ b/exercises/practice/nth-prime/NthPrimeTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class NthPrimeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class NthPrimeTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.php
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class NucleotideCountTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class NucleotideCountTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/ocr-numbers/OcrNumbersTest.php
+++ b/exercises/practice/ocr-numbers/OcrNumbersTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class OcrNumbersTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class OcrNumbersTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/ordinal-number/OrdinalNumberTest.php
+++ b/exercises/practice/ordinal-number/OrdinalNumberTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class OrdinalNumberTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class OrdinalNumberTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/palindrome-products/PalindromeProductsTest.php
+++ b/exercises/practice/palindrome-products/PalindromeProductsTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class PalindromeProductsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class PalindromeProductsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/pangram/PangramTest.php
+++ b/exercises/practice/pangram/PangramTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class PangramTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class PangramTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 64f61791-508e-4f5c-83ab-05de042b0149
-     * @testdox Empty sentence
      */
+    #[TestDox('Empty sentence')]
     public function testSentenceEmpty(): void
     {
         $this->assertFalse(isPangram(''));
@@ -20,8 +23,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 74858f80-4a4d-478b-8a5e-c6477e4e4e84
-     * @testdox Perfect lower case
      */
+    #[TestDox('Perfect lower case')]
     public function testPerfectLowerCase(): void
     {
         $this->assertTrue(isPangram('abcdefghijklmnopqrstuvwxyz'));
@@ -29,8 +32,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 61288860-35ca-4abe-ba08-f5df76ecbdcd
-     * @testdox Only lower case
      */
+    #[TestDox('Only lower case')]
     public function testPangramWithOnlyLowerCase(): void
     {
         $this->assertTrue(isPangram('the quick brown fox jumps over the lazy dog'));
@@ -38,8 +41,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6564267d-8ac5-4d29-baf2-e7d2e304a743
-     * @testdox Missing the letter 'x'
      */
+    #[TestDox("Missing the letter 'x'")]
     public function testMissingCharacterX(): void
     {
         $this->assertFalse(isPangram('a quick movement of the enemy will jeopardize five gunboats'));
@@ -47,8 +50,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0
-     * @testdox Missing the letter 'h'
      */
+    #[TestDox("Missing the letter 'h'")]
     public function testMissingCharacterH(): void
     {
         $this->assertFalse(isPangram('five boxing wizards jump quickly at it'));
@@ -56,8 +59,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d835ec38-bc8f-48e4-9e36-eb232427b1df
-     * @testdox With underscores
      */
+    #[TestDox('With underscores')]
     public function testPangramWithUnderscores(): void
     {
         $this->assertTrue(isPangram('the_quick_brown_fox_jumps_over_the_lazy_dog'));
@@ -65,8 +68,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8cc1e080-a178-4494-b4b3-06982c9be2a8
-     * @testdox With numbers
      */
+    #[TestDox('With numbers')]
     public function testPangramWithNumbers(): void
     {
         $this->assertTrue(isPangram('the 1 quick brown fox jumps over the 2 lazy dogs'));
@@ -74,8 +77,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bed96b1c-ff95-45b8-9731-fdbdcb6ede9a
-     * @testdox Missing letters replaced by numbers
      */
+    #[TestDox('Missing letters replaced by numbers')]
     public function testMissingLettersReplacedByNumbers(): void
     {
         $this->assertFalse(isPangram('7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog'));
@@ -83,8 +86,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 938bd5d8-ade5-40e2-a2d9-55a338a01030
-     * @testdox Mixed case and punctuation
      */
+    #[TestDox('Mixed case and punctuation')]
     public function testPangramWithMixedCaseAndPunctuation(): void
     {
         $this->assertTrue(isPangram('"Five quacking Zephyrs jolt my wax bed."'));
@@ -92,8 +95,8 @@ class PangramTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7138e389-83e4-4c6e-8413-1e40a0076951
-     * @testdox a-m and A-M are 26 different characters but not a pangram
      */
+    #[TestDox('a-m and A-M are 26 different characters but not a pangram')]
     public function testEnoughDifferentCharsButOnlyCaseDiffers(): void
     {
         $this->assertFalse(isPangram('abcdefghijklm ABCDEFGHIJKLM'));
@@ -102,10 +105,7 @@ class PangramTest extends PHPUnit\Framework\TestCase
     /*
      * PHP track addons
      */
-
-    /**
-     * @testdox Unicode mixed into pangram
-     */
+    #[TestDox('Unicode mixed into pangram')]
     public function testPangramMixedWithUnicode(): void
     {
         $this->assertTrue(isPangram('Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.'));

--- a/exercises/practice/pascals-triangle/PascalsTriangleTest.php
+++ b/exercises/practice/pascals-triangle/PascalsTriangleTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class PascalsTriangleTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class PascalsTriangleTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9920ce55-9629-46d5-85d6-4201f4a4234d
-     * @testdox Zero rows
      */
+    #[TestDox('Zero rows')]
     public function testZeroRows(): void
     {
         $this->assertSame([], pascalsTriangleRows(0));
@@ -20,8 +23,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 70d643ce-a46d-4e93-af58-12d88dd01f21
-     * @testdox Single row
      */
+    #[TestDox('Single row')]
     public function testSingleRow(): void
     {
         $this->assertSame([[1]], pascalsTriangleRows(1));
@@ -29,8 +32,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd
-     * @testdox Two rows
      */
+    #[TestDox('Two rows')]
     public function testTwoRows(): void
     {
         $this->assertSame([[1], [1, 1]], pascalsTriangleRows(2));
@@ -38,8 +41,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 97206a99-79ba-4b04-b1c5-3c0fa1e16925
-     * @testdox Three rows
      */
+    #[TestDox('Three rows')]
     public function testThreeRows(): void
     {
         $this->assertSame([[1], [1, 1], [1, 2, 1]], pascalsTriangleRows(3));
@@ -47,8 +50,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 565a0431-c797-417c-a2c8-2935e01ce306
-     * @testdox Four rows
      */
+    #[TestDox('Four rows')]
     public function testFourRows(): void
     {
         $this->assertSame([[1], [1, 1], [1, 2, 1], [1, 3, 3, 1]], pascalsTriangleRows(4));
@@ -56,8 +59,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 06f9ea50-9f51-4eb2-b9a9-c00975686c27
-     * @testdox Five rows
      */
+    #[TestDox('Five rows')]
     public function testFiveRows(): void
     {
         $this->assertEquals(
@@ -74,8 +77,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c3912965-ddb4-46a9-848e-3363e6b00b13
-     * @testdox Six rows
      */
+    #[TestDox('Six rows')]
     public function testSixRows(): void
     {
         $this->assertEquals([
@@ -90,8 +93,8 @@ class PascalsTriangleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6cb26c66-7b57-4161-962c-81ec8c99f16b
-     * @testdox Ten rows
      */
+    #[TestDox('Ten rows')]
     public function testTenRows(): void
     {
         $this->assertEquals([

--- a/exercises/practice/perfect-numbers/PerfectNumbersTest.php
+++ b/exercises/practice/perfect-numbers/PerfectNumbersTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class PerfectNumbersTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class PerfectNumbersTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/phone-number/PhoneNumberTest.php
+++ b/exercises/practice/phone-number/PhoneNumberTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class PhoneNumberTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class PhoneNumberTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 79666dce-e0f1-46de-95a1-563802913c35
-     * @testdox cleans the number
      */
+    #[TestDox('cleans the number')]
     public function testCleansTheNumber(): void
     {
         $number = new PhoneNumber('(223) 456-7890');
@@ -21,8 +24,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c360451f-549f-43e4-8aba-fdf6cb0bf83f
-     * @testdox cleans numbers with dots
      */
+    #[TestDox('cleans numbers with dots')]
     public function testCleansTheNumberWithDots(): void
     {
         $number = new PhoneNumber('223.456.7890');
@@ -31,8 +34,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 08f94c34-9a37-46a2-a123-2a8e9727395d
-     * @testdox cleans numbers with multiple spaces
      */
+    #[TestDox('cleans numbers with multiple spaces')]
     public function testCleansTheNumberWithMultipleSpaces(): void
     {
         $number = new PhoneNumber('223 456   7890   ');
@@ -41,8 +44,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2de74156-f646-42b5-8638-0ef1d8b58bc2
-     * @testdox invalid when 9 digits
      */
+    #[TestDox('invalid when 9 digits')]
     public function testInvalidWhen9Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -52,8 +55,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 57061c72-07b5-431f-9766-d97da7c4399d
-     * @testdox invalid when 11 digits does not start with a 1
      */
+    #[TestDox('invalid when 11 digits does not start with a 1')]
     public function testInvalidWhen11DigitsDoesNotStartWithA1(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -64,8 +67,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9962cbf3-97bb-4118-ba9b-38ff49c64430
-     * @testdox valid when 11 digits and starting with 1
      */
+    #[TestDox('valid when 11 digits and starting with 1')]
     public function testValidWhen11DigitsAndStartingWith1(): void
     {
         $number = new PhoneNumber('12234567890');
@@ -74,8 +77,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fa724fbf-054c-4d91-95da-f65ab5b6dbca
-     * @testdox valid when 11 digits and starting with 1 even with punctuation
      */
+    #[TestDox('valid when 11 digits and starting with 1 even with punctuation')]
     public function testValidWhen11DigitsAndStartingWith1EvenWithPunctuation(): void
     {
         $number = new PhoneNumber('+1 (223) 456-7890');
@@ -84,8 +87,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4a1509b7-8953-4eec-981b-c483358ff531
-     * @testdox invalid when more than 11 digits
      */
+    #[TestDox('invalid when more than 11 digits')]
     public function testInvalidWhenMoreThan11Digits(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -95,8 +98,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid eb8a1fc0-64e5-46d3-b0c6-33184208e28a
-     * @testdox invalid with letters
      */
+    #[TestDox('invalid with letters')]
     public function testInvalidWithLetters(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -107,8 +110,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 065f6363-8394-4759-b080-e6c8c351dd1f
-     * @testdox invalid with punctuations
      */
+    #[TestDox('invalid with punctuations')]
     public function testInvalidWithPunctuation(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -119,8 +122,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d77d07f8-873c-4b17-8978-5f66139bf7d7
-     * @testdox invalid if area code starts with 0
      */
+    #[TestDox('invalid if area code starts with 0')]
     public function testInvalidIfAreaCodeStartsWith0(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -131,8 +134,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c7485cfb-1e7b-4081-8e96-8cdb3b77f15e
-     * @testdox invalid if area code starts with 1
      */
+    #[TestDox('invalid if area code starts with 1')]
     public function testInvalidIfAreaCodeStartsWith1(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -143,8 +146,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4d622293-6976-413d-b8bf-dd8a94d4e2ac
-     * @testdox invalid if exchange code starts with 0
      */
+    #[TestDox('invalid if exchange code starts with 0')]
     public function testInvalidIfExchangeCodeStartsWith0(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -155,8 +158,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4cef57b4-7d8e-43aa-8328-1e1b89001262
-     * @testdox invalid if exchange code starts with 1
      */
+    #[TestDox('invalid if exchange code starts with 1')]
     public function testInvalidIfExchangeCodeStartsWith1(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -167,8 +170,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9925b09c-1a0d-4960-a197-5d163cbe308c
-     * @testdox invalid if area code starts with 0 on valid 11-digit number
      */
+    #[TestDox('invalid if area code starts with 0 on valid 11-digit number')]
     public function testInvalidIfAreaCodeStartsWith0OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -179,8 +182,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3f809d37-40f3-44b5-ad90-535838b1a816
-     * @testdox invalid if area code starts with 1 on valid 11-digit number
      */
+    #[TestDox('invalid if area code starts with 1 on valid 11-digit number')]
     public function testInvalidIfAreaCodeStartsWith1OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -191,8 +194,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e08e5532-d621-40d4-b0cc-96c159276b65
-     * @testdox invalid if exchange code starts with 0 on valid 11-digit number
      */
+    #[TestDox('invalid if exchange code starts with 0 on valid 11-digit number')]
     public function testInvalidIfExchangeCodeStartsWith0OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -203,8 +206,8 @@ class PhoneNumberTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 57b32f3d-696a-455c-8bf1-137b6d171cdf
-     * @testdox invalid if exchange code starts with 1 on valid 11-digit number
      */
+    #[TestDox('invalid if exchange code starts with 1 on valid 11-digit number')]
     public function testInvalidIfExchangeCodeStartsWith1OnValid11DigitNumber(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/exercises/practice/pig-latin/PigLatinTest.php
+++ b/exercises/practice/pig-latin/PigLatinTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class PigLatinTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class PigLatinTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 11567f84-e8c6-4918-aedb-435f0b73db57
-     * @testdox ay is added to words that start with vowels -> word beginning with a
      */
+    #[TestDox('ay is added to words that start with vowels -> word beginning with a')]
     public function testWordBeginningWithA(): void
     {
         $this->assertEquals("appleay", translate("apple"));
@@ -20,8 +23,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f623f581-bc59-4f45-9032-90c3ca9d2d90
-     * @testdox ay is added to words that start with vowels -> word beginning with e
      */
+    #[TestDox('ay is added to words that start with vowels -> word beginning with e')]
     public function testWordBeginningWithE(): void
     {
         $this->assertEquals("earay", translate("ear"));
@@ -29,8 +32,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7dcb08b3-23a6-4e8a-b9aa-d4e859450d58
-     * @testdox ay is added to words that start with vowels -> word beginning with i
      */
+    #[TestDox('ay is added to words that start with vowels -> word beginning with i')]
     public function testWordBeginningWithI(): void
     {
         $this->assertEquals("iglooay", translate("igloo"));
@@ -38,8 +41,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0e5c3bff-266d-41c8-909f-364e4d16e09c
-     * @testdox ay is added to words that start with vowels -> word beginning with o
      */
+    #[TestDox('ay is added to words that start with vowels -> word beginning with o')]
     public function testWordBeginningWithO(): void
     {
         $this->assertEquals("objectay", translate("object"));
@@ -47,8 +50,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 614ba363-ca3c-4e96-ab09-c7320799723c
-     * @testdox ay is added to words that start with vowels -> word beginning with u
      */
+    #[TestDox('ay is added to words that start with vowels -> word beginning with u')]
     public function testWordBeginningWithU(): void
     {
         $this->assertEquals("underay", translate("under"));
@@ -56,8 +59,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bf2538c6-69eb-4fa7-a494-5a3fec911326
-     * @testdox ay is added to words that start with vowels -> word beginning with a vowel and followed by a qu
      */
+    #[TestDox('ay is added to words that start with vowels -> word beginning with a vowel and followed by a qu')]
     public function testWordBeginningVowelFollowedByQu(): void
     {
         $this->assertEquals("equalay", translate("equal"));
@@ -65,8 +68,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e5be8a01-2d8a-45eb-abb4-3fcc9582a303
-     * @testdox First letter and ay are moved to the end of words that start with consonants -> word beginning with p
      */
+    #[TestDox('First letter and ay are moved to the end of words that start with consonants -> word beginning with p')]
     public function testWordBeginningWithP(): void
     {
         $this->assertEquals("igpay", translate("pig"));
@@ -74,8 +77,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d36d1e13-a7ed-464d-a282-8820cb2261ce
-     * @testdox First letter and ay are moved to the end of words that start with consonants -> word beginning with k
      */
+    #[TestDox('First letter and ay are moved to the end of words that start with consonants -> word beginning with k')]
     public function testWordBeginningWithK(): void
     {
         $this->assertEquals("oalakay", translate("koala"));
@@ -83,8 +86,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d838b56f-0a89-4c90-b326-f16ff4e1dddc
-     * @testdox First letter and ay are moved to the end of words that start with consonants -> word beginning with x
      */
+    #[TestDox('First letter and ay are moved to the end of words that start with consonants -> word beginning with x')]
     public function testWordBeginningWithX(): void
     {
         $this->assertEquals("enonxay", translate("xenon"));
@@ -92,8 +95,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bce94a7a-a94e-4e2b-80f4-b2bb02e40f71
-     * @testdox First letter and ay are moved to the end of words that start with consonants -> word beginning with q without a following u
      */
+    #[TestDox('First letter and ay are moved to the end of words that start with consonants -> word beginning with q without a following u')]
     public function testWordBeginningWithQWithoutAFollowingU(): void
     {
         $this->assertEquals("atqay", translate("qat"));
@@ -101,8 +104,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e59dbbe8-ccee-4619-a8e9-ce017489bfc0
-     * @testdox First letter and ay are moved to the end of words that start with consonants -> word beginning with consonant and vowel containing qu
      */
+    #[TestDox('First letter and ay are moved to the end of words that start with consonants -> word beginning with consonant and vowel containing qu')]
     public function testWordBeginningWithConsonantAndVowelContainingQu(): void
     {
         $this->assertEquals("iquidlay", translate("liquid"));
@@ -110,8 +113,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c01e049a-e3e2-451c-bf8e-e2abb7e438b8
-     * @testdox Some letter clusters are treated like a single consonant -> word beginning with ch
      */
+    #[TestDox('Some letter clusters are treated like a single consonant -> word beginning with ch')]
     public function testWordBeginningWithCh(): void
     {
         $this->assertEquals("airchay", translate("chair"));
@@ -119,8 +122,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9ba1669e-c43f-4b93-837a-cfc731fd1425
-     * @testdox Some letter clusters are treated like a single consonant -> word beginning with qu
      */
+    #[TestDox('Some letter clusters are treated like a single consonant -> word beginning with qu')]
     public function testWordBeginningWithQu(): void
     {
         $this->assertEquals("eenquay", translate("queen"));
@@ -128,8 +131,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 92e82277-d5e4-43d7-8dd3-3a3b316c41f7
-     * @testdox Some letter clusters are treated like a single consonant -> word beginning with qu and a preceding consonant
      */
+    #[TestDox('Some letter clusters are treated like a single consonant -> word beginning with qu and a preceding consonant')]
     public function testWordBeginningWithQuAndAPrecedingConsonant(): void
     {
         $this->assertEquals("aresquay", translate("square"));
@@ -137,8 +140,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 79ae4248-3499-4d5b-af46-5cb05fa073ac
-     * @testdox Some letter clusters are treated like a single consonant -> word beginning with th
      */
+    #[TestDox('Some letter clusters are treated like a single consonant -> word beginning with th')]
     public function testWordBeginningWithTh(): void
     {
         $this->assertEquals("erapythay", translate("therapy"));
@@ -146,8 +149,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e0b3ae65-f508-4de3-8999-19c2f8e243e1
-     * @testdox Some letter clusters are treated like a single consonant -> word beginning with thr
      */
+    #[TestDox('Some letter clusters are treated like a single consonant -> word beginning with thr')]
     public function testWordBeginningWithThr(): void
     {
         $this->assertEquals("ushthray", translate("thrush"));
@@ -155,8 +158,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 20bc19f9-5a35-4341-9d69-1627d6ee6b43
-     * @testdox Some letter clusters are treated like a single consonant -> word beginning with sch
      */
+    #[TestDox('Some letter clusters are treated like a single consonant -> word beginning with sch')]
     public function testWordBeginningWithSch(): void
     {
         $this->assertEquals("oolschay", translate("school"));
@@ -164,8 +167,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 54b796cb-613d-4509-8c82-8fbf8fc0af9e
-     * @testdox Some letter clusters are treated like a single vowel -> word beginning with yt
      */
+    #[TestDox('Some letter clusters are treated like a single vowel -> word beginning with yt')]
     public function testWordBeginningWithYt(): void
     {
         $this->assertEquals("yttriaay", translate("yttria"));
@@ -173,8 +176,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8c37c5e1-872e-4630-ba6e-d20a959b67f6
-     * @testdox Some letter clusters are treated like a single vowel -> word beginning with xr
      */
+    #[TestDox('Some letter clusters are treated like a single vowel -> word beginning with xr')]
     public function testWordBeginningWithXr(): void
     {
         $this->assertEquals("xrayay", translate("xray"));
@@ -183,8 +186,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a4a36d33-96f3-422c-a233-d4021460ff00
-     * @testdox Position of y in a word determines if it is a consonant or a vowel -> y is treated like a consonant at the beginning of a word
      */
+    #[TestDox('Position of y in a word determines if it is a consonant or a vowel -> y is treated like a consonant at the beginning of a word')]
     public function testWordBeginningWithY(): void
     {
         $this->assertEquals("ellowyay", translate("yellow"));
@@ -192,8 +195,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid adc90017-1a12-4100-b595-e346105042c7
-     * @testdox Position of y in a word determines if it is a consonant or a vowel -> y is treated like a vowel at the end of a consonant cluster
      */
+    #[TestDox('Position of y in a word determines if it is a consonant or a vowel -> y is treated like a vowel at the end of a consonant cluster')]
     public function testWordBeginningWithConsonantClusterThenY(): void
     {
         $this->assertEquals("ythmrhay", translate("rhythm"));
@@ -201,8 +204,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 29b4ca3d-efe5-4a95-9a54-8467f2e5e59a
-     * @testdox Position of y in a word determines if it is a consonant or a vowel -> y as second letter in two letter word
      */
+    #[TestDox('Position of y in a word determines if it is a consonant or a vowel -> y as second letter in two letter word')]
     public function testTwoLetterWordWithY(): void
     {
         $this->assertEquals("ymay", translate("my"));
@@ -211,8 +214,8 @@ class PigLatinTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 44616581-5ce3-4a81-82d0-40c7ab13d2cf
-     * @testdox Phrases are translated -> a whole phrase
      */
+    #[TestDox('Phrases are translated -> a whole phrase')]
     public function testAWholePhrase(): void
     {
         $this->assertEquals("ickquay astfay unray", translate("quick fast run"));

--- a/exercises/practice/poker/Poker.php
+++ b/exercises/practice/poker/Poker.php
@@ -30,6 +30,6 @@ class Poker
 
     public function __construct(array $hands)
     {
-        throw new BadFunctionCallException("Please implement the Poker class!");
+        throw new \BadFunctionCallException("Please implement the Poker class!");
     }
 }

--- a/exercises/practice/poker/PokerTest.php
+++ b/exercises/practice/poker/PokerTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class PokerTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class PokerTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/prime-factors/PrimeFactorsTest.php
+++ b/exercises/practice/prime-factors/PrimeFactorsTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class PrimeFactorsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class PrimeFactorsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/protein-translation/ProteinTranslationTest.php
+++ b/exercises/practice/protein-translation/ProteinTranslationTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ProteinTranslationTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ProteinTranslationTest extends TestCase
 {
     private ProteinTranslation $translator;
 
@@ -18,8 +21,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98
-     * @testdox Empty RNA sequence results in no proteins
      */
+    #[TestDox('Empty RNA sequence results in no proteins')]
     public function testEmptyRnaSequence(): void
     {
         $this->assertEquals([], $this->translator->getProteins(''));
@@ -27,8 +30,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 96d3d44f-34a2-4db4-84cd-fff523e069be
-     * @testdox Methionine RNA sequence
      */
+    #[TestDox('Methionine RNA sequence')]
     public function testMethionineRnaSequence(): void
     {
         $this->assertEquals(['Methionine'], $this->translator->getProteins('AUG'));
@@ -36,8 +39,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1b4c56d8-d69f-44eb-be0e-7b17546143d9
-     * @testdox Phenylalanine RNA sequence 1
      */
+    #[TestDox('Phenylalanine RNA sequence 1')]
     public function testPhenylalanineRnaSequenceOne(): void
     {
         $this->assertEquals(['Phenylalanine'], $this->translator->getProteins('UUU'));
@@ -45,8 +48,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 81b53646-bd57-4732-b2cb-6b1880e36d11
-     * @testdox Phenylalanine RNA sequence 2
      */
+    #[TestDox('Phenylalanine RNA sequence 2')]
     public function testPhenylalanineRnaSequenceTwo(): void
     {
         $this->assertEquals(['Phenylalanine'], $this->translator->getProteins('UUC'));
@@ -54,8 +57,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4
-     * @testdox Leucine RNA sequence 1
      */
+    #[TestDox('Leucine RNA sequence 1')]
     public function testLeucineRnaSequenceOne(): void
     {
         $this->assertEquals(['Leucine'], $this->translator->getProteins('UUA'));
@@ -63,8 +66,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ac5edadd-08ed-40a3-b2b9-d82bb50424c4
-     * @testdox Leucine RNA sequence 2
      */
+    #[TestDox('Leucine RNA sequence 2')]
     public function testLeucineRnaSequenceTwo(): void
     {
         $this->assertEquals(['Leucine'], $this->translator->getProteins('UUG'));
@@ -72,8 +75,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8bc36e22-f984-44c3-9f6b-ee5d4e73f120
-     * @testdox Serine RNA sequence 1
      */
+    #[TestDox('Serine RNA sequence 1')]
     public function testSerineRnaSequenceOne(): void
     {
         $this->assertEquals(['Serine'], $this->translator->getProteins('UCU'));
@@ -81,8 +84,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5c3fa5da-4268-44e5-9f4b-f016ccf90131
-     * @testdox Serine RNA sequence 2
      */
+    #[TestDox('Serine RNA sequence 2')]
     public function testSerineRnaSequenceTwo(): void
     {
         $this->assertEquals(['Serine'], $this->translator->getProteins('UCC'));
@@ -90,8 +93,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 00579891-b594-42b4-96dc-7ff8bf519606
-     * @testdox Serine RNA sequence 3
      */
+    #[TestDox('Serine RNA sequence 3')]
     public function testSerineRnaSequenceThree(): void
     {
         $this->assertEquals(['Serine'], $this->translator->getProteins('UCA'));
@@ -99,8 +102,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 08c61c3b-fa34-4950-8c4a-133945570ef6
-     * @testdox Serine RNA sequence 4
      */
+    #[TestDox('Serine RNA sequence 4')]
     public function testSerineRnaSequenceFour(): void
     {
         $this->assertEquals(['Serine'], $this->translator->getProteins('UCG'));
@@ -108,8 +111,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 54e1e7d8-63c0-456d-91d2-062c72f8eef5
-     * @testdox Tyrosine RNA sequence 1
      */
+    #[TestDox('Tyrosine RNA sequence 1')]
     public function testTyrosineRnaSequenceOne(): void
     {
         $this->assertEquals(['Tyrosine'], $this->translator->getProteins('UAU'));
@@ -117,8 +120,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 47bcfba2-9d72-46ad-bbce-22f7666b7eb1
-     * @testdox Tyrosine RNA sequence 2
      */
+    #[TestDox('Tyrosine RNA sequence 2')]
     public function testTyrosineRnaSequenceTwo(): void
     {
         $this->assertEquals(['Tyrosine'], $this->translator->getProteins('UAC'));
@@ -126,8 +129,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3a691829-fe72-43a7-8c8e-1bd083163f72
-     * @testdoxCysteine RNA sequence 1
      */
+    #[TestDox('Cysteine RNA sequence 1')]
     public function testCysteineRnaSequenceOne(): void
     {
         $this->assertEquals(['Cysteine'], $this->translator->getProteins('UGU'));
@@ -135,8 +138,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1b6f8a26-ca2f-43b8-8262-3ee446021767
-     * @testdox Cysteine RNA sequence 2
      */
+    #[TestDox('Cysteine RNA sequence 2')]
     public function testCysteineRnaSequenceTwo(): void
     {
         $this->assertEquals(['Cysteine'], $this->translator->getProteins('UGC'));
@@ -144,8 +147,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1e91c1eb-02c0-48a0-9e35-168ad0cb5f39
-     * @testdox Tryptophan RNA sequence
      */
+    #[TestDox('Tryptophan RNA sequence')]
     public function testTryptophanRnaSequence(): void
     {
         $this->assertEquals(['Tryptophan'], $this->translator->getProteins('UGG'));
@@ -153,8 +156,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e547af0b-aeab-49c7-9f13-801773a73557
-     * @testdox STOP codon RNA sequence 1
      */
+    #[TestDox('STOP codon RNA sequence 1')]
     public function testStopCodonRnaSequenceOne(): void
     {
         $this->assertEquals([], $this->translator->getProteins('UAA'));
@@ -162,8 +165,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 67640947-ff02-4f23-a2ef-816f8a2ba72e
-     * @testdox STOP codon RNA sequence 2
      */
+    #[TestDox('STOP codon RNA sequence 2')]
     public function testStopCodonRnaSequenceTwo(): void
     {
         $this->assertEquals([], $this->translator->getProteins('UAG'));
@@ -171,8 +174,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9c2ad527-ebc9-4ace-808b-2b6447cb54cb
-     * @testdox STOP codon RNA sequence 3
      */
+    #[TestDox('STOP codon RNA sequence 3')]
     public function testStopCodonRnaSequenceThree(): void
     {
         $this->assertEquals([], $this->translator->getProteins('UGA'));
@@ -180,8 +183,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f4d9d8ee-00a8-47bf-a1e3-1641d4428e54
-     * @testdox Sequence of two protein codons translates into proteins
      */
+    #[TestDox('Sequence of two protein codons translates into proteins')]
     public function testToCodonsTranslateToProteins(): void
     {
         $this->assertEquals(['Phenylalanine', 'Phenylalanine'], $this->translator->getProteins('UUUUUU'));
@@ -189,8 +192,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dd22eef3-b4f1-4ad6-bb0b-27093c090a9d
-     * @testdox Sequence of two different protein codons translates into proteins
      */
+    #[TestDox('Sequence of two different protein codons translates into proteins')]
     public function testToDifferentCodonsTranslateToProteins(): void
     {
         $this->assertEquals(['Leucine', 'Leucine'], $this->translator->getProteins('UUAUUG'));
@@ -198,8 +201,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d0f295df-fb70-425c-946c-ec2ec185388e
-     * @testdox Translate RNA strand into correct protein list
      */
+    #[TestDox('Translate RNA strand into correct protein list')]
     public function testTranslateRnaStrandIntoCorrectProteinList(): void
     {
         $this->assertEquals(
@@ -210,8 +213,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e30e8505-97ec-4e5f-a73e-5726a1faa1f4
-     * @testdox Translation stops if STOP codon at beginning of sequence
      */
+    #[TestDox('Translation stops if STOP codon at beginning of sequence')]
     public function testTranslationStopsIfStopCodonAtBeginningOfSequence(): void
     {
         $this->assertEquals([], $this->translator->getProteins('UAGUGG'));
@@ -219,8 +222,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 5358a20b-6f4c-4893-bce4-f929001710f3
-     * @testdox Translation stops if STOP codon at end of two-codon sequence
      */
+    #[TestDox('Translation stops if STOP codon at end of two-codon sequence')]
     public function testTranslationStopsIfStopCodonAtEndOfTwoCodonSequence(): void
     {
         $this->assertEquals(['Tryptophan'], $this->translator->getProteins('UGGUAG'));
@@ -228,8 +231,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ba16703a-1a55-482f-bb07-b21eef5093a3
-     * @testdox Translation stops if STOP codon at end of three-codon sequence
      */
+    #[TestDox('Translation stops if STOP codon at end of three-codon sequence')]
     public function testTranslationStopsIfStopCodonAtEndOfThreeCodonSequence(): void
     {
         $this->assertEquals(['Methionine', 'Phenylalanine'], $this->translator->getProteins('AUGUUUUAA'));
@@ -237,8 +240,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4089bb5a-d5b4-4e71-b79e-b8d1f14a2911
-     * @testdox Translation stops if STOP codon in middle of three-codon sequence"
      */
+    #[TestDox('Translation stops if STOP codon in middle of three-codon sequence"')]
     public function testTranslationStopsIfStopCodonInMiddleOfThreeCodonSequence(): void
     {
         $this->assertEquals(['Tryptophan'], $this->translator->getProteins('UGGUAGUGG'));
@@ -246,8 +249,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2c2a2a60-401f-4a80-b977-e0715b23b93d
-     * @testdox Translation stops if STOP codon in middle of six-codon sequence
      */
+    #[TestDox('Translation stops if STOP codon in middle of six-codon sequence')]
     public function testTranslationStopsIfStopCodonInMiddleOfSixCodonSequence(): void
     {
         $this->assertEquals(
@@ -258,8 +261,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f6f92714-769f-4187-9524-e353e8a41a80
-     * @testdox Sequence of two non-STOP codons does not translate to a STOP codon
      */
+    #[TestDox('Sequence of two non-STOP codons does not translate to a STOP codon')]
     public function testSequenceOfTwoNonStopCodonsDoesNotTranslateToAStopCodon(): void
     {
         $this->assertEquals(
@@ -270,8 +273,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9eac93f3-627a-4c90-8653-6d0a0595bc6f
-     * @testdox Unknown amino acids, not part of a codon, can't translate
      */
+    #[TestDox("Unknown amino acids, not part of a codon, can't translate")]
     public function testUnknownAminoAcidsCantTranslate(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -282,8 +285,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9d73899f-e68e-4291-b1e2-7bf87c00f024
-     * @testdox Incomplete RNA sequence can't translate
      */
+    #[TestDox("Incomplete RNA sequence can't translate")]
     public function testIncompleteRnaSequenceCantTranslate(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -293,8 +296,8 @@ class ProteinTranslationTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 43945cf7-9968-402d-ab9f-b8a28750b050
-     * @testdox Incomplete RNA sequence can translate if valid until a STOP codon
      */
+    #[TestDox('Incomplete RNA sequence can translate if valid until a STOP codon')]
     public function testIncompleteRnaSequenceCanTranslateIfValidUntilStop(): void
     {
         $this->assertEquals(['Phenylalanine', 'Phenylalanine'], $this->translator->getProteins('UUCUUCUAAUGGU'));

--- a/exercises/practice/proverb/ProverbTest.php
+++ b/exercises/practice/proverb/ProverbTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class ProverbTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ProverbTest extends TestCase
 {
     private Proverb $proverb;
 

--- a/exercises/practice/queen-attack/QueenAttackTest.php
+++ b/exercises/practice/queen-attack/QueenAttackTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class QueenAttackTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class QueenAttackTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
+++ b/exercises/practice/rail-fence-cipher/RailFenceCipherTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class RailFenceCipherTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class RailFenceCipherTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/raindrops/RaindropsTest.php
+++ b/exercises/practice/raindrops/RaindropsTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class RaindropsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class RaindropsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1575d549-e502-46d4-a8e1-6b7bec6123d8
-     * @testdox Sound for 1 is 1
      */
+    #[TestDox('Sound for 1 is 1')]
     public function testSoundFor1Is1(): void
     {
         $this->assertSame("1", raindrops(1));
@@ -20,8 +23,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1f51a9f9-4895-4539-b182-d7b0a5ab2913
-     * @testdox Sound for 3 is Pling
      */
+    #[TestDox('Sound for 3 is Pling')]
     public function testSoundFor3IsPling(): void
     {
         $this->assertSame("Pling", raindrops(3));
@@ -29,8 +32,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0
-     * @testdox Sound for 5 is Plang
      */
+    #[TestDox('Sound for 5 is Plang')]
     public function testSoundFor5IsPlang(): void
     {
         $this->assertSame("Plang", raindrops(5));
@@ -38,8 +41,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d7e60daa-32ef-4c23-b688-2abff46c4806
-     * @testdox Sound for 7 is Plong
      */
+    #[TestDox('Sound for 7 is Plong')]
     public function testSoundFor7IsPlong(): void
     {
         $this->assertSame("Plong", raindrops(7));
@@ -47,8 +50,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6bb4947b-a724-430c-923f-f0dc3d62e56a
-     * @testdox Sound for 6 is Pling as it has a factor 3
      */
+    #[TestDox('Sound for 6 is Pling as it has a factor 3')]
     public function testSoundFor6IsPling(): void
     {
         $this->assertSame("Pling", raindrops(6));
@@ -56,8 +59,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ce51e0e8-d9d4-446d-9949-96eac4458c2d
-     * @testdox 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
      */
+    #[TestDox('2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base')]
     public function testSoundFor8Is8(): void
     {
         $this->assertSame("8", raindrops(8));
@@ -65,8 +68,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0dd66175-e3e2-47fc-8750-d01739856671
-     * @testdox Sound for 9 is Pling as it has a factor 3
      */
+    #[TestDox('Sound for 9 is Pling as it has a factor 3')]
     public function testSoundFor9IsPling(): void
     {
         $this->assertSame("Pling", raindrops(9));
@@ -74,8 +77,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 022c44d3-2182-4471-95d7-c575af225c96
-     * @testdox Sound for 10 is Plang as it has a factor 5
      */
+    #[TestDox('Sound for 10 is Plang as it has a factor 5')]
     public function testSoundFor10IsPlang(): void
     {
         $this->assertSame("Plang", raindrops(10));
@@ -83,8 +86,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 37ab74db-fed3-40ff-b7b9-04acdfea8edf
-     * @testdox Sound for 14 is Plong as it has a factor of 7
      */
+    #[TestDox('Sound for 14 is Plong as it has a factor of 7')]
     public function testSoundFor14IsPlong(): void
     {
         $this->assertSame("Plong", raindrops(14));
@@ -92,8 +95,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 31f92999-6afb-40ee-9aa4-6d15e3334d0f
-     * @testdox Sound for 15 is PlingPlang as it has factors 3 and 5
      */
+    #[TestDox('Sound for 15 is PlingPlang as it has factors 3 and 5')]
     public function testSoundFor15IsPlingPlang(): void
     {
         $this->assertSame("PlingPlang", raindrops(15));
@@ -101,8 +104,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ff9bb95d-6361-4602-be2c-653fe5239b54
-     * @testdox Sound for 21 is PlingPlong as it has factors 3 and 7
      */
+    #[TestDox('Sound for 21 is PlingPlong as it has factors 3 and 7')]
     public function testSoundFor21IsPlingPlong(): void
     {
         $this->assertSame("PlingPlong", raindrops(21));
@@ -110,8 +113,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d2e75317-b72e-40ab-8a64-6734a21dece1
-     * @testdox Sound for 25 is Plang as it has a factor 5
      */
+    #[TestDox('Sound for 25 is Plang as it has a factor 5')]
     public function testSoundFor25IsPlang(): void
     {
         $this->assertSame("Plang", raindrops(25));
@@ -119,8 +122,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a09c4c58-c662-4e32-97fe-f1501ef7125c
-     * @testdox Sound for 27 is Pling as it has a factor 3
      */
+    #[TestDox('Sound for 27 is Pling as it has a factor 3')]
     public function testSoundFor27IsPlang(): void
     {
         $this->assertSame("Pling", raindrops(27));
@@ -128,8 +131,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bdf061de-8564-4899-a843-14b48b722789
-     * @testdox Sound for 35 is PlangPlong as it has factors 5 and 7
      */
+    #[TestDox('Sound for 35 is PlangPlong as it has factors 5 and 7')]
     public function testSoundFor35IsPlangPlong(): void
     {
         $this->assertSame("PlangPlong", raindrops(35));
@@ -137,8 +140,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c4680bee-69ba-439d-99b5-70c5fd1a7a83
-     * @testdox Sound for 49 is Plong as it has a factor 7
      */
+    #[TestDox('Sound for 49 is Plong as it has a factor 7')]
     public function testSoundFor49IsPlong(): void
     {
         $this->assertSame("Plong", raindrops(49));
@@ -146,8 +149,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 17f2bc9a-b65a-4d23-8ccd-266e8c271444
-     * @testdox Sound for 52 is 52
      */
+    #[TestDox('Sound for 52 is 52')]
     public function testSoundFor52Is52(): void
     {
         $this->assertSame("52", raindrops(52));
@@ -155,8 +158,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e46677ed-ff1a-419f-a740-5c713d2830e4
-     * @testdox Sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
      */
+    #[TestDox('Sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7')]
     public function testSoundFor105IsPlingPlangPlong(): void
     {
         $this->assertSame("PlingPlangPlong", raindrops(105));
@@ -164,8 +167,8 @@ class RaindropsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 13c6837a-0fcd-4b86-a0eb-20572f7deb0b
-     * @testdox Sound for 3125 is Plang as it has a factor 5
      */
+    #[TestDox('Sound for 3125 is Plang as it has a factor 5')]
     public function testSoundFor3125IsPlang(): void
     {
         $this->assertSame("Plang", raindrops(3125));

--- a/exercises/practice/resistor-color-duo/ResistorColorDuoTest.php
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuoTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class ResistorColorDuoTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResistorColorDuoTest extends TestCase
 {
     private ResistorColorDuo $resistor;
 

--- a/exercises/practice/resistor-color-trio/ResistorColorTrioTest.php
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrioTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class ResistorColorTrioTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResistorColorTrioTest extends TestCase
 {
     private ResistorColorTrio $resistor;
 

--- a/exercises/practice/resistor-color/ResistorColorTest.php
+++ b/exercises/practice/resistor-color/ResistorColorTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class ResistorColorTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResistorColorTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/reverse-string/ReverseString.php
+++ b/exercises/practice/reverse-string/ReverseString.php
@@ -26,5 +26,5 @@ declare(strict_types=1);
 
 function reverseString(string $text): string
 {
-    throw new BadFunctionCallException("Please implement the reverseString method!");
+    throw new \BadFunctionCallException("Please implement the reverseString method!");
 }

--- a/exercises/practice/reverse-string/ReverseStringTest.php
+++ b/exercises/practice/reverse-string/ReverseStringTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ReverseStringTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ReverseStringTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,17 +14,15 @@ class ReverseStringTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c3b7d806-dced-49ee-8543-933fd1719b1c
-     * @testdox an empty string
      */
+    #[TestDox('an empty string')]
     public function testEmptyString(): void
     {
         $this->assertEquals("", reverseString(""));
     }
 
-    /**
-     * @testdox a word
-     * uudi 01ebf55b-bebb-414e-9dec-06f7bb0bee3c
-     */
+    /** uuid 01ebf55b-bebb-414e-9dec-06f7bb0bee3c */
+    #[TestDox('a word')]
     public function testWord(): void
     {
         $this->assertEquals("tobor", reverseString("robot"));
@@ -29,8 +30,8 @@ class ReverseStringTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 0f7c07e4-efd1-4aaa-a07a-90b49ce0b746
-     * @testdox a capitalized word
      */
+    #[TestDox('a capitalized word')]
     public function testCapitalizedWord(): void
     {
         $this->assertEquals("nemaR", reverseString("Ramen"));
@@ -38,8 +39,8 @@ class ReverseStringTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 71854b9c-f200-4469-9f5c-1e8e5eff5614
-     * @testdox a sentence with punctuation
      */
+    #[TestDox('a sentence with punctuation')]
     public function testSentenceWithPunctuation(): void
     {
         $this->assertEquals("!yrgnuh m'I", reverseString("I'm hungry!"));
@@ -47,8 +48,8 @@ class ReverseStringTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c
-     * @testdox a palindrome
      */
+    #[TestDox('a palindrome')]
     public function testPalindrome(): void
     {
         $this->assertEquals("racecar", reverseString("racecar"));
@@ -56,8 +57,8 @@ class ReverseStringTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c
-     * @testdox an even-sized word
      */
+    #[TestDox('an even-sized word')]
     public function testEvenSizedWord(): void
     {
         $this->assertEquals("reward", reverseString("drawer"));

--- a/exercises/practice/rna-transcription/RnaTranscriptionTest.php
+++ b/exercises/practice/rna-transcription/RnaTranscriptionTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class RnaTranscriptionTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b4631f82-c98c-4a2f-90b3-c5c2b6c6f661
-     * @testdox It handles an empty string
      */
+    #[TestDox('It handles an empty string')]
     public function testHandlesEmptyString(): void
     {
         $this->assertSame('', toRna(''));
@@ -20,8 +23,8 @@ class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a9558a3c-318c-4240-9256-5d5ed47005a6
-     * @testdox It transcribes guanine to cytosine
      */
+    #[TestDox('It transcribes guanine to cytosine')]
     public function testTranscribesGuanineToCytosine(): void
     {
         $this->assertSame('G', toRna('C'));
@@ -29,8 +32,8 @@ class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7
-     * @testdox It transcribes cytosine to guanine
      */
+    #[TestDox('It transcribes cytosine to guanine')]
     public function testTranscribesCytosineToGuanine(): void
     {
         $this->assertSame('C', toRna('G'));
@@ -38,8 +41,8 @@ class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 870bd3ec-8487-471d-8d9a-a25046488d3e
-     * @testdox It transcribes thymine to adenine
      */
+    #[TestDox('It transcribes thymine to adenine')]
     public function testTranscribesThymineToAdenine(): void
     {
         $this->assertSame('A', toRna('T'));
@@ -47,8 +50,8 @@ class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid aade8964-02e1-4073-872f-42d3ffd74c5f
-     * @testdox It transcribes adenine to uracil
      */
+    #[TestDox('It transcribes adenine to uracil')]
     public function testTranscribesAdenineToUracil(): void
     {
         $this->assertSame('U', toRna('A'));
@@ -56,8 +59,8 @@ class RnaTranscriptionTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 79ed2757-f018-4f47-a1d7-34a559392dbf
-     * @testdox RNA complement
      */
+    #[TestDox('RNA complement')]
     public function testTranscribesAllOccurrencesOne(): void
     {
         $this->assertSame('UGCACCAGAAUU', toRna('ACGTGGTCTTAA'));

--- a/exercises/practice/robot-name/RobotNameTest.php
+++ b/exercises/practice/robot-name/RobotNameTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class RobotNameTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class RobotNameTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/robot-simulator/RobotSimulatorTest.php
+++ b/exercises/practice/robot-simulator/RobotSimulatorTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class RobotSimulatorTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class RobotSimulatorTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: c557c16d-26c1-4e06-827c-f6602cd0785c
-     * @testdox Create robot - at origin facing north
      */
+    #[TestDox('Create robot - at origin facing north')]
     public function testCreateRobotAtOriginFacingNorth(): void
     {
         $robot = new RobotSimulator([0, 0], 'north');
@@ -22,8 +25,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d
-     * @testdox Create robot - at negative position facing south
      */
+    #[TestDox('Create robot - at negative position facing south')]
     public function testCreateRobotAtNegativePositionFacingSouth(): void
     {
         $robot = new RobotSimulator([-1, -1], 'south');
@@ -33,8 +36,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8cbd0086-6392-4680-b9b9-73cf491e67e5
-     * @testdox Rotating clockwise - changes north to east
      */
+    #[TestDox('Rotating clockwise - changes north to east')]
     public function testRotatingClockwiseChangesNorthToEast(): void
     {
         $robot = new RobotSimulator([0, 0], 'north');
@@ -45,8 +48,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 8abc87fc-eab2-4276-93b7-9c009e866ba1
-     * @testdox Rotating clockwise - changes east to south
      */
+    #[TestDox('Rotating clockwise - changes east to south')]
     public function testRotatingClockwiseChangesEastToSouth(): void
     {
         $robot = new RobotSimulator([0, 0], 'east');
@@ -57,8 +60,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3cfe1b85-bbf2-4bae-b54d-d73e7e93617a
-     * @testdox Rotating clockwise - changes south to west
      */
+    #[TestDox('Rotating clockwise - changes south to west')]
     public function testRotatingClockwiseChangesSouthToWest(): void
     {
         $robot = new RobotSimulator([0, 0], 'south');
@@ -69,8 +72,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716
-     * @testdox Rotating clockwise - changes west to north
      */
+    #[TestDox('Rotating clockwise - changes west to north')]
     public function testRotatingClockwiseChangesWestToNorth(): void
     {
         $robot = new RobotSimulator([0, 0], 'west');
@@ -81,8 +84,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63
-     * @testdox Rotating counter-clockwise - changes north to west
      */
+    #[TestDox('Rotating counter-clockwise - changes north to west')]
     public function testRotatingCounterClockwiseChangesNorthToWest(): void
     {
         $robot = new RobotSimulator([0, 0], 'north');
@@ -93,8 +96,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: da33d734-831f-445c-9907-d66d7d2a92e2
-     * @testdox Rotating counter-clockwise - changes west to south
      */
+    #[TestDox('Rotating counter-clockwise - changes west to south')]
     public function testRotatingCounterClockwiseChangesWestToSouth(): void
     {
         $robot = new RobotSimulator([0, 0], 'west');
@@ -105,8 +108,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bd1ca4b9-4548-45f4-b32e-900fc7c19389
-     * @testdox Rotating counter-clockwise - changes south to east
      */
+    #[TestDox('Rotating counter-clockwise - changes south to east')]
     public function testRotatingCounterClockwiseChangesSouthToEast(): void
     {
         $robot = new RobotSimulator([0, 0], 'south');
@@ -117,8 +120,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2de27b67-a25c-4b59-9883-bc03b1b55bba
-     * @testdox Rotating counter-clockwise - changes east to north
      */
+    #[TestDox('Rotating counter-clockwise - changes east to north')]
     public function testRotatingCounterClockwiseChangesEastToNorth(): void
     {
         $robot = new RobotSimulator([0, 0], 'east');
@@ -129,8 +132,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8
-     * @testdox Moving forward one - facing north increments Y
      */
+    #[TestDox('Moving forward one - facing north increments Y')]
     public function testMovingForwardOneFacingNorthIncrementsY(): void
     {
         $robot = new RobotSimulator([0, 0], 'north');
@@ -141,8 +144,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2786cf80-5bbf-44b0-9503-a89a9c5789da
-     * @testdox Moving forward one - facing south decrements Y
      */
+    #[TestDox('Moving forward one - facing south decrements Y')]
     public function testMovingForwardOneFacingSouthDecrementsY(): void
     {
         $robot = new RobotSimulator([0, 0], 'south');
@@ -153,8 +156,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 84bf3c8c-241f-434d-883d-69817dbd6a48
-     * @testdox Moving forward one - facing east increments X
      */
+    #[TestDox('Moving forward one - facing east increments X')]
     public function testMovingForwardOneFacingEastIncrementsX(): void
     {
         $robot = new RobotSimulator([0, 0], 'east');
@@ -165,8 +168,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: bb69c4a7-3bbf-4f64-b415-666fa72d7b04
-     * @testdox Moving forward one - facing west decrements X
      */
+    #[TestDox('Moving forward one - facing west decrements X')]
     public function testMovingForwardOneFacingWestDecrementsX(): void
     {
         $robot = new RobotSimulator([0, 0], 'west');
@@ -177,8 +180,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e34ac672-4ed4-4be3-a0b8-d9af259cbaa1
-     * @testdox Follow series of instructions - moving east and north from instructions
      */
+    #[TestDox('Follow series of instructions - moving east and north from instructions')]
     public function testFollowSeriesOfInstructionsMovingEastAndNorthFromInstructions(): void
     {
         $robot = new RobotSimulator([7, 3], 'north');
@@ -189,8 +192,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: f30e4955-4b47-4aa3-8b39-ae98cfbd515b
-     * @testdox Follow series of instructions - moving west and north
      */
+    #[TestDox('Follow series of instructions - moving west and north')]
     public function testFollowSeriesOfInstructionsMovingWestAndNorth(): void
     {
         $robot = new RobotSimulator([0, 0], 'north');
@@ -201,8 +204,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3e466bf6-20ab-4d79-8b51-264165182fca
-     * @testdox Follow series of instructions - moving west and south
      */
+    #[TestDox('Follow series of instructions - moving west and south')]
     public function testFollowSeriesOfInstructionsMovingWestAndSouth(): void
     {
         // Instructions to move west and south
@@ -214,8 +217,8 @@ class RobotSimulatorTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 41f0bb96-c617-4e6b-acff-a4b279d44514
-     * @testdox Follow series of instructions - moving east and north
      */
+    #[TestDox('Follow series of instructions - moving east and north')]
     public function testFollowSeriesOfInstructionsMovingEastAndNorth(): void
     {
         // Instructions to move east and north

--- a/exercises/practice/roman-numerals/RomanNumeralsTest.php
+++ b/exercises/practice/roman-numerals/RomanNumeralsTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class RomanNumeralsTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class RomanNumeralsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 19828a3a-fbf7-4661-8ddd-cbaeee0e2178
-     * @testdox 1 is I
      */
+    #[TestDox('1 is I')]
     public function test1IsI(): void
     {
         $this->assertSame('I', toRoman(1));
@@ -20,8 +23,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f088f064-2d35-4476-9a41-f576da3f7b03
-     * @testdox 2 is II
      */
+    #[TestDox('2 is II')]
     public function test2IsII(): void
     {
         $this->assertSame('II', toRoman(2));
@@ -29,8 +32,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b374a79c-3bea-43e6-8db8-1286f79c7106
-     * @testdox 3 is III
      */
+    #[TestDox('3 is III')]
     public function test3IsIII(): void
     {
         $this->assertSame('III', toRoman(3));
@@ -38,8 +41,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 05a0a1d4-a140-4db1-82e8-fcc21fdb49bb
-     * @testdox 4 is IV
      */
+    #[TestDox('4 is IV')]
     public function test4IsIV(): void
     {
         $this->assertSame('IV', toRoman(4));
@@ -47,8 +50,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 57c0f9ad-5024-46ab-975d-de18c430b290
-     * @testdox 5 is V
      */
+    #[TestDox('5 is V')]
     public function test5IsV(): void
     {
         $this->assertSame('V', toRoman(5));
@@ -56,8 +59,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 20a2b47f-e57f-4797-a541-0b3825d7f249
-     * @testdox 6 is VI
      */
+    #[TestDox('6 is VI')]
     public function test6IsVI(): void
     {
         $this->assertSame('VI', toRoman(6));
@@ -65,8 +68,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ff3fb08c-4917-4aab-9f4e-d663491d083d
-     * @testdox 9 is IX
      */
+    #[TestDox('9 is IX')]
     public function test9IsIX(): void
     {
         $this->assertSame('IX', toRoman(9));
@@ -74,8 +77,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6d1d82d5-bf3e-48af-9139-87d7165ed509
-     * @testdox 16 is XVI
      */
+    #[TestDox('16 is XVI')]
     public function test16IsXVI(): void
     {
         $this->assertSame('XVI', toRoman(16));
@@ -83,8 +86,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2bda64ca-7d28-4c56-b08d-16ce65716cf6
-     * @testdox 27 is XXVII
      */
+    #[TestDox('27 is XXVII')]
     public function test27IsXXVII(): void
     {
         $this->assertSame('XXVII', toRoman(27));
@@ -92,8 +95,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid a1f812ef-84da-4e02-b4f0-89c907d0962c
-     * @testdox 48 is XLVIII
      */
+    #[TestDox('48 is XLVIII')]
     public function test48IsXLVIII(): void
     {
         $this->assertSame('XLVIII', toRoman(48));
@@ -101,8 +104,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 607ead62-23d6-4c11-a396-ef821e2e5f75
-     * @testdox 49 is XLIX
      */
+    #[TestDox('49 is XLIX')]
     public function test49IsXLIX(): void
     {
         $this->assertSame('XLIX', toRoman(49));
@@ -110,8 +113,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d5b283d4-455d-4e68-aacf-add6c4b51915
-     * @testdox 59 is LIX
      */
+    #[TestDox('59 is LIX')]
     public function test59IsLIX(): void
     {
         $this->assertSame('LIX', toRoman(59));
@@ -119,8 +122,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4465ffd5-34dc-44f3-ada5-56f5007b6dad
-     * @testdox 66 is LXVI
      */
+    #[TestDox('66 is LXVI')]
     public function test66IsLXVI(): void
     {
         $this->assertSame('LXVI', toRoman(66));
@@ -128,8 +131,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 46b46e5b-24da-4180-bfe2-2ef30b39d0d0
-     * @testdox 93 is XCIII
      */
+    #[TestDox('93 is XCIII')]
     public function test93IsXCIII(): void
     {
         $this->assertSame('XCIII', toRoman(93));
@@ -137,8 +140,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 30494be1-9afb-4f84-9d71-db9df18b55e3
-     * @testdox 141 is CXLI
      */
+    #[TestDox('141 is CXLI')]
     public function test141IsCXLI(): void
     {
         $this->assertSame('CXLI', toRoman(141));
@@ -146,8 +149,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 267f0207-3c55-459a-b81d-67cec7a46ed9
-     * @testdox 163 is CLXIII
      */
+    #[TestDox('163 is CLXIII')]
     public function test163IsCLXIII(): void
     {
         $this->assertSame('CLXIII', toRoman(163));
@@ -155,8 +158,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 902ad132-0b4d-40e3-8597-ba5ed611dd8d
-     * @testdox 166 is CLXVI
      */
+    #[TestDox('166 is CLXVI')]
     public function test166IsCLXVI(): void
     {
         $this->assertSame('CLXVI', toRoman(166));
@@ -164,8 +167,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cdb06885-4485-4d71-8bfb-c9d0f496b404
-     * @testdox 402 is CDII
      */
+    #[TestDox('402 is CDII')]
     public function test402IsCDII(): void
     {
         $this->assertSame('CDII', toRoman(402));
@@ -173,8 +176,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 6b71841d-13b2-46b4-ba97-dec28133ea80
-     * @testdox 575 is DLXXV
      */
+    #[TestDox('575 is DLXXV')]
     public function test575IsDLXXV(): void
     {
         $this->assertSame('DLXXV', toRoman(575));
@@ -182,8 +185,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dacb84b9-ea1c-4a61-acbb-ce6b36674906
-     * @testdox 666 is DCLXVI
      */
+    #[TestDox('666 is DCLXVI')]
     public function test666IsDCLXVI(): void
     {
         $this->assertSame('DCLXVI', toRoman(666));
@@ -191,8 +194,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 432de891-7fd6-4748-a7f6-156082eeca2f
-     * @testdox 911 is CMXI
      */
+    #[TestDox('911 is CMXI')]
     public function test911IsCMXI(): void
     {
         $this->assertSame('CMXI', toRoman(911));
@@ -200,8 +203,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e6de6d24-f668-41c0-88d7-889c0254d173
-     * @testdox 1024 is MXXIV
      */
+    #[TestDox('1024 is MXXIV')]
     public function test1024IsMXXIV(): void
     {
         $this->assertSame('MXXIV', toRoman(1024));
@@ -209,8 +212,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid efbe1d6a-9f98-4eb5-82bc-72753e3ac328
-     * @testdox 1666 is MDCLXVI
      */
+    #[TestDox('1666 is MDCLXVI')]
     public function test1666IsMDCLXVI(): void
     {
         $this->assertSame('MDCLXVI', toRoman(1666));
@@ -218,8 +221,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid bb550038-d4eb-4be2-a9ce-f21961ac3bc6
-     * @testdox 3000 is MMM
      */
+    #[TestDox('3000 is MMM')]
     public function test3000IsMMM(): void
     {
         $this->assertSame('MMM', toRoman(3000));
@@ -227,8 +230,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3bc4b41c-c2e6-49d9-9142-420691504336
-     * @testdox 3001 is MMMI
      */
+    #[TestDox('3001 is MMMI')]
     public function test3001IsMMMI(): void
     {
         $this->assertSame('MMMI', toRoman(3001));
@@ -236,8 +239,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 2f89cad7-73f6-4d1b-857b-0ef531f68b7e
-     * @testdox 3888 is MMMDCCCLXXXVIII
      */
+    #[TestDox('3888 is MMMDCCCLXXXVIII')]
     public function test3888IsMMMDCCCLXXXVIII(): void
     {
         $this->assertSame('MMMDCCCLXXXVIII', toRoman(3888));
@@ -245,8 +248,8 @@ class RomanNumeralsTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4e18e96b-5fbb-43df-a91b-9cb511fe0856
-     * @testdox 3999 is MMMCMXCIX
      */
+    #[TestDox('3999 is MMMCMXCIX')]
     public function test3999IsMMMCMXCIX(): void
     {
         $this->assertSame('MMMCMXCIX', toRoman(3999));

--- a/exercises/practice/rotational-cipher/RotationalCipherTest.php
+++ b/exercises/practice/rotational-cipher/RotationalCipherTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class RotationalCipherTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class RotationalCipherTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 74e58a38-e484-43f1-9466-877a7515e10f
-     * @testdox Rotate a by 0, same output as input
      */
+    #[TestDox('Rotate a by 0, same output as input')]
     public function testRotateAByZero(): void
     {
         $expected = 'a';
@@ -25,8 +28,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7ee352c6-e6b0-4930-b903-d09943ecb8f5
-     * @testdox Rotate a by 1
      */
+    #[TestDox('Rotate a by 1')]
     public function testRotateAByOne(): void
     {
         $expected = 'b';
@@ -39,8 +42,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: edf0a733-4231-4594-a5ee-46a4009ad764
-     * @testdox Rotate a by 26, same output as input
      */
+    #[TestDox('Rotate a by 26, same output as input')]
     public function testRotateABy26(): void
     {
         $expected = 'a';
@@ -53,8 +56,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: e3e82cb9-2a5b-403f-9931-e43213879300
-     * @testdox Rotate m by 13
      */
+    #[TestDox('Rotate m by 13')]
     public function testRotateMBy13(): void
     {
         $expected = 'z';
@@ -67,8 +70,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 19f9eb78-e2ad-4da4-8fe3-9291d47c1709
-     * @testdox Rotate n by 13 with wrap around alphabet
      */
+    #[TestDox('Rotate n by 13 with wrap around alphabet')]
     public function testRotateNBy13WithWrapAroundAlphabet(): void
     {
         $expected = 'a';
@@ -81,8 +84,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a116aef4-225b-4da9-884f-e8023ca6408a
-     * @testdox Rotate capital letters
      */
+    #[TestDox('Rotate capital letters')]
     public function testRotateCapitalLetters(): void
     {
         $expected = 'TRL';
@@ -95,8 +98,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 71b541bb-819c-4dc6-a9c3-132ef9bb737b
-     * @testdox Rotate spaces
      */
+    #[TestDox('Rotate spaces')]
     public function testRotateSpaces(): void
     {
         $expected = 'T R L';
@@ -109,8 +112,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ef32601d-e9ef-4b29-b2b5-8971392282e6
-     * @testdox Rotate numbers
      */
+    #[TestDox('Rotate numbers')]
     public function testRotateNumbers(): void
     {
         $expected = 'Xiwxmrk 1 2 3 xiwxmrk';
@@ -123,8 +126,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 32dd74f6-db2b-41a6-b02c-82eb4f93e549
-     * @testdox Rotate punctuation
      */
+    #[TestDox('Rotate punctuation')]
     public function testRotatePunctuation(): void
     {
         $expected = "Gzo'n zvo, Bmviyhv!";
@@ -137,8 +140,8 @@ class RotationalCipherTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9
-     * @testdox Rotate all letters
      */
+    #[TestDox('Rotate all letters')]
     public function testRotateAllLetters(): void
     {
         $expected = 'Gur dhvpx oebja sbk whzcf bire gur ynml qbt.';

--- a/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
+++ b/exercises/practice/run-length-encoding/RunLengthEncodingTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class RunLengthEncodingTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ad53b61b-6ffc-422f-81a6-61f7df92a231
-     * @testdox Run-length encode a string - empty string
      */
+    #[TestDox('Run-length encode a string - empty string')]
     public function testEncodeEmptyString(): void
     {
         $this->assertEquals(
@@ -23,8 +26,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 52012823-b7e6-4277-893c-5b96d42f82de
-     * @testdox Run-length encode a string - single characters only are encoded without count
      */
+    #[TestDox('Run-length encode a string - single characters only are encoded without count')]
     public function testEncodeSingleCharactersOnlyAreEncodedWithoutCount(): void
     {
         $this->assertEquals(
@@ -35,8 +38,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b7868492-7e3a-415f-8da3-d88f51f80409
-     * @testdox Run-length encode a string - string with no single characters
      */
+    #[TestDox('Run-length encode a string - string with no single characters')]
     public function testEncodeStringWithNoSingleCharacters(): void
     {
         $this->assertEquals(
@@ -47,8 +50,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 859b822b-6e9f-44d6-9c46-6091ee6ae358
-     * @testdox Run-length encode a string - single characters mixed with repeated characters
      */
+    #[TestDox('Run-length encode a string - single characters mixed with repeated characters')]
     public function testEncodeSingleCharactersMixedWithRepeatedCharacters(): void
     {
         $this->assertEquals(
@@ -59,8 +62,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 1b34de62-e152-47be-bc88-469746df63b3
-     * @testdox Run-length encode a string - multiple whitespace mixed in string
      */
+    #[TestDox('Run-length encode a string - multiple whitespace mixed in string')]
     public function testEncodeMultipleWhitespaceMixedInString(): void
     {
         $this->assertEquals(
@@ -71,8 +74,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: abf176e2-3fbd-40ad-bb2f-2dd6d4df721a
-     * @testdox Run-length encode a string - lowercase characters
      */
+    #[TestDox('Run-length encode a string - lowercase characters')]
     public function testEncodeLowercaseCharacters(): void
     {
         $this->assertEquals(
@@ -83,8 +86,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 7ec5c390-f03c-4acf-ac29-5f65861cdeb5
-     * @testdox Run-length decode a string - empty string
      */
+    #[TestDox('Run-length decode a string - empty string')]
     public function testDecodeEmptyString(): void
     {
         $this->assertEquals(
@@ -95,8 +98,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ad23f455-1ac2-4b0e-87d0-b85b10696098
-     * @testdox Run-length decode a string - single characters only
      */
+    #[TestDox('Run-length decode a string - single characters only')]
     public function testDecodeSingleCharactersOnly(): void
     {
         $this->assertEquals(
@@ -106,8 +109,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
     }
     /**
      * uuid: 21e37583-5a20-4a0e-826c-3dee2c375f54
-     * @testdox Run-length decode a string - string with no single characters
      */
+    #[TestDox('Run-length decode a string - string with no single characters')]
     public function testDecodeStringWithNoSingleCharacters(): void
     {
         $this->assertEquals(
@@ -117,8 +120,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
     }
     /**
      * uuid: 1389ad09-c3a8-4813-9324-99363fba429c
-     * @testdox Run-length decode a string - single characters with repeated characters
      */
+    #[TestDox('Run-length decode a string - single characters with repeated characters')]
     public function testDecodeSingleCharactersWithRepeatedCharacters(): void
     {
         $this->assertEquals(
@@ -128,8 +131,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
     }
     /**
      * uuid: 3f8e3c51-6aca-4670-b86c-a213bf4706b0
-     * @testdox Run-length decode a string - multiple whitespace mixed in string
      */
+    #[TestDox('Run-length decode a string - multiple whitespace mixed in string')]
     public function testDecodeMultipleWhitespaceMixedInString(): void
     {
         $this->assertEquals(
@@ -139,8 +142,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
     }
     /**
      * uuid: 29f721de-9aad-435f-ba37-7662df4fb551
-     * @testdox Run-length decode a string - lowercase string
      */
+    #[TestDox('Run-length decode a string - lowercase string')]
     public function testDecodeLowercaseString(): void
     {
         $this->assertEquals(
@@ -150,8 +153,8 @@ class RunLengthEncodingTest extends PHPUnit\Framework\TestCase
     }
     /**
      * uuid: 2a762efd-8695-4e04-b0d6-9736899fbc16
-     * @testdox encode followed by decode gives original string
      */
+    #[TestDox('encode followed by decode gives original string')]
     public function testEncodeFollowedByDecodeGivesOriginalString(): void
     {
         $this->assertEquals(

--- a/exercises/practice/say/SayTest.php
+++ b/exercises/practice/say/SayTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class SayTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SayTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -125,7 +127,7 @@ class SayTest extends PHPUnit\Framework\TestCase
 
     public function testNumbersBelowZeroAreOutOfRange(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Input out of range');
 
         say(-1);
@@ -133,7 +135,7 @@ class SayTest extends PHPUnit\Framework\TestCase
 
     public function testNumbersAbove999999999999AreOutOfRange(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Input out of range');
 
         say(1_000_000_000_000);

--- a/exercises/practice/scale-generator/ScaleGenerator.php
+++ b/exercises/practice/scale-generator/ScaleGenerator.php
@@ -28,6 +28,6 @@ class Scale
 {
     public function __construct(string $tonic, string $scaleName, string $pattern)
     {
-        throw new BadFunctionCallException("Please implement the Scale class!");
+        throw new \BadFunctionCallException("Please implement the Scale class!");
     }
 }

--- a/exercises/practice/scale-generator/ScaleGeneratorTest.php
+++ b/exercises/practice/scale-generator/ScaleGeneratorTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class ScaleGeneratorTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class ScaleGeneratorTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/scrabble-score/ScrabbleScoreTest.php
+++ b/exercises/practice/scrabble-score/ScrabbleScoreTest.php
@@ -2,10 +2,13 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
 /**
  * Calculate the value of scrabble score for a given word.
  */
-class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
+class ScrabbleScoreTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -14,8 +17,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f46cda29-1ca5-4ef2-bd45-388a767e3db2
-     * @testdox Lowercase letter
      */
+    #[TestDox('Lowercase letter')]
     public function testLowercaseSingleLetter(): void
     {
         $word = 'a';
@@ -24,8 +27,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f7794b49-f13e-45d1-a933-4e48459b2201
-     * @testdox Uppercase letter
      */
+    #[TestDox('Uppercase letter')]
     public function testUppercaseSingleLetter(): void
     {
         $word = 'A';
@@ -34,8 +37,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa
-     * @testdox Valuable letter
      */
+    #[TestDox('Valuable letter')]
     public function testValuableSingleLetter(): void
     {
         $word = 'f';
@@ -44,8 +47,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f3c8c94e-bb48-4da2-b09f-e832e103151e
-     * @testdox Short word
      */
+    #[TestDox('Short word')]
     public function testShortWord(): void
     {
         $word = 'at';
@@ -54,8 +57,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 71e3d8fa-900d-4548-930e-68e7067c4615
-     * @testdox Short, valuable word
      */
+    #[TestDox('Short, valuable word')]
     public function testShortValuableWord(): void
     {
         $word = 'zoo';
@@ -64,8 +67,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d3088ad9-570c-4b51-8764-c75d5a430e99
-     * @testdox Medium word
      */
+    #[TestDox('Medium word')]
     public function testMediumWord(): void
     {
         $word = 'street';
@@ -74,8 +77,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fa20c572-ad86-400a-8511-64512daac352
-     * @testdox Medium, valuable word
      */
+    #[TestDox('Medium, valuable word')]
     public function testMediumValuableWord(): void
     {
         $word = 'quirky';
@@ -84,8 +87,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967
-     * @testdox Long, mixed-case word
      */
+    #[TestDox('Long, mixed-case word')]
     public function testLongMixedCaseWord(): void
     {
         $word = 'OxyphenButazone';
@@ -94,8 +97,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1e34e2c3-e444-4ea7-b598-3c2b46fd2c10
-     * @testdox English-like word
      */
+    #[TestDox('English-like word')]
     public function testEnglishLikeWord(): void
     {
         $word = 'pinata';
@@ -104,8 +107,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 4efe3169-b3b6-4334-8bae-ff4ef24a7e4f
-     * @testdox Empty input
      */
+    #[TestDox('Empty input')]
     public function testEmptyWordScore(): void
     {
         $word = '';
@@ -114,8 +117,8 @@ class ScrabbleScoreTest extends PHPUnit\Framework\TestCase
 
     /*
      * uuid 3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7
-     * @testdox Entire alphabet available
      */
+    #[TestDox('Entire alphabet available')]
     public function testEntireAlphabetWord(): void
     {
         $word = 'abcdefghijklmnopqrstuvwxyz';

--- a/exercises/practice/secret-handshake/SecretHandshakeTest.php
+++ b/exercises/practice/secret-handshake/SecretHandshakeTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class SecretHandshakeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class SecretHandshakeTest extends TestCase
 {
     private SecretHandshake $secretHandshake;
 
@@ -18,8 +21,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b8496fbd-6778-468c-8054-648d03c4bb23
-     * @testdox Wink for 1
      */
+    #[TestDox('Wink for 1')]
     public function testWinkForOne(): void
     {
         $this->assertEquals(['wink'], $this->secretHandshake->commands(1));
@@ -27,8 +30,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 83ec6c58-81a9-4fd1-bfaf-0160514fc0e3
-     * @testdox Double blink for 10
      */
+    #[TestDox('Double blink for 10')]
     public function testDoubleBlinkForTen(): void
     {
         $this->assertEquals(['double blink'], $this->secretHandshake->commands(0b0_0010));
@@ -36,8 +39,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0e20e466-3519-4134-8082-5639d85fef71
-     * @testdox close your eyes for 100
      */
+    #[TestDox('close your eyes for 100')]
     public function testCloseYourEyesForHundred(): void
     {
         $this->assertEquals(['close your eyes'], $this->secretHandshake->commands(0b100));
@@ -45,8 +48,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: b339ddbb-88b7-4b7d-9b19-4134030d9ac0
-     * @testdox jump for 1000
      */
+    #[TestDox('jump for 1000')]
     public function testJumpForThousand(): void
     {
         $this->assertEquals(['jump'], $this->secretHandshake->commands(8));
@@ -54,8 +57,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 40499fb4-e60c-43d7-8b98-0de3ca44e0eb
-     * @testdox combine two actions
      */
+    #[TestDox('combine two actions')]
     public function testCombineTwoActions(): void
     {
         $this->assertEquals(['wink', 'double blink'], $this->secretHandshake->commands(3));
@@ -63,8 +66,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9730cdd5-ef27-494b-afd3-5c91ad6c3d9d
-     * @testdox reverse two actions
      */
+    #[TestDox('reverse two actions')]
     public function testReverseTwoActions(): void
     {
         $this->assertEquals(['double blink', 'wink'], $this->secretHandshake->commands(0b10011));
@@ -72,8 +75,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0b828205-51ca-45cd-90d5-f2506013f25f
-     * @testdox reversing one action gives the same action
      */
+    #[TestDox('reversing one action gives the same action')]
     public function testReversingOneActionGivesTheSameAction(): void
     {
         $this->assertEquals(['jump'], $this->secretHandshake->commands(24));
@@ -81,8 +84,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 9949e2ac-6c9c-4330-b685-2089ab28b05f
-     * @testdox reversing no actions still gives no actions
      */
+    #[TestDox('reversing no actions still gives no actions')]
     public function testReversingNoActionsStillGivesNoActions(): void
     {
         $this->assertEquals([], $this->secretHandshake->commands(16));
@@ -90,8 +93,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 23fdca98-676b-4848-970d-cfed7be39f81
-     * @testdox all possible actions
      */
+    #[TestDox('all possible actions')]
     public function testAllPossibleActions(): void
     {
         $this->assertEquals(
@@ -102,8 +105,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: ae8fe006-d910-4d6f-be00-54b7c3799e79
-     * @testdox reverse all possible actions
      */
+    #[TestDox('reverse all possible actions')]
     public function testReverseAllPossibleActions(): void
     {
         $this->assertEquals(
@@ -114,8 +117,8 @@ class SecretHandshakeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3d36da37-b31f-4cdb-a396-d93a2ee1c4a5
-     * @testdox do nothing for zero
      */
+    #[TestDox('do nothing for zero')]
     public function testDoNothingForZero(): void
     {
         $this->assertEquals([], $this->secretHandshake->commands(0b0));

--- a/exercises/practice/series/SeriesTest.php
+++ b/exercises/practice/series/SeriesTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class SeriesTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SeriesTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/sieve/SieveTest.php
+++ b/exercises/practice/sieve/SieveTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class SieveTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class SieveTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -11,8 +14,8 @@ class SieveTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 88529125-c4ce-43cc-bb36-1eb4ddd7b44f
-     * @testdox No primes under two
      */
+    #[TestDox('No primes under two')]
     public function testNoPrimesUnderTwo(): void
     {
         $this->assertEquals([], sieve(1));
@@ -20,8 +23,8 @@ class SieveTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 4afe9474-c705-4477-9923-840e1024cc2b
-     * @testdox Find first prime
      */
+    #[TestDox('Find first prime')]
     public function testFindFirstPrime(): void
     {
         $this->assertEquals([2], sieve(2));
@@ -29,8 +32,8 @@ class SieveTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 974945d8-8cd9-4f00-9463-7d813c7f17b7
-     * @testdox Find primes up to 10
      */
+    #[TestDox('Find primes up to 10')]
     public function testFindPrimesUpTo10(): void
     {
         $this->assertEquals([2, 3, 5, 7], sieve(10));
@@ -38,8 +41,8 @@ class SieveTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 2e2417b7-3f3a-452a-8594-b9af08af6d82
-     * @testdox Limit is prime
      */
+    #[TestDox('Limit is prime')]
     public function testLimitIsPrime(): void
     {
         $this->assertEquals([2, 3, 5, 7, 11, 13], sieve(13));
@@ -47,8 +50,8 @@ class SieveTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 92102a05-4c7c-47de-9ed0-b7d5fcd00f21
-     * @testdox Find primes up to 1000
      */
+    #[TestDox('Find primes up to 1000')]
     public function testFindPrimesUpTo1000(): void
     {
         $this->assertEquals(

--- a/exercises/practice/simple-cipher/SimpleCipher.php
+++ b/exercises/practice/simple-cipher/SimpleCipher.php
@@ -28,7 +28,7 @@ class SimpleCipher
 {
     public function __construct(string $key = null)
     {
-        throw new BadFunctionCallException("Please implement the SimpleCipher class!");
+        throw new \BadFunctionCallException("Please implement the SimpleCipher class!");
     }
 
     public function encode(string $plainText): string

--- a/exercises/practice/simple-cipher/SimpleCipherTest.php
+++ b/exercises/practice/simple-cipher/SimpleCipherTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class SimpleCipherTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SimpleCipherTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -65,19 +67,19 @@ class SimpleCipherTest extends PHPUnit\Framework\TestCase
 
     public function testCipherWithCapsKey(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $cipher = new SimpleCipher('ABCDEF');
     }
 
     public function testCipherWithNumericKey(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $cipher = new SimpleCipher('12345');
     }
 
     public function testCipherWithEmptyKey(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $cipher = new SimpleCipher('');
     }
 

--- a/exercises/practice/space-age/SpaceAgeTest.php
+++ b/exercises/practice/space-age/SpaceAgeTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class SpaceAgeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class SpaceAgeTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
@@ -13,8 +16,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 84f609af-5a91-4d68-90a3-9e32d8a5cd34
-     * @testdox Age on Earth
      */
+    #[TestDox('Age on Earth')]
     public function testAgeOnEarth(): void
     {
         $age = new SpaceAge(1000000000);
@@ -23,8 +26,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid ca20c4e9-6054-458c-9312-79679ffab40b
-     * @testdox Age on Mercury
      */
+    #[TestDox('Age on Mercury')]
     public function testAgeOnMercury(): void
     {
         $age = new SpaceAge(2134835688);
@@ -33,8 +36,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 502c6529-fd1b-41d3-8fab-65e03082b024
-     * @testdox Age on Venus
      */
+    #[TestDox('Age on Venus')]
     public function testAgeOnVenus(): void
     {
         $age = new SpaceAge(189839836);
@@ -43,8 +46,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9ceadf5e-a0d5-4388-9d40-2c459227ceb8
-     * @testdox Age on Mars
      */
+    #[TestDox('Age on Mars')]
     public function testAgeOnMars(): void
     {
         $age = new SpaceAge(2129871239);
@@ -53,8 +56,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 42927dc3-fe5e-4f76-a5b5-f737fc19bcde
-     * @testdox Age on Jupiter
      */
+    #[TestDox('Age on Jupiter')]
     public function testAgeOnJupiter(): void
     {
         $age = new SpaceAge(901876382);
@@ -63,8 +66,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 8469b332-7837-4ada-b27c-00ee043ebcad
-     * @testdox Age on Saturn
      */
+    #[TestDox('Age on Saturn')]
     public function testAgeOnSaturn(): void
     {
         $age = new SpaceAge(2000000000);
@@ -73,8 +76,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 999354c1-76f8-4bb5-a672-f317b6436743
-     * @testdox Age on Uranus
      */
+    #[TestDox('Age on Uranus')]
     public function testAgeOnUranus(): void
     {
         $age = new SpaceAge(1210123456);
@@ -83,8 +86,8 @@ class SpaceAgeTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 80096d30-a0d4-4449-903e-a381178355d8
-     * @testdox Age on Neptune
      */
+    #[TestDox('Age on Neptune')]
     public function testAgeOnNeptune(): void
     {
         $age = new SpaceAge(1821023456);

--- a/exercises/practice/spiral-matrix/SpiralMatrixTest.php
+++ b/exercises/practice/spiral-matrix/SpiralMatrixTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class SpiralMatrixTest extends TestCase
@@ -20,8 +21,8 @@ class SpiralMatrixTest extends TestCase
 
     /**
      * uuid: 8f584201-b446-4bc9-b132-811c8edd9040
-     * @testdox empty spiral
      */
+    #[TestDox('empty spiral')]
     public function testEmptySpiral(): void
     {
         $expected = [];
@@ -31,8 +32,8 @@ class SpiralMatrixTest extends TestCase
 
     /**
      * uuid: e40ae5f3-e2c9-4639-8116-8a119d632ab2
-     * @testdox trivial spiral
      */
+    #[TestDox('trivial spiral')]
     public function testTrivialSpiral(): void
     {
         $expected = [[1]];
@@ -42,8 +43,8 @@ class SpiralMatrixTest extends TestCase
 
     /**
      * uuid: cf05e42d-eb78-4098-a36e-cdaf0991bc48
-     * @testdox spiral of size 2
      */
+    #[TestDox('spiral of size 2')]
     public function testSpiralOfSize2(): void
     {
         $expected = [
@@ -56,8 +57,8 @@ class SpiralMatrixTest extends TestCase
 
     /**
      * uuid: 1c475667-c896-4c23-82e2-e033929de939
-     * @testdox spiral of size 3
      */
+    #[TestDox('spiral of size 3')]
     public function testSpiralOfSize3(): void
     {
         $expected = [
@@ -71,8 +72,8 @@ class SpiralMatrixTest extends TestCase
 
     /**
      * uuid: 05ccbc48-d891-44f5-9137-f4ce462a759d
-     * @testdox spiral of size 4
      */
+    #[TestDox('spiral of size 4')]
     public function testSpiralOfSize4(): void
     {
         $expected = [
@@ -87,8 +88,8 @@ class SpiralMatrixTest extends TestCase
 
     /**
      * uuid: f4d2165b-1738-4e0c-bed0-c459045ae50d
-     * @testdox spiral of size 5
      */
+    #[TestDox('spiral of size 5')]
     public function testSpiralOfSize5(): void
     {
         $expected = [

--- a/exercises/practice/state-of-tic-tac-toe/StateOfTicTacToeTest.php
+++ b/exercises/practice/state-of-tic-tac-toe/StateOfTicTacToeTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class StateOfTicTacToeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class StateOfTicTacToeTest extends TestCase
 {
     private StateOfTicTacToe $stateOfTicTacToe;
 

--- a/exercises/practice/strain/StrainTest.php
+++ b/exercises/practice/strain/StrainTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class StrainTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class StrainTest extends TestCase
 {
     private Strain $strain;
 

--- a/exercises/practice/sublist/SublistTest.php
+++ b/exercises/practice/sublist/SublistTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-class SublistTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SublistTest extends TestCase
 {
     private Sublist $sublist;
 

--- a/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
+++ b/exercises/practice/sum-of-multiples/SumOfMultiplesTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class SumOfMultiplesTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class SumOfMultiplesTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/tournament/Tournament.php
+++ b/exercises/practice/tournament/Tournament.php
@@ -28,6 +28,6 @@ class Tournament
 {
     public function __construct()
     {
-        throw new BadFunctionCallException("Please implement the Tournament class!");
+        throw new \BadFunctionCallException("Please implement the Tournament class!");
     }
 }

--- a/exercises/practice/tournament/TournamentTest.php
+++ b/exercises/practice/tournament/TournamentTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class TournamentTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class TournamentTest extends TestCase
 {
     private Tournament $tournament;
 

--- a/exercises/practice/transpose/TransposeTest.php
+++ b/exercises/practice/transpose/TransposeTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class TransposeTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class TransposeTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/triangle/TriangleTest.php
+++ b/exercises/practice/triangle/TriangleTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class TriangleTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class TriangleTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/trinary/TrinaryTest.php
+++ b/exercises/practice/trinary/TrinaryTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class TrinaryTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class TrinaryTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/twelve-days/TwelveDaysTest.php
+++ b/exercises/practice/twelve-days/TwelveDaysTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class TwelveDaysTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class TwelveDaysTest extends TestCase
 {
     private TwelveDays $twelveDays;
 

--- a/exercises/practice/two-bucket/TwoBucketTest.php
+++ b/exercises/practice/two-bucket/TwoBucketTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class TwoBucketTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class TwoBucketTest extends TestCase
 {
     private TwoBucket $twoBucket;
 
@@ -13,8 +16,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: a6f2b4ba-065f-4dca-b6f0-e3eee51cb661
-     * @testdox Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
      */
+    #[TestDox('Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one')]
     public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketOne(): void
     {
         $subject = new TwoBucket();
@@ -27,8 +30,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 6c4ea451-9678-4926-b9b3-68364e066d40
-     * @testdox Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
      */
+    #[TestDox('Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two')]
     public function testMeasureUsingBucketOneOfSize3AndBucketTwoOfSize5StartWithBucketTwo(): void
     {
         $subject = new TwoBucket();
@@ -41,8 +44,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 3389f45e-6a56-46d5-9607-75aa930502ff
-     * @testdox Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
      */
+    #[TestDox('Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one')]
     public function testMeasureUsingBucketOneOfSize7AndBucketTwoOfSize11StartWithBucketOne(): void
     {
         $subject = new TwoBucket();
@@ -55,8 +58,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1
-     * @testdox Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
      */
+    #[TestDox('Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two')]
     public function testMeasureUsingBucketOneOfSize7AndBucketTwoOfSize11StartWithBucketTwo(): void
     {
         $subject = new TwoBucket();
@@ -69,8 +72,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 0ee1f57e-da84-44f7-ac91-38b878691602
-     * @testdox Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
      */
+    #[TestDox('Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two')]
     public function testMeasureOneStepUsingBucketOneOfSize1AndBucketTwoOfSize3StartWithBucketTwo(): void
     {
         $subject = new TwoBucket();
@@ -83,8 +86,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: eb329c63-5540-4735-b30b-97f7f4df0f84
-     * @testdox Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
      */
+    #[TestDox('Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two')]
     public function testMeasureUsingBucketOneOfSize2AndBucketTwoOfSize3StartWithBucketOneAndEndWithBucketTwo(): void
     {
         $subject = new TwoBucket();
@@ -97,8 +100,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 449be72d-b10a-4f4b-a959-ca741e333b72
-     * @testdox Not possible to reach the goal
      */
+    #[TestDox('Not possible to reach the goal')]
     public function testReachabilityNotPossibleToReachGoalStartWithBucketOne(): void
     {
         $this->expectException(Exception::class);
@@ -109,8 +112,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: aac38b7a-77f4-4d62-9b91-8846d533b054
-     * @testdox With the same buckets but a different goal, then it is possible
      */
+    #[TestDox('With the same buckets but a different goal, then it is possible')]
     public function testWithSameBucketsButDifferentGoalItIsPossible(): void
     {
         $subject = new TwoBucket();
@@ -123,8 +126,8 @@ class TwoBucketTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 74633132-0ccf-49de-8450-af4ab2e3b299
-     * @testdox Goal larger than both buckets is impossible
      */
+    #[TestDox('Goal larger than both buckets is impossible')]
     public function testGoalLargerThanBothBucketsIsImpossible(): void
     {
         $this->expectException(Exception::class);

--- a/exercises/practice/two-fer/TwoFerTest.php
+++ b/exercises/practice/two-fer/TwoFerTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class TwoFerTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class TwoFerTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class VariableLengthQuantityTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class VariableLengthQuantityTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/word-count/WordCountTest.php
+++ b/exercises/practice/word-count/WordCountTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class WordCountTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class WordCountTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/wordy/WordyTest.php
+++ b/exercises/practice/wordy/WordyTest.php
@@ -24,7 +24,9 @@
 
 declare(strict_types=1);
 
-class WordyTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+class WordyTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/exercises/practice/yacht/YachtTest.php
+++ b/exercises/practice/yacht/YachtTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class YachtTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class YachtTest extends TestCase
 {
     private Yacht $yacht;
 
@@ -18,8 +21,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 3060e4a5-4063-4deb-a380-a630b43a84b6
-     * @testdox Yacht
      */
+    #[TestDox('Yacht')]
     public function testScoreYacht(): void
     {
         $this->assertEquals(50, $this->yacht->score([5, 5, 5, 5, 5], 'yacht'));
@@ -27,8 +30,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 15026df2-f567-482f-b4d5-5297d57769d9
-     * @testdox Not Yacht
      */
+    #[TestDox('Not Yacht')]
     public function testScoreNotYacht(): void
     {
         $this->assertEquals(0, $this->yacht->score([1, 3, 3, 2, 5], 'yacht'));
@@ -36,8 +39,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 36b6af0c-ca06-4666-97de-5d31213957a4
-     * @testdox Ones
      */
+    #[TestDox('Ones')]
     public function testScoreOnes(): void
     {
         $this->assertEquals(3, $this->yacht->score([1, 1, 1, 3, 5], 'ones'));
@@ -45,8 +48,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 023a07c8-6c6e-44d0-bc17-efc5e1b8205a
-     * @testdox Ones, out of order
      */
+    #[TestDox('Ones, out of order')]
     public function testScoreOnesOutOfOrders(): void
     {
         $this->assertEquals(3, $this->yacht->score([3, 1, 1, 5, 1], 'ones'));
@@ -54,8 +57,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7189afac-cccd-4a74-8182-1cb1f374e496
-     * @testdox No ones
      */
+    #[TestDox('No ones')]
     public function testScoreNoOnes(): void
     {
         $this->assertEquals(0, $this->yacht->score([4, 3, 6, 5, 5], 'ones'));
@@ -63,8 +66,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 793c4292-dd14-49c4-9707-6d9c56cee725
-     * @testdox Twos
      */
+    #[TestDox('Twos')]
     public function testScoreTwos(): void
     {
         $this->assertEquals(2, $this->yacht->score([2, 3, 4, 5, 6], 'twos'));
@@ -72,8 +75,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid dc41bceb-d0c5-4634-a734-c01b4233a0c6
-     * @testdox Fours
      */
+    #[TestDox('Fours')]
     public function testScoreFours(): void
     {
         $this->assertEquals(8, $this->yacht->score([1, 4, 1, 4, 1], 'fours'));
@@ -81,8 +84,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f6125417-5c8a-4bca-bc5b-b4b76d0d28c8
-     * @testdox Yacht counted as threes
      */
+    #[TestDox('Yacht counted as threes')]
     public function testScoreYachtAsThrees(): void
     {
         $this->assertEquals(15, $this->yacht->score([3, 3, 3, 3, 3], 'threes'));
@@ -90,8 +93,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 464fc809-96ed-46e4-acb8-d44e302e9726
-     * @testdox Yacht of 3s counted as fives
      */
+    #[TestDox('Yacht of 3s counted as fives')]
     public function testScoreYachtThreesCountedAsFives(): void
     {
         $this->assertEquals(0, $this->yacht->score([3, 3, 3, 3, 3], 'fives'));
@@ -99,8 +102,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid d054227f-3a71-4565-a684-5c7e621ec1e9
-     * @testdox Fives
      */
+    #[TestDox('Fives')]
     public function testScoreFives(): void
     {
         $this->assertEquals(10, $this->yacht->score([1, 5, 3, 5, 3], 'fives'));
@@ -108,8 +111,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid e8a036e0-9d21-443a-8b5f-e15a9e19a761
-     * @testdox Sixes
      */
+    #[TestDox('Sixes')]
     public function testScoreSixes(): void
     {
         $this->assertEquals(6, $this->yacht->score([2, 3, 4, 5, 6], 'sixes'));
@@ -117,8 +120,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 51cb26db-6b24-49af-a9ff-12f53b252eea
-     * @testdox Full house two small, three big
      */
+    #[TestDox('Full house two small, three big')]
     public function testScoreFullHouseThreeLargeNumbers(): void
     {
         $this->assertEquals(16, $this->yacht->score([2, 2, 4, 4, 4], 'full house'));
@@ -126,8 +129,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 1822ca9d-f235-4447-b430-2e8cfc448f0c
-     * @testdox Full house three small, two big
      */
+    #[TestDox('Full house three small, two big')]
     public function testScoreFullHouseThreeSmallNumbers(): void
     {
         $this->assertEquals(19, $this->yacht->score([5, 3, 3, 5, 3], 'full house'));
@@ -135,8 +138,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b208a3fc-db2e-4363-a936-9e9a71e69c07
-     * @testdox Two pair is not a full house
      */
+    #[TestDox('Two pair is not a full house')]
     public function testScoreTwoPairNotFullHouse(): void
     {
         $this->assertEquals(0, $this->yacht->score([2, 2, 4, 4, 5], 'full house'));
@@ -144,8 +147,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b90209c3-5956-445b-8a0b-0ac8b906b1c2
-     * @testdox Four of a kind is not a full house
      */
+    #[TestDox('Four of a kind is not a full house')]
     public function testScoreFourOfAKindNotFullHouse(): void
     {
         $this->assertEquals(0, $this->yacht->score([1, 4, 4, 4, 4], 'full house'));
@@ -153,8 +156,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 32a3f4ee-9142-4edf-ba70-6c0f96eb4b0c
-     * @testdox Yacht is not a full house
      */
+    #[TestDox('Yacht is not a full house')]
     public function testScoreYachtNotFullHouse(): void
     {
         $this->assertEquals(0, $this->yacht->score([2, 2, 2, 2, 2], 'full house'));
@@ -162,8 +165,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b286084d-0568-4460-844a-ba79d71d79c6
-     * @testdox Four of a Kind
      */
+    #[TestDox('Four of a Kind')]
     public function testScoreFourOfAKind(): void
     {
         $this->assertEquals(24, $this->yacht->score([6, 6, 4, 6, 6], 'four of a kind'));
@@ -171,8 +174,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid f25c0c90-5397-4732-9779-b1e9b5f612ca
-     * @testdox Yacht can be scored as Four of a Kind
      */
+    #[TestDox('Yacht can be scored as Four of a Kind')]
     public function testScoreYachtAsFourOfAKind(): void
     {
         $this->assertEquals(12, $this->yacht->score([3, 3, 3, 3, 3], 'four of a kind'));
@@ -180,8 +183,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 9f8ef4f0-72bb-401a-a871-cbad39c9cb08
-     * @testdox Full house is not Four of a Kind
      */
+    #[TestDox('Full house is not Four of a Kind')]
     public function testScoreFullHouseNotFourOfAKind(): void
     {
         $this->assertEquals(0, $this->yacht->score([3, 3, 3, 5, 5], 'four of a kind'));
@@ -189,8 +192,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b4743c82-1eb8-4a65-98f7-33ad126905cd
-     * @testdox Little Straight
      */
+    #[TestDox('Little Straight')]
     public function testScoreLittleStraight(): void
     {
         $this->assertEquals(30, $this->yacht->score([3, 5, 4, 1, 2], 'little straight'));
@@ -198,8 +201,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 7ac08422-41bf-459c-8187-a38a12d080bc
-     * @testdox Little Straight as Big Straight
      */
+    #[TestDox('Little Straight as Big Straight')]
     public function testScoreLittleStraightAsBigStraight(): void
     {
         $this->assertEquals(0, $this->yacht->score([1, 2, 3, 4, 5], 'big straight'));
@@ -207,8 +210,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 97bde8f7-9058-43ea-9de7-0bc3ed6d3002
-     * @testdox Four in order but not a little straight
      */
+    #[TestDox('Four in order but not a little straight')]
     public function testScoreFourInOrderNotStraight(): void
     {
         $this->assertEquals(0, $this->yacht->score([1, 1, 2, 3, 4], 'little straight'));
@@ -216,8 +219,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid cef35ff9-9c5e-4fd2-ae95-6e4af5e95a99
-     * @testdox No pairs but not a little straight
      */
+    #[TestDox('No pairs but not a little straight')]
     public function testScoreNoPairsNoLittleStraight(): void
     {
         $this->assertEquals(0, $this->yacht->score([1, 2, 3, 4, 6], 'little straight'));
@@ -225,8 +228,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid fd785ad2-c060-4e45-81c6-ea2bbb781b9d
-     * @testdox Minimum is 1, maximum is 5, but not a little straight
      */
+    #[TestDox('Minimum is 1, maximum is 5, but not a little straight')]
     public function testScoreMinOneMaxFiveNotLittleStraight(): void
     {
         $this->assertEquals(0, $this->yacht->score([1, 1, 3, 4, 5], 'little straight'));
@@ -234,8 +237,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 35bd74a6-5cf6-431a-97a3-4f713663f467
-     * @testdox Big Straight
      */
+    #[TestDox('Big Straight')]
     public function testScoreBigStraight(): void
     {
         $this->assertEquals(30, $this->yacht->score([4, 6, 2, 5, 3], 'big straight'));
@@ -243,8 +246,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 87c67e1e-3e87-4f3a-a9b1-62927822b250
-     * @testdox Big Straight as little straight
      */
+    #[TestDox('Big Straight as little straight')]
     public function testScoreBigStraightAsLittleStraight(): void
     {
         $this->assertEquals(0, $this->yacht->score([6, 5, 4, 3, 2], 'little straight'));
@@ -252,8 +255,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid c1fa0a3a-40ba-4153-a42d-32bc34d2521e
-     * @testdox No pairs but not a big straight
      */
+    #[TestDox('No pairs but not a big straight')]
     public function testScoreNoPairsNoBigStraight(): void
     {
         $this->assertEquals(0, $this->yacht->score([6, 5, 4, 3, 1], 'big straight'));
@@ -261,8 +264,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid 207e7300-5d10-43e5-afdd-213e3ac8827d
-     * @testdox Choice
      */
+    #[TestDox('Choice')]
     public function testScoreChoice(): void
     {
         $this->assertEquals(23, $this->yacht->score([3, 3, 5, 6, 6], 'choice'));
@@ -270,8 +273,8 @@ class YachtTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid b524c0cf-32d2-4b40-8fb3-be3500f3f135
-     * @testdox Yacht as choice
      */
+    #[TestDox('Yacht as choice')]
     public function testScoreYachtAsChoice(): void
     {
         $this->assertEquals(10, $this->yacht->score([2, 2, 2, 2, 2], 'choice'));

--- a/exercises/practice/zebra-puzzle/ZebraPuzzleTest.php
+++ b/exercises/practice/zebra-puzzle/ZebraPuzzleTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-class ZebraPuzzleTest extends PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class ZebraPuzzleTest extends TestCase
 {
     private ZebraPuzzle $zebraPuzzle;
 
@@ -18,8 +21,8 @@ class ZebraPuzzleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 16efb4e4-8ad7-4d5e-ba96-e5537b66fd42
-     * @testdox Resident who drinks water
      */
+    #[TestDox('Resident who drinks water')]
     public function testResidentWhoDrinksWater(): void
     {
         $this->assertEquals('Norwegian', $this->zebraPuzzle->waterDrinker());
@@ -27,8 +30,8 @@ class ZebraPuzzleTest extends PHPUnit\Framework\TestCase
 
     /**
      * uuid: 084d5b8b-24e2-40e6-b008-c800da8cd257
-     * @testdox Resident who owns zebra
      */
+    #[TestDox('Resident who owns zebra')]
     public function testResidentWhoOwnsZebra(): void
     {
         $this->assertEquals('Japanese', $this->zebraPuzzle->zebraOwner());


### PR DESCRIPTION
1. Used rector with the following configuration:
     ```php
     <?php
    declare(strict_types=1);

    use Rector\Config\RectorConfig;
    use Rector\PHPUnit\Set\PHPUnitSetList;

    return RectorConfig::configure()
        ->withPaths([__DIR__ . '/exercises'])
        ->withSets([PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES, PHPUnitSetList::PHPUNIT_110])
	->withImportNames(importShortClasses: false, removeUnusedImports: true);
    ```
2. Manually fix testdox that contains `::`:
    ```diff
    -#[TestDox(specify a string type for Address::$street)]
    +#[TestDox('specify a string type for Address::$street')]
    ```
4. Updated `TestGenerator.php` to use attribute
5. Updated `bootstrap.sh` to use attribute