### PR TITLE
Add test for invalid board with wrong move count for winner

### DIFF
--- a/exercises/practice/state-of-tic-tac-toe/.meta/tests.toml
+++ b/exercises/practice/state-of-tic-tac-toe/.meta/tests.toml
@@ -99,3 +99,6 @@ reimplements = "b1dc8b13-46c4-47db-a96d-aa90eedc4e8d"
 
 [4801cda2-f5b7-4c36-8317-3cdd167ac22c]
 description = "Invalid boards -> Invalid board: players kept playing after a win"
+
+[09e53d22-f223-4ef0-b555-ba2102867c7f]
+description = "Invalid boards -> Invalid board: wrong move count for winner"

--- a/exercises/practice/state-of-tic-tac-toe/StateOfTicTacToeTest.php
+++ b/exercises/practice/state-of-tic-tac-toe/StateOfTicTacToeTest.php
@@ -380,4 +380,20 @@ class StateOfTicTacToeTest extends TestCase
         ];
         $this->stateOfTicTacToe->gameState($board);
     }
+    /**
+     * uuid: 09e53d22-f223-4ef0-b555-ba2102867c7f
+     */
+    public function testImpossibleGameXWinsButMovesAreEqual(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Impossible board: wrong move count for winner');
+
+        $board = [
+            'XXX',
+            'XOO',
+            'OO '
+        ];
+
+        $this->stateOfTicTacToe->gameState($board);
+    }
 }


### PR DESCRIPTION
This PR adds a missing test for the Tic-Tac-Toe exercise, covering the case
where X wins but both players have the same move count, which represents an
impossible game state.
