### PR TITLE
Variable length quantity

### DIFF
--- a/bin/auto-sync.txt
+++ b/bin/auto-sync.txt
@@ -83,6 +83,7 @@ sublist
 twelve-days
 two-bucket
 two-fer
+variable-length-quantity
 wordy
 yacht
 zebra-puzzle

--- a/exercises/practice/variable-length-quantity/.docs/instructions.md
+++ b/exercises/practice/variable-length-quantity/.docs/instructions.md
@@ -2,10 +2,10 @@
 
 Implement variable length quantity encoding and decoding.
 
-The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
+The goal of this exercise is to implement [VLQ][vlq] encoding/decoding.
 
 In short, the goal of this encoding is to encode integer values in a way that would save bytes.
-Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte).
+Only the first 7 bits of each byte are significant (right-justified; sort of like an ASCII byte).
 So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes.
 Of course, you will have a variable number of bytes depending upon your integer.
 To indicate which is the last byte of the series, you leave bit #7 clear.
@@ -30,3 +30,5 @@ Here are examples of integers as 32-bit values, and the variable length quantiti
 08000000          C0 80 80 00
 0FFFFFFF          FF FF FF 7F
 ```
+
+[vlq]: https://en.wikipedia.org/wiki/Variable-length_quantity

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -7,7 +7,8 @@
     "Hrumpa",
     "kunicmarko20",
     "kytrinyx",
-    "petemcfarlane"
+    "petemcfarlane",
+    "A-O-Emmanuel"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/variable-length-quantity/.meta/example.php
+++ b/exercises/practice/variable-length-quantity/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 /**

--- a/exercises/practice/variable-length-quantity/.meta/tests.toml
+++ b/exercises/practice/variable-length-quantity/.meta/tests.toml
@@ -1,81 +1,103 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [35c9db2e-f781-4c52-b73b-8e76427defd0]
-description = "zero"
+description = "Encode a series of integers, producing a series of bytes. -> zero"
 
 [be44d299-a151-4604-a10e-d4b867f41540]
-description = "arbitrary single byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary single byte"
+
+[890bc344-cb80-45af-b316-6806a6971e81]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric single byte"
 
 [ea399615-d274-4af6-bbef-a1c23c9e1346]
-description = "largest single byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest single byte"
 
 [77b07086-bd3f-4882-8476-8dcafee79b1c]
-description = "smallest double byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest double byte"
 
 [63955a49-2690-4e22-a556-0040648d6b2d]
-description = "arbitrary double byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary double byte"
+
+[4977d113-251b-4d10-a3ad-2f5a7756bb58]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric double byte"
 
 [29da7031-0067-43d3-83a7-4f14b29ed97a]
-description = "largest double byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest double byte"
 
 [3345d2e3-79a9-4999-869e-d4856e3a8e01]
-description = "smallest triple byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest triple byte"
 
 [5df0bc2d-2a57-4300-a653-a75ee4bd0bee]
-description = "arbitrary triple byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary triple byte"
+
+[6731045f-1e00-4192-b5ae-98b22e17e9f7]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric triple byte"
 
 [f51d8539-312d-4db1-945c-250222c6aa22]
-description = "largest triple byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest triple byte"
 
 [da78228b-544f-47b7-8bfe-d16b35bbe570]
-description = "smallest quadruple byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest quadruple byte"
 
 [11ed3469-a933-46f1-996f-2231e05d7bb6]
-description = "arbitrary quadruple byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quadruple byte"
+
+[b45ef770-cbba-48c2-bd3c-c6362679516e]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric quadruple byte"
 
 [d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c]
-description = "largest quadruple byte"
+description = "Encode a series of integers, producing a series of bytes. -> largest quadruple byte"
 
 [91a18b33-24e7-4bfb-bbca-eca78ff4fc47]
-description = "smallest quintuple byte"
+description = "Encode a series of integers, producing a series of bytes. -> smallest quintuple byte"
 
 [5f34ff12-2952-4669-95fe-2d11b693d331]
-description = "arbitrary quintuple byte"
+description = "Encode a series of integers, producing a series of bytes. -> arbitrary quintuple byte"
+
+[9be46731-7cd5-415c-b960-48061cbc1154]
+description = "Encode a series of integers, producing a series of bytes. -> asymmetric quintuple byte"
 
 [7489694b-88c3-4078-9864-6fe802411009]
-description = "maximum 32-bit integer input"
+description = "Encode a series of integers, producing a series of bytes. -> maximum 32-bit integer input"
 
 [f9b91821-cada-4a73-9421-3c81d6ff3661]
-description = "two single-byte values"
+description = "Encode a series of integers, producing a series of bytes. -> two single-byte values"
 
 [68694449-25d2-4974-ba75-fa7bb36db212]
-description = "two multi-byte values"
+description = "Encode a series of integers, producing a series of bytes. -> two multi-byte values"
 
 [51a06b5c-de1b-4487-9a50-9db1b8930d85]
-description = "many multi-byte values"
+description = "Encode a series of integers, producing a series of bytes. -> many multi-byte values"
 
 [baa73993-4514-4915-bac0-f7f585e0e59a]
-description = "one byte"
+description = "Decode a series of bytes, producing a series of integers. -> one byte"
 
 [72e94369-29f9-46f2-8c95-6c5b7a595aee]
-description = "two bytes"
+description = "Decode a series of bytes, producing a series of integers. -> two bytes"
 
 [df5a44c4-56f7-464e-a997-1db5f63ce691]
-description = "three bytes"
+description = "Decode a series of bytes, producing a series of integers. -> three bytes"
 
 [1bb58684-f2dc-450a-8406-1f3452aa1947]
-description = "four bytes"
+description = "Decode a series of bytes, producing a series of integers. -> four bytes"
 
 [cecd5233-49f1-4dd1-a41a-9840a40f09cd]
-description = "maximum 32-bit integer"
+description = "Decode a series of bytes, producing a series of integers. -> maximum 32-bit integer"
 
 [e7d74ba3-8b8e-4bcb-858d-d08302e15695]
-description = "incomplete sequence causes error"
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error"
 
 [aa378291-9043-4724-bc53-aca1b4a3fcb6]
-description = "incomplete sequence causes error, even if value is zero"
+description = "Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error, even if value is zero"
 
 [a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee]
-description = "multiple values"
+description = "Decode a series of bytes, producing a series of integers. -> multiple values"

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;

--- a/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
+++ b/exercises/practice/variable-length-quantity/VariableLengthQuantityTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
 
 class VariableLengthQuantityTest extends TestCase
 {
@@ -11,120 +12,307 @@ class VariableLengthQuantityTest extends TestCase
         require_once 'VariableLengthQuantity.php';
     }
 
-    public function testItEncodesSingleBytes(): void
+    /**
+     * uuid 35c9db2e-f781-4c52-b73b-8e76427defd0
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> zero')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesZero(): void
     {
         $this->assertEquals([0x00], vlq_encode([0x00]));
+    }
+
+    /**
+     * uuid be44d299-a151-4604-a10e-d4b867f41540
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> arbitrary single byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesArbitrarySingleByte(): void
+    {
         $this->assertEquals([0x40], vlq_encode([0x40]));
+    }
+
+    /**
+     * uuid 890bc344-cb80-45af-b316-6806a6971e81
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> asymmetric single byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesAsymmetricSingleByte(): void
+    {
+        $this->assertEquals([0x53], vlq_encode([0x53]));
+    }
+
+    /**
+     * uuid ea399615-d274-4af6-bbef-a1c23c9e1346
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> largest single byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesLargestSingleByte(): void
+    {
         $this->assertEquals([0x7f], vlq_encode([0x7f]));
     }
 
-    public function testItEncodesDoubleBytes(): void
+    /**
+     * uuid 77b07086-bd3f-4882-8476-8dcafee79b1c
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> smallest double byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesSmallestDoubleByte(): void
     {
         $this->assertEquals([0x81, 0x00], vlq_encode([0x80]));
-        $this->assertEquals([0xc0, 0x00], vlq_encode([0x2000]));
-        $this->assertEquals([0xff, 0x7f], vlq_encode([0x3fff]));
     }
 
-    public function testItEncodesTripleBytes(): void
+    /**
+     * uuid 63955a49-2690-4e22-a556-0040648d6b2d
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> arbitrary double byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesArbitraryDoubleByte(): void
+    {
+        $this->assertEquals([0xC0, 0x00], vlq_encode([0x2000]));
+    }
+
+    /**
+     * uuid 4977d113-251b-4d10-a3ad-2f5a7756bb58
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> asymmetric double byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesAsymmetricDoubleByte(): void
+    {
+        $this->assertEquals([0x81, 0x2D], vlq_encode([0xAD]));
+    }
+
+    /**
+     * uuid 29da7031-0067-43d3-83a7-4f14b29ed97a
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> largest double byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesLargestDoubleByte(): void
+    {
+        $this->assertEquals([0xFF, 0x7F], vlq_encode([0x3FFF]));
+    }
+
+    /**
+     * uuid 3345d2e3-79a9-4999-869e-d4856e3a8e01
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> smallest triple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesSmallestTripleByte(): void
     {
         $this->assertEquals([0x81, 0x80, 0x00], vlq_encode([0x4000]));
-        $this->assertEquals([0xc0, 0x80, 0x00], vlq_encode([0x100000]));
-        $this->assertEquals([0xff, 0xff, 0x7f], vlq_encode([0x1fffff]));
     }
 
-    public function testItEncodesQuadrupleBytes(): void
+    /**
+     * uuid 5df0bc2d-2a57-4300-a653-a75ee4bd0bee
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> arbitrary triple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesArbitraryTripleByte(): void
+    {
+        $this->assertEquals([0xC0, 0x80, 0x00], vlq_encode([0x100000]));
+    }
+
+    /**
+     * uuid 6731045f-1e00-4192-b5ae-98b22e17e9f7
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> asymmetric triple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesAsymmetricTripleByte(): void
+    {
+        $this->assertEquals([0x87, 0xAB, 0x1C], vlq_encode([0x1D6DC]));
+    }
+
+    /**
+     * uuid f51d8539-312d-4db1-945c-250222c6aa22
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> largest triple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesLargestTripleByte(): void
+    {
+        $this->assertEquals([0xFF, 0xFF, 0x7F], vlq_encode([0x1FFFFF]));
+    }
+
+    /**
+     * uuid da78228b-544f-47b7-8bfe-d16b35bbe570
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> smallest quadruple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesSmallestQuadrupleByte(): void
     {
         $this->assertEquals([0x81, 0x80, 0x80, 0x00], vlq_encode([0x200000]));
-        $this->assertEquals([0xc0, 0x80, 0x80, 0x00], vlq_encode([0x8000000]));
-        $this->assertEquals([0xff, 0xff, 0xff, 0x7f], vlq_encode([0xfffffff]));
     }
 
-    public function testItEncodesMultipleValues(): void
+    /**
+     * uuid 11ed3469-a933-46f1-996f-2231e05d7bb6
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> arbitrary quadruple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesArbitraryQuadrupleByte(): void
     {
-        $this->assertEquals([0x00, 0x00], vlq_encode([0x00, 0x00]));
-        $this->assertEquals([0x40, 0x7f], vlq_encode([0x40, 0x7f]));
-        $this->assertEquals([0x81, 0x80, 0x00, 0xc8, 0xe8, 0x56], vlq_encode([0x4000, 0x123456]));
-        $this->assertEquals([
-            0xc0, 0x00, 0xc8, 0xe8, 0x56,
-            0xff, 0xff, 0xff, 0x7f, 0x00,
-            0xff, 0x7f, 0x81, 0x80, 0x00,
-        ], vlq_encode(
-            [0x2000, 0x123456, 0x0fffffff, 0x00, 0x3fff, 0x4000]
-        ));
+        $this->assertEquals([0xC0, 0x80, 0x80, 0x00], vlq_encode([0x8000000]));
     }
 
-    public function testItDecodesFromSingleBytes(): void
+    /**
+     * uuid b45ef770-cbba-48c2-bd3c-c6362679516e
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> asymmetric quadruple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesAsymmetricQuadrupleByte(): void
     {
-        $this->assertEquals([0x00], vlq_decode([0x00]));
-        $this->assertEquals([0x40], vlq_decode([0x40]));
-        $this->assertEquals([0x7f], vlq_decode([0x7f]));
+        $this->assertEquals([0x81, 0xD5, 0xEE, 0x04], vlq_encode([0x357F34]));
     }
 
-    public function testItDecodesDoubleBytes(): void
+    /**
+     * uuid d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> largest quadruple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesLargestQuadrupleByte(): void
     {
-        $this->assertEquals([0x80], vlq_decode([0x81, 0x00]));
-        $this->assertEquals([0x2000], vlq_decode([0xc0, 0x00]));
-        $this->assertEquals([0x3fff], vlq_decode([0xff, 0x7f]));
+        $this->assertEquals([0xFF, 0xFF, 0xFF, 0x7F], vlq_encode([0x0FFFFFFF]));
     }
 
-    public function testItDecodesTripleBytes(): void
+    /**
+     * uuid 91a18b33-24e7-4bfb-bbca-eca78ff4fc47
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> smallest quintuple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesSmallestQuintupleByte(): void
     {
-        $this->assertEquals([0x4000], vlq_decode([0x81, 0x80, 0x00]));
-        $this->assertEquals([0x100000], vlq_decode([0xc0, 0x80, 0x00]));
-        $this->assertEquals([0x1FFFFF], vlq_decode([0xff, 0xff, 0x7f]));
+        $this->assertEquals([0x81, 0x80, 0x80, 0x80, 0x00], vlq_encode([0x10000000]));
     }
 
-    public function testItDecodesQuadrupleBytes(): void
+    /**
+     * uuid 5f34ff12-2952-4669-95fe-2d11b693d331
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> arbitrary quintuple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesArbitraryQuintupleByte(): void
     {
-        $this->assertEquals([0x200000], vlq_decode([0x81, 0x80, 0x80, 0x00]));
-        $this->assertEquals([0x8000000], vlq_decode([0xc0, 0x80, 0x80, 0x00]));
-        $this->assertEquals([0xFFFFFFF], vlq_decode([0xff, 0xff, 0xff, 0x7f]));
+        $this->assertEquals([0x8F, 0xF8, 0x80, 0x80, 0x00], vlq_encode([0xFF000000]));
     }
 
-    public function testItDecodesMultipleValues(): void
+    /**
+     * uuid 9be46731-7cd5-415c-b960-48061cbc1154
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> asymmetric quintuple byte')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesAsymmetricQuintupleByte(): void
     {
-        $this->assertEquals([0x00, 0x00], vlq_decode([0x00, 0x00]));
-        $this->assertEquals([0x40, 0x7f], vlq_decode([0x40, 0x7f]));
-        $this->assertEquals([0x4000, 0x123456], vlq_decode([0x81, 0x80, 0x00, 0xc8, 0xe8, 0x56]));
+        $this->assertEquals([0x88, 0xB3, 0x95, 0xC2, 0x05], vlq_encode([0x8665C205]));
+    }
+
+    /**
+     * uuid 7489694b-88c3-4078-9864-6fe802411009
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> maximum 32-bit integer input')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesMaximum32BitIntegerInput(): void
+    {
+        $this->assertEquals([0x8F, 0xFF, 0xFF, 0xFF, 0x7F], vlq_encode([0xFFFFFFFF]));
+    }
+
+    /**
+     * uuid f9b91821-cada-4a73-9421-3c81d6ff3661
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> two single-byte values')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesTwoSingleByteValues(): void
+    {
+        $this->assertEquals([0x40, 0x7F], vlq_encode([0x40, 0x7F]));
+    }
+
+    /**
+     * uuid 68694449-25d2-4974-ba75-fa7bb36db212
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> two multi-byte values')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesTwoMultiByteValues(): void
+    {
         $this->assertEquals(
-            [0x2000, 0x123456, 0x0fffffff, 0x00, 0x3fff, 0x4000],
-            vlq_decode([
-                0xc0, 0x00, 0xc8, 0xe8, 0x56,
-                0xff, 0xff, 0xff, 0x7f, 0x00,
-                0xff, 0x7f, 0x81, 0x80, 0x00,
-            ])
+            [0x81, 0x80, 0x00, 0xC8, 0xE8, 0x56],
+            vlq_encode([0x4000, 0x123456])
         );
     }
 
-    public function testIncompleteByteSequence(): void
+    /**
+     * uuid 51a06b5c-de1b-4487-9a50-9db1b8930d85
+     */
+    #[TestDox('Encode a series of integers, producing a series of bytes. -> many multi-byte values')]
+    public function testEncodeSeriesOfIntegersProducingSeriesOfBytesManyMultiByteValues(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        vlq_decode([0xff]);
+        $this->assertEquals(
+            [
+                0xC0, 0x00,
+                0xC8, 0xE8, 0x56,
+                0xFF, 0xFF, 0xFF, 0x7F,
+                0x00,
+                0xFF, 0x7F,
+                0x81, 0x80, 0x00
+            ],
+            vlq_encode([0x2000, 0x123456, 0x0FFFFFFF, 0x00, 0x3FFF, 0x4000])
+        );
     }
 
-    public function testOverflow(): void
+    /**
+     * uuid baa73993-4514-4915-bac0-f7f585e0e59a
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> one byte')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersOneByte(): void
     {
-        $this->expectException(OverflowException::class);
-
-        vlq_decode([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]);
+        $this->assertEquals([0x7F], vlq_decode([0x7F]));
     }
 
-    public function testChainedDecodeEncodeGivesOriginalBytes(): void
+    /**
+     * uuid 72e94369-29f9-46f2-8c95-6c5b7a595aee
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> two bytes')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersTwoBytes(): void
     {
-        $bytes = [
-            0xc0, 0x00, 0xc8, 0xe8, 0x56,
-            0xff, 0xff, 0xff, 0x7f, 0x00,
-            0xff, 0x7f, 0x81, 0x80, 0x00,
-        ];
-
-        $this->assertTrue($bytes === vlq_encode(vlq_decode($bytes)));
+        $this->assertEquals([8192], vlq_decode([0xC0, 0x00]));
     }
 
-    public function testChainedEncodeDecodeGivesOriginalIntegers(): void
+    /**
+     * uuid df5a44c4-56f7-464e-a997-1db5f63ce691
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> three bytes')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersThreeBytes(): void
     {
-        $integers = [0x2000, 0x123456, 0x0fffffff, 0x00, 0x3fff, 0x4000];
+        $this->assertEquals([2097151], vlq_decode([0xFF, 0xFF, 0x7F]));
+    }
 
-        $this->assertEquals($integers, vlq_decode(vlq_encode($integers)));
+    /**
+     * uuid 1bb58684-f2dc-450a-8406-1f3452aa1947
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> four bytes')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersFourBytes(): void
+    {
+        $this->assertEquals([2097152], vlq_decode([0x81, 0x80, 0x80, 0x00]));
+    }
+
+    /**
+     * uuid cecd5233-49f1-4dd1-a41a-9840a40f09cd
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> maximum 32-bit integer')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersMaximum32BitInteger(): void
+    {
+        $this->assertEquals([4294967295], vlq_decode([0x8F, 0xFF, 0xFF, 0xFF, 0x7F]));
+    }
+
+    /**
+     * uuid e7d74ba3-8b8e-4bcb-858d-d08302e15695
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersIncompleteSequenceCausesError(): void
+    {
+        $this->expectExceptionMessage('incomplete sequence');
+        vlq_decode([0xFF]);
+    }
+
+    /**
+     * uuid aa378291-9043-4724-bc53-aca1b4a3fcb6
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> incomplete sequence causes error, even if value is zero')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersIncompleteSequenceZeroValue(): void
+    {
+        $this->expectExceptionMessage('incomplete sequence');
+        vlq_decode([0x80]);
+    }
+
+    /**
+     * uuid a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee
+     */
+    #[TestDox('Decode a series of bytes, producing a series of integers. -> multiple values')]
+    public function testDecodeSeriesOfBytesProducingSeriesOfIntegersMultipleValues(): void
+    {
+        $this->assertEquals(
+            [8192, 1193046, 268435455, 0, 16383, 16384],
+            vlq_decode([
+                0xC0, 0x00,
+                0xC8, 0xE8, 0x56,
+                0xFF, 0xFF, 0xFF, 0x7F,
+                0x00,
+                0xFF, 0x7F,
+                0x81, 0x80, 0x00
+            ])
+        );
     }
 }


### PR DESCRIPTION
This PR updates the PHP track implementation of variable-length-quantity to bring it fully in line with the current canonical data from problem-specifications.

✅ Summary of Changes
1. Ran configlet sync for the exercise
Updated exercise metadata using:
configlet sync -u -e variable-length-quantity --yes --docs --filepaths --metadata --tests include

Ensured Markdown instructions and .meta files reflect the latest canonical content.

Resolved the previously unsynced instructions.md.

2. Cleaned up strict types comments
Removed unnecessary // strict_types comments from:

Test file

Example solution

Preserved the directive itself (declare(strict_types=1);) as required for PHP track consistency.

Left the comment intact in the student stub file, per track conventions.

3. Synced test metadata
Added missing UUIDs to test DocBlocks.

Updated all #[TestDox] annotations to match canonical descriptions exactly.

Ensured every test case corresponds 1:1 with the canonical JSON.

4. Updated test method names
Renamed all test methods to reflect the full canonical description for clarity and consistency.

Ensured naming is deterministic and generator‑friendly.

5. Added exercise to bin/auto-sync.txt
Inserted variable-length-quantity alphabetically to keep the file properly ordered.

Ensures future syncs will include this exercise automatically.

6. Reviewed, adjusted, and ordered test cases
Verified all test cases match canonical order.

Removed outdated patterns and ensured full alignment with current problem-specifications.

Confirmed no missing or duplicated tests.

7. Added contributor entry
Added my GitHub handle to .meta/config.json as a contributor to this exercise.