### PR TITLE
Sync gigasecond

### DIFF
--- a/bin/auto-sync.txt
+++ b/bin/auto-sync.txt
@@ -26,6 +26,7 @@ eliuds-eggs
 etl
 flower-field
 food-chain
+gigasecond
 grade-school
 hamming
 hello-world

--- a/exercises/practice/gigasecond/.meta/example.php
+++ b/exercises/practice/gigasecond/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 function from(DateTimeImmutable $from): DateTimeImmutable

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
@@ -16,3 +23,8 @@ description = "full time specified"
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false
+comment = "It is impossible to mutate type DateTimeImmutable, which we test for"

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -19,7 +19,6 @@ class GigasecondTest extends TestCase
     public static function inputAndExpectedDates(): array
     {
         return [
-            ['1959-07-19', '1991-03-27 01:46:40'],
             ['2015-01-24 22:00:00', '2046-10-02 23:46:40'],
             ['2015-01-24 23:59:59', '2046-10-03 01:46:39'],
         ];
@@ -65,6 +64,22 @@ class GigasecondTest extends TestCase
         $this->assertInstanceOf(DateTimeImmutable::class, $actual);
         $this->assertSame(
             '2009-02-19 01:46:40',
+            $actual->format('Y-m-d H:i:s'),
+        );
+    }
+
+    /** uuid: 77eb8502-2bca-4d92-89d9-7b39ace28dd5 */
+    #[TestDox('Third test for date only specification of time')]
+    public function testThirdTestForDateOnlySpecificationOfTime(): void
+    {
+        $UTC = new DateTimeZone('UTC');
+        $input = new DateTimeImmutable('1959-07-19', $UTC);
+
+        $actual = from($input);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            '1991-03-27 01:46:40',
             $actual->format('Y-m-d H:i:s'),
         );
     }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -19,7 +19,6 @@ class GigasecondTest extends TestCase
     public static function inputAndExpectedDates(): array
     {
         return [
-            ['1977-06-13', '2009-02-19 01:46:40'],
             ['1959-07-19', '1991-03-27 01:46:40'],
             ['2015-01-24 22:00:00', '2046-10-02 23:46:40'],
             ['2015-01-24 23:59:59', '2046-10-03 01:46:39'],
@@ -50,6 +49,22 @@ class GigasecondTest extends TestCase
         $this->assertInstanceOf(DateTimeImmutable::class, $actual);
         $this->assertSame(
             '2043-01-01 01:46:40',
+            $actual->format('Y-m-d H:i:s'),
+        );
+    }
+
+    /** uuid: 6d86dd16-6f7a-47be-9e58-bb9fb2ae1433 */
+    #[TestDox('Second test for date only specification of time')]
+    public function testSecondTestForDateOnlySpecificationOfTime(): void
+    {
+        $UTC = new DateTimeZone('UTC');
+        $input = new DateTimeImmutable('1977-06-13', $UTC);
+
+        $actual = from($input);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            '2009-02-19 01:46:40',
             $actual->format('Y-m-d H:i:s'),
         );
     }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
 /**
@@ -14,25 +13,6 @@ class GigasecondTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         require_once 'Gigasecond.php';
-    }
-
-    public static function inputAndExpectedDates(): array
-    {
-        return [
-            ['2015-01-24 23:59:59', '2046-10-03 01:46:39'],
-        ];
-    }
-
-    #[DataProvider('inputAndExpectedDates')]
-    public function testFrom(string $inputDate, string $expected): void
-    {
-        $UTC = new DateTimeZone('UTC');
-        $input = new DateTimeImmutable($inputDate, $UTC);
-
-        $actual = from($input);
-
-        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
-        $this->assertSame($expected, $actual->format('Y-m-d H:i:s'));
     }
 
     /** uuid: 92fbe71c-ea52-4fac-bd77-be38023cacf7 */
@@ -95,6 +75,22 @@ class GigasecondTest extends TestCase
         $this->assertInstanceOf(DateTimeImmutable::class, $actual);
         $this->assertSame(
             '2046-10-02 23:46:40',
+            $actual->format('Y-m-d H:i:s'),
+        );
+    }
+
+    /** uuid: 09d4e30e-728a-4b52-9005-be44a58d9eba */
+    #[TestDox('Full time with day roll-over')]
+    public function testFullTimeWithDayRollOver(): void
+    {
+        $UTC = new DateTimeZone('UTC');
+        $input = new DateTimeImmutable('2015-01-24 23:59:59', $UTC);
+
+        $actual = from($input);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            '2046-10-03 01:46:39',
             $actual->format('Y-m-d H:i:s'),
         );
     }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * ATTENTION: We use a `from()` function for backwards compatibility, not `add()`
@@ -18,7 +19,6 @@ class GigasecondTest extends TestCase
     public static function inputAndExpectedDates(): array
     {
         return [
-            ['2011-04-25', '2043-01-01 01:46:40'],
             ['1977-06-13', '2009-02-19 01:46:40'],
             ['1959-07-19', '1991-03-27 01:46:40'],
             ['2015-01-24 22:00:00', '2046-10-02 23:46:40'],
@@ -36,5 +36,21 @@ class GigasecondTest extends TestCase
 
         $this->assertInstanceOf(DateTimeImmutable::class, $actual);
         $this->assertSame($expected, $actual->format('Y-m-d H:i:s'));
+    }
+
+    /** uuid: 92fbe71c-ea52-4fac-bd77-be38023cacf7 */
+    #[TestDox('Date only specification of time')]
+    public function testDateOnlySpecificationOfTime(): void
+    {
+        $UTC = new DateTimeZone('UTC');
+        $input = new DateTimeImmutable('2011-04-25', $UTC);
+
+        $actual = from($input);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            '2043-01-01 01:46:40',
+            $actual->format('Y-m-d H:i:s'),
+        );
     }
 }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -19,7 +19,6 @@ class GigasecondTest extends TestCase
     public static function inputAndExpectedDates(): array
     {
         return [
-            ['2015-01-24 22:00:00', '2046-10-02 23:46:40'],
             ['2015-01-24 23:59:59', '2046-10-03 01:46:39'],
         ];
     }
@@ -80,6 +79,22 @@ class GigasecondTest extends TestCase
         $this->assertInstanceOf(DateTimeImmutable::class, $actual);
         $this->assertSame(
             '1991-03-27 01:46:40',
+            $actual->format('Y-m-d H:i:s'),
+        );
+    }
+
+    /** uuid: c9d89a7d-06f8-4e28-a305-64f1b2abc693 */
+    #[TestDox('Full time specified')]
+    public function testFullTimeSpecified(): void
+    {
+        $UTC = new DateTimeZone('UTC');
+        $input = new DateTimeImmutable('2015-01-24 22:00:00', $UTC);
+
+        $actual = from($input);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame(
+            '2046-10-02 23:46:40',
             $actual->format('Y-m-d H:i:s'),
         );
     }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\TestDox;
 
 /**
- * ATTENTION: We use a `from()` function for backwards compatibility, not `add()`
+ * ATTENTION: We use function `from()` for backwards compatibility, not `add()`
  */
 class GigasecondTest extends TestCase
 {

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -23,18 +23,15 @@ class GigasecondTest extends TestCase
         ];
     }
 
-    /**
-     * @param string $inputDate
-     * @param string $expected
-     */
     #[DataProvider('inputAndExpectedDates')]
     public function testFrom(string $inputDate, string $expected): void
     {
         $UTC = new DateTimeZone('UTC');
-        $date = new DateTimeImmutable($inputDate, $UTC);
-        $gs = from($date);
+        $input = new DateTimeImmutable($inputDate, $UTC);
 
-        $this->assertInstanceOf(DateTimeImmutable::class, $gs);
-        $this->assertSame($expected, $gs->format('Y-m-d H:i:s'));
+        $actual = from($input);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $actual);
+        $this->assertSame($expected, $actual->format('Y-m-d H:i:s'));
     }
 }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+/**
+ * ATTENTION: We use a `from()` function for backwards compatibility, not `add()`
+ */
 class GigasecondTest extends TestCase
 {
     public static function setUpBeforeClass(): void

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -12,12 +12,6 @@ class GigasecondTest extends TestCase
         require_once 'Gigasecond.php';
     }
 
-    public function dateSetup($date): DateTimeImmutable
-    {
-        $UTC = new DateTimeZone('UTC');
-        return new DateTimeImmutable($date, $UTC);
-    }
-
     public static function inputAndExpectedDates(): array
     {
         return [
@@ -36,7 +30,8 @@ class GigasecondTest extends TestCase
     #[DataProvider('inputAndExpectedDates')]
     public function testFrom(string $inputDate, string $expected): void
     {
-        $date = $this->dateSetup($inputDate);
+        $UTC = new DateTimeZone('UTC');
+        $date = new DateTimeImmutable($inputDate, $UTC);
         $gs = from($date);
 
         $this->assertInstanceOf(DateTimeImmutable::class, $gs);

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -29,17 +29,6 @@ class GigasecondTest extends TestCase
         ];
     }
 
-    public static function inputDates(): array
-    {
-        return [
-            ['2011-04-25'],
-            ['1977-06-13'],
-            ['1959-07-19'],
-            ['2015-01-24 22:00:00'],
-            ['2015-01-24 23:59:59'],
-        ];
-    }
-
     /**
      * @param string $inputDate
      * @param string $expected
@@ -50,16 +39,7 @@ class GigasecondTest extends TestCase
         $date = $this->dateSetup($inputDate);
         $gs = from($date);
 
+        $this->assertInstanceOf(DateTimeImmutable::class, $gs);
         $this->assertSame($expected, $gs->format('Y-m-d H:i:s'));
-    }
-
-    /**
-     * @param string $inputDate
-     */
-    #[DataProvider('inputDates')]
-    public function testFromReturnType(string $inputDate): void
-    {
-        $date = $this->dateSetup($inputDate);
-        $this->assertInstanceOf(DateTimeImmutable::class, from($date));
     }
 }

--- a/exercises/practice/gigasecond/GigasecondTest.php
+++ b/exercises/practice/gigasecond/GigasecondTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
- The missing test is useless for us, we use `DateTimeImmutable` which cannot be mutated
- The students interface is function `from()`, that is kept for backwards compatibility
- DataProvider is inlined as discussed in #755 

Closes #911 