### PR TITLE
Flatten array

### DIFF
--- a/bin/auto-sync.txt
+++ b/bin/auto-sync.txt
@@ -24,6 +24,7 @@ difference-of-squares
 dnd-character
 eliuds-eggs
 etl
+flatten-array
 flower-field
 food-chain
 gigasecond

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,11 +1,16 @@
 # Instructions
 
-Take a nested list and return a single flattened list with all values except nil/null.
+Take a nested array of any depth and return a fully flattened array.
 
-The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+Note that some language tracks may include null-like values in the input array, and the way these values are represented varies by track.
+Such values should be excluded from the flattened array.
 
-For Example
+Additionally, the input may be of a different data type and contain different types, depending on the track.
 
-input: [1,[2,3,null,4],[null],5]
+Check the test suite for details.
 
-output: [1,2,3,4,5]
+## Example
+
+input: `[1, [2, 6, null], [[null, [4]], 5]]`
+
+output: `[1, 2, 6, 4, 5]`

--- a/exercises/practice/flatten-array/.docs/introduction.md
+++ b/exercises/practice/flatten-array/.docs/introduction.md
@@ -1,0 +1,7 @@
+# Introduction
+
+A shipment of emergency supplies has arrived, but there's a problem.
+To protect from damage, the items — flashlights, first-aid kits, blankets — are packed inside boxes, and some of those boxes are nested several layers deep inside other boxes!
+
+To be prepared for an emergency, everything must be easily accessible in one box.
+Can you unpack all the supplies and place them into a single box, so they're ready when needed most?

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -19,7 +19,7 @@
       ".meta/example.php"
     ]
   },
-  "blurb": "Take a nested list and return a single list with all values except nil/null",
+  "blurb": "Take a nested list and return a single list with all values except nil/null.",
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"
 }

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -6,7 +6,8 @@
     "arueckauer",
     "kunicmarko20",
     "kytrinyx",
-    "neenjaw"
+    "neenjaw",
+    "A-O-Emmanuel"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/flatten-array/.meta/example.php
+++ b/exercises/practice/flatten-array/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 function flatten($array = [])

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -1,9 +1,22 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8c71dabd-da60-422d-a290-4a571471fb14]
+description = "empty"
 
 [d268b919-963c-442d-9f07-82b93f1b518c]
 description = "no nesting"
+
+[3f15bede-c856-479e-bb71-1684b20c6a30]
+description = "flattens a nested array"
 
 [c84440cc-bb3a-48a6-862c-94cf23f2815d]
 description = "flattens array with just integers present"
@@ -14,8 +27,37 @@ description = "5 level nesting"
 [d572bdba-c127-43ed-bdcd-6222ac83d9f7]
 description = "6 level nesting"
 
+[0705a8e5-dc86-4cec-8909-150c5e54fa9c]
+description = "null values are omitted from the final result"
+
+[c6cf26de-8ccd-4410-84bd-b9efd88fd2bc]
+description = "consecutive null values at the front of the list are omitted from the final result"
+include = false
+
+[bc72da10-5f55-4ada-baf3-50e4da02ec8e]
+description = "consecutive null values at the front of the array are omitted from the final result"
+reimplements = "c6cf26de-8ccd-4410-84bd-b9efd88fd2bc"
+
+[382c5242-587e-4577-b8ce-a5fb51e385a1]
+description = "consecutive null values in the middle of the list are omitted from the final result"
+include = false
+
+[6991836d-0d9b-4703-80a0-3f1f23eb5981]
+description = "consecutive null values in the middle of the array are omitted from the final result"
+reimplements = "382c5242-587e-4577-b8ce-a5fb51e385a1"
+
 [ef1d4790-1b1e-4939-a179-51ace0829dbd]
 description = "6 level nest list with null values"
+include = false
+
+[dc90a09c-5376-449c-a7b3-c2d20d540069]
+description = "6 level nested array with null values"
+reimplements = "ef1d4790-1b1e-4939-a179-51ace0829dbd"
 
 [85721643-705a-4150-93ab-7ae398e2942d]
 description = "all values in nested list are null"
+include = false
+
+[51f5d9af-8f7f-4fb5-a156-69e8282cb275]
+description = "all values in nested array are null"
+reimplements = "85721643-705a-4150-93ab-7ae398e2942d"

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
 
 class FlattenArrayTest extends TestCase
 {
@@ -10,13 +11,21 @@ class FlattenArrayTest extends TestCase
     {
         require_once 'FlattenArray.php';
     }
-
+    /**
+     * uuid d268b919-963c-442d-9f07-82b93f1b518c
+     */
+    #[TestDox('no nesting')]
     public function testWithOutNesting(): void
     {
         $input = [0, 1, 2];
         $expected = [0, 1, 2];
         $this->assertEquals($expected, flatten($input));
     }
+
+    /**
+     * uuid c84440cc-bb3a-48a6-862c-94cf23f2815d
+     */
+    #[TestDox('flattens array with just integers present')]
     public function testArrayWithJustIntegersPresent(): void
     {
         $input = [1, [2, 3, 4, 5, 6, 7], 8];
@@ -24,6 +33,11 @@ class FlattenArrayTest extends TestCase
         $this->assertEquals($expected, flatten($input));
     }
 
+
+    /**
+     * uuid d3d99d39-6be5-44f5-a31d-6037d92ba34f
+     */
+    #[TestDox('5 level nesting')]
     public function testFiveLevelNesting(): void
     {
         $input = [0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2];
@@ -31,12 +45,21 @@ class FlattenArrayTest extends TestCase
         $this->assertEquals($expected, flatten($input));
     }
 
+    /**
+     * uuid d572bdba-c127-43ed-bdcd-6222ac83d9f7
+     */
+    #[TestDox('6 level nesting')]
     public function testSixLevelNesting(): void
     {
         $input = [1, [2, [[3]], [4, [[5]]], 6, 7], 8];
         $expected = [1, 2, 3, 4, 5, 6, 7, 8];
         $this->assertEquals($expected, flatten($input));
     }
+
+    /**
+     * uuid dc90a09c-5376-449c-a7b3-c2d20d540069
+     */
+    #[TestDox('6 level nested array with null values')]
     public function testSixLevelNestListWithNullValues(): void
     {
         $input = [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2];
@@ -44,6 +67,11 @@ class FlattenArrayTest extends TestCase
         $this->assertEquals($expected, flatten($input));
     }
 
+
+    /**
+     * uuid 51f5d9af-8f7f-4fb5-a156-69e8282cb275
+     */
+    #[TestDox('all values in nested array are null')]
     public function testAllValuesInNestedListAreNull(): void
     {
         $input = [null, [[[null]]], null, null, [[null, null], null], null];

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;

--- a/exercises/practice/flatten-array/FlattenArrayTest.php
+++ b/exercises/practice/flatten-array/FlattenArrayTest.php
@@ -11,6 +11,18 @@ class FlattenArrayTest extends TestCase
     {
         require_once 'FlattenArray.php';
     }
+
+    /**
+     * uuid 8c71dabd-da60-422d-a290-4a571471fb14
+     */
+    #[TestDox('empty')]
+    public function testEmpty(): void
+    {
+        $input = [];
+        $expected = [];
+        $this->assertEquals($expected, flatten($input));
+    }
+
     /**
      * uuid d268b919-963c-442d-9f07-82b93f1b518c
      */
@@ -19,6 +31,18 @@ class FlattenArrayTest extends TestCase
     {
         $input = [0, 1, 2];
         $expected = [0, 1, 2];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+
+    /**
+     * uuid 3f15bede-c856-479e-bb71-1684b20c6a30
+     */
+    #[TestDox('flattens a nested array')]
+    public function testFlattensANestedArray(): void
+    {
+        $input = [[[]]];
+        $expected = [];
         $this->assertEquals($expected, flatten($input));
     }
 
@@ -57,10 +81,77 @@ class FlattenArrayTest extends TestCase
     }
 
     /**
+     * uuid 0705a8e5-dc86-4cec-8909-150c5e54fa9c
+     */
+    #[TestDox('null values are omitted from the final result')]
+    public function testNullValuesAreOmittedFromTheFinalResult(): void
+    {
+        $input = [1, 2, null];
+        $expected = [1, 2];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+    /**
+     * uuid c6cf26de-8ccd-4410-84bd-b9efd88fd2bc
+     */
+    #[TestDox('consecutive null values at the front of the list are omitted from the final result')]
+    public function testConsecutiveNullValuesAtTheFrontOfTheListAreOmittedFromTheFinalResult(): void
+    {
+        $input = [null, null, 3];
+        $expected = [3];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+    /**
+     * uuid bc72da10-5f55-4ada-baf3-50e4da02ec8e
+     */
+    #[TestDox('consecutive null values at the front of the array are omitted from the final result')]
+    public function testConsecutiveNullValuesAtTheFrontOfTheArrayAreOmittedFromTheFinalResult(): void
+    {
+        $input = [null, null, 3];
+        $expected = [3];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+    /**
+     * uuid 382c5242-587e-4577-b8ce-a5fb51e385a1
+     */
+    #[TestDox('consecutive null values in the middle of the list are omitted from the final result')]
+    public function testConsecutiveNullValuesInTheMiddleOfTheListAreOmittedFromTheFinalResult(): void
+    {
+        $input = [1, null, null, 4];
+        $expected = [1, 4];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+    /**
+     * uuid 6991836d-0d9b-4703-80a0-3f1f23eb5981
+     */
+    #[TestDox('consecutive null values in the middle of the array are omitted from the final result')]
+    public function testConsecutiveNullValuesInTheMiddleOfTheArrayAreOmittedFromTheFinalResult(): void
+    {
+        $input = [1, null, null, 4];
+        $expected = [1, 4];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+    /**
+     * uuid ef1d4790-1b1e-4939-a179-51ace0829dbd
+     */
+    #[TestDox('6 level nest list with null values')]
+    public function testSixLevelNestListWithNullValues(): void
+    {
+        $input = [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2];
+        $expected = [0, 2, 2, 3, 8, 100, -2];
+        $this->assertEquals($expected, flatten($input));
+    }
+
+
+    /**
      * uuid dc90a09c-5376-449c-a7b3-c2d20d540069
      */
     #[TestDox('6 level nested array with null values')]
-    public function testSixLevelNestListWithNullValues(): void
+    public function testSixLevelNestedArrayWithNullValues(): void
     {
         $input = [0, 2, [[2, 3], 8, [[100]], null, [[null]]], -2];
         $expected = [0, 2, 2, 3, 8, 100, -2];


### PR DESCRIPTION
Ran bin/configlet sync to update Markdown documentation, tests.toml, and metadata for consistency.

Removed unnecessary strict types comments from the test file and example code.

Updated test metadata with correct UUIDs and #TestDox DocBlocks.

Added missing test cases from canonical data to fully cover flattening arrays with nested levels and null values.

