### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,6 @@
 # Instructions append
 
-The skipped tests near the bottom of the anagram_test.php are **Stretch Goals**, they are optional. They require the usage of `mb_string` functions, which aren't installed by default with every version of PHP.
+## Implementation
+
+The skipped tests near the bottom of the `anagram_test.php` are **Stretch Goals**, they are optional.
+They require the usage of `mb_string` functions, which aren't installed by default with every version of PHP.

--- a/exercises/practice/eliuds-eggs/.docs/instructions.append.md
+++ b/exercises/practice/eliuds-eggs/.docs/instructions.append.md
@@ -1,8 +1,11 @@
+# Instructions append
+
 ## Bitwise operators
 
 In PHP there are [bitwise operators](https://www.php.net/manual/en/language.operators.bitwise.php).
 
 For example, the "bitwise and" operator (`&`) can be used to check that a bit of a number is defined:
+
 ```php
 $number = 89; // 0b01011001
 $mask16 = 16; // 0b00010000

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Introduction append
 
+## Implementation
+
 For this exercise, you may want to look at [PHP property hooks][property_hooks].
 
 [property_hooks]: https://www.php.net/manual/en/language.oop5.property-hooks.php

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Callable
 
 In PHP there is a concept of [callable](https://www.php.net/manual/en/language.types.callable.php).

--- a/exercises/practice/rotational-cipher/.docs/instructions.append.md
+++ b/exercises/practice/rotational-cipher/.docs/instructions.append.md
@@ -1,3 +1,8 @@
+# Instructions append
+
+## Implementation
+
 ~~~~exercism/note
-Do not use PHP functions like `str_rot13()` to solve this exercise! Only use basic string and character manipulation functions.
+Do not use PHP functions like `str_rot13()` to solve this exercise!
+Only use basic string and character manipulation functions.
 ~~~~


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.