### PR TITLE
Fix description for random key in SimpleCipher

### DIFF
--- a/exercises/practice/simple-cipher/.docs/instructions.md
+++ b/exercises/practice/simple-cipher/.docs/instructions.md
@@ -59,7 +59,7 @@ substitution cipher a little more fault tolerant by providing a source
 of randomness and ensuring that the key contains only lowercase letters.
 
 If someone doesn't submit a key at all, generate a truly random key of
-at least 100 alphanumeric characters in length.
+at least 100 lowercase letters.
 
 ## Extensions
 


### PR DESCRIPTION
The tests in SimpleCipher expect the key to only contain lowercase letters, but the instructions for generating a random key say to use alphanumeric characters.