### PR TITLE
fix: add missing semicolon after class instantiation

### DIFF
--- a/exercises/concept/annalyns-infiltration/.docs/instructions.md
+++ b/exercises/concept/annalyns-infiltration/.docs/instructions.md
@@ -85,7 +85,7 @@ $is_archer_awake = true;
 $is_prisoner_awake = false;
 $is_dog_present = false
 
-$infiltration = new AnnalynsInfiltration()
+$infiltration = new AnnalynsInfiltration();
 $infiltration->canLiberate(
     $is_knight_awake,
     $is_archer_awake,


### PR DESCRIPTION
I added the missing semi colon after class instantiation in file: exercises/concept/annalyns-infiltration/.docs/instructions.md.