### PR TITLE
Fix typo in language-list (phpunit test)  [no important files changed]

### DIFF
--- a/exercises/concept/language-list/LanguageListTest.php
+++ b/exercises/concept/language-list/LanguageListTest.php
@@ -86,7 +86,7 @@ class LanguageListTest extends TestCase
     /**
      * @task_id 4
      */
-    #[TestDox('when pushing, original is unchanged')]
+    #[TestDox('when removing, original is unchanged')]
     public function testPruningDoesNotMutate()
     {
         $language_list = language_list('c', 'cpp', 'php');

--- a/exercises/concept/language-list/LanguageListTest.php
+++ b/exercises/concept/language-list/LanguageListTest.php
@@ -86,7 +86,7 @@ class LanguageListTest extends TestCase
     /**
      * @task_id 4
      */
-    #[TestDox('when removing, original is unchanged')]
+    #[TestDox('when pruning, original is unchanged')]
     public function testPruningDoesNotMutate()
     {
         $language_list = language_list('c', 'cpp', 'php');


### PR DESCRIPTION
This pull request fix a typo in LanguageListTest.php
[no important files changed]