### PR TITLE
fix: Refactor exception message to display function name properly

### DIFF
--- a/exercises/practice/darts/Darts.php
+++ b/exercises/practice/darts/Darts.php
@@ -26,5 +26,5 @@ declare(strict_types=1);
 
 function score(float $xAxis, float $yAxis): int
 {
-    throw new \BadFunctionCallException("Please implement the __FUNCTION__ function!");
+    throw new \BadMethodCallException(sprintf('Implement the %s method', __FUNCTION__));
 }


### PR DESCRIPTION
I refactored exception message since constants are not interpolated.