### PR TITLE
#967 Sync resistor-color-duo

### DIFF
--- a/bin/auto-sync.txt
+++ b/bin/auto-sync.txt
@@ -62,6 +62,7 @@ pig-latin
 protein-translation
 proverb
 raindrops
+resistor-color-duo
 reverse-string
 rna-transcription
 robot-simulator

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "MichaelBunker"
   ],
+  "contributors": [
+    "resu-xuniL"
+  ],
   "files": {
     "solution": [
       "ResistorColorDuo.php"

--- a/exercises/practice/resistor-color-duo/.meta/example.php
+++ b/exercises/practice/resistor-color-duo/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class ResistorColorDuo

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -1,0 +1,31 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[ce11995a-5b93-4950-a5e9-93423693b2fc]
+description = "Brown and black"
+
+[7bf82f7a-af23-48ba-a97d-38d59406a920]
+description = "Blue and grey"
+
+[f1886361-fdfd-4693-acf8-46726fe24e0c]
+description = "Yellow and violet"
+
+[b7a6cbd2-ae3c-470a-93eb-56670b305640]
+description = "White and red"
+
+[77a8293d-2a83-4016-b1af-991acc12b9fe]
+description = "Orange and orange"
+
+[0c4fb44f-db7c-4d03-afa8-054350f156a8]
+description = "Ignore additional colors"
+
+[4a8ceec5-0ab4-4904-88a4-daf953a5e818]
+description = "Black and brown, one-digit"

--- a/exercises/practice/resistor-color-duo/ResistorColorDuoTest.php
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuoTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;

--- a/exercises/practice/resistor-color-duo/ResistorColorDuoTest.php
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuoTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
 
 class ResistorColorDuoTest extends TestCase
 {
@@ -18,37 +19,65 @@ class ResistorColorDuoTest extends TestCase
         $this->resistor = new ResistorColorDuo();
     }
 
+    /**
+     * uuid ce11995a-5b93-4950-a5e9-93423693b2fc
+     */
+    #[TestDox('Brown and black')]
     public function testBrownAndBlack(): void
     {
         $this->assertEquals(10, $this->resistor->getColorsValue(['brown', 'black']));
     }
 
+    /**
+     * uuid 7bf82f7a-af23-48ba-a97d-38d59406a920
+     */
+    #[TestDox('Blue and grey')]
     public function testBlueAndGrey(): void
     {
         $this->assertEquals(68, $this->resistor->getColorsValue(['blue', 'grey']));
     }
 
+    /**
+     * uuid f1886361-fdfd-4693-acf8-46726fe24e0c
+     */
+    #[TestDox('Yellow and violet')]
     public function testYellowAndViolet(): void
     {
         $this->assertEquals(47, $this->resistor->getColorsValue(['yellow', 'violet']));
     }
 
+    /**
+     * uuid b7a6cbd2-ae3c-470a-93eb-56670b305640
+     */
+    #[TestDox('White and red')]
     public function testWhiteAndRed(): void
     {
         $this->assertEquals(92, $this->resistor->getColorsValue(['white', 'red']));
     }
 
+    /**
+     * uuid 77a8293d-2a83-4016-b1af-991acc12b9fe
+     */
+    #[TestDox('Orange and orange')]
     public function testOrangeAndOrange(): void
     {
         $this->assertEquals(33, $this->resistor->getColorsValue(['orange', 'orange']));
     }
 
-    public function testAdditionalColorsAreIgnored(): void
+    /**
+     * uuid 0c4fb44f-db7c-4d03-afa8-054350f156a8
+     */
+    #[TestDox('Ignore additional colors')]
+    public function testIgnoreAdditionalColors(): void
     {
         $this->assertEquals(51, $this->resistor->getColorsValue(['green', 'brown', 'orange']));
     }
 
-    public function testBlackAndBrownSingleDigit(): void
+    /**
+     * uuid 4a8ceec5-0ab4-4904-88a4-daf953a5e818
+     */
+    #[TestDox('Black and brown, one-digit')]
+    public function testBlackAndBrownOneDigit(): void
     {
         $this->assertEquals(1, $this->resistor->getColorsValue(['black', 'brown']));
     }


### PR DESCRIPTION
- [x] Synced resistor-color-duo metadata and docs
- [x] Removed strict types comments from `example.php` and `ResistorColorDuoTest`.php
- [x] Added UUID and TestDox to tests
- [x] Added missing tests
- [x] Added `resistor-color-duo` to `auto-sync.txt`
- [x] Added GitHub handle to `config.json`

Ref: [#967](https://github.com/exercism/php/issues/967)

[no important files changed]