### PR TITLE
Make instructions consistent with (y, x) and (height, width) ordering

### DIFF
--- a/exercises/concept/windowing-system/.docs/instructions.md
+++ b/exercises/concept/windowing-system/.docs/instructions.md
@@ -7,8 +7,8 @@ The following image is representative of the values you will be working with bel
 ```text
  ╔════════════════════════════════════════════════════════════╗
  ║                                                            ║
- ║        position::$x,_                                      ║
- ║        position::$y  \                                     ║
+ ║        position::$y,_                                      ║
+ ║        position::$x  \                                     ║
  ║                       \<---- size::$width ---->            ║
  ║                 ^      *──────────────────────┐            ║
  ║                 |      │        title         │            ║
@@ -26,39 +26,39 @@ The following image is representative of the values you will be working with bel
 
 ## 1. Define the properties of the Program Window
 
-Using the provided class scaffold, provide the properties for the `x`, `y`, `height`, and `width` values.
+Using the provided class scaffold, provide the properties for the `y`, `x`, `height`, and `width` values.
 
 ```php
 <?php
 
 $window = new ProgramWindow();
-$window->x; // => null
 $window->y; // => null
-$window->width; // => null
+$window->x; // => null
 $window->height; // => null
+$window->width; // => null
 ```
 
 ## 2. Define the initial values for the program window
 
 Define a constructor function for `ProgramWindow`.
 It should not take any arguments, but during the constructor execution set the default values for its properties.
-It should set the initial `x` and `y` values to `0`.
-It should set the initial `width` and `height` to an `800x600` screen size.
+It should set the initial `y` and `x` values to `0`.
+It should set the initial `height` and `width` to a `600x800` screen size.
 
 ```php
 <?php
 
 $window = new ProgramWindow();
-$window->x; // => 0 
-$window->y; // => 0
-$window->width; // => 800
+$window->y; // => 0 
+$window->x; // => 0
 $window->height; // => 600
+$window->width; // => 800
 ```
 
 ## 3. Define a function to resize the window
 
 Define a new class in `Size.php` for a Size class.
-It should take constructor arguments to set an `height` and `width` property.
+It should take constructor arguments to set the `height` and `width` properties.
 Additionally `ProgramWindow` requires a resize function, which receives the `Size` object instance and updates its own properties.
 
 ```php
@@ -77,7 +77,7 @@ $window->width;
 ## 4. Define a function to move the window
 
 Define a new class in `Position.php` for a Position class.
-It should take constructor arguments to set a `y` and `x` property.
+It should take constructor arguments to set the `y` and `x` properties.
 Additionally `ProgramWindow` requires a move function, which receives the `Position` object instance and updates its own properties.
 
 ```php


### PR DESCRIPTION
To minimise confusion within the exercise, the instructions now consistently refer to the parameters in the order they are required. While the ordering is a little strange, it maintains the backwards compatibility of completed exercises.

All instructions now follow:

(y, x)
(height, width)