### PR TITLE
Sync resistor-color #966 

### DIFF
--- a/bin/auto-sync.txt
+++ b/bin/auto-sync.txt
@@ -64,6 +64,7 @@ proverb
 queen-attack
 rail-fence-cipher
 raindrops
+resistor-color
 resistor-color-duo
 reverse-string
 rna-transcription

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -3,6 +3,7 @@
     "camilopayan"
   ],
   "contributors": [
+    "manupereiraduarte",
     "MichaelBunker"
   ],
   "files": {

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -3,8 +3,8 @@
     "camilopayan"
   ],
   "contributors": [
-    "manupereiraduarte",
-    "MichaelBunker"
+    "MichaelBunker",
+    "manupereiraduarte"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/resistor-color/.meta/example.php
+++ b/exercises/practice/resistor-color/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 function getAllColors(): array

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -1,0 +1,22 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[49eb31c5-10a8-4180-9f7f-fea632ab87ef]
+description = "Color codes -> Black"
+
+[0a4df94b-92da-4579-a907-65040ce0b3fc]
+description = "Color codes -> White"
+
+[5f81608d-f36f-4190-8084-f45116b6f380]
+description = "Color codes -> Orange"
+
+[581d68fa-f968-4be2-9f9d-880f2fb73cf7]
+description = "Colors"

--- a/exercises/practice/resistor-color/ResistorColorTest.php
+++ b/exercises/practice/resistor-color/ResistorColorTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
@@ -33,6 +11,10 @@ class ResistorColorTest extends TestCase
         require_once 'ResistorColor.php';
     }
 
+    /**
+     * uuid: 581d68fa-f968-4be2-9f9d-880f2fb73cf7
+     */
+    #[TestDox('Colors')]
     public function testColors(): void
     {
         $this->assertEquals([
@@ -49,16 +31,28 @@ class ResistorColorTest extends TestCase
         ], getAllColors());
     }
 
+    /**
+     * uuid: 49eb31c5-10a8-4180-9f7f-fea632ab87ef
+     */
+    #[TestDox('Black')]
     public function testBlackColorCode(): void
     {
         $this->assertEquals(0, colorCode("black"));
     }
 
+    /**
+     * uuid: 5f81608d-f36f-4190-8084-f45116b6f380
+     */
+    #[TestDox('Orange')]
     public function testOrangeColorCode(): void
     {
         $this->assertEquals(3, colorCode("orange"));
     }
 
+    /**
+     * uuid: 0a4df94b-92da-4579-a907-65040ce0b3fc
+     */
+    #[TestDox('White')]
     public function testWhiteColorCode(): void
     {
         $this->assertEquals(9, colorCode("white"));

--- a/exercises/practice/resistor-color/ResistorColorTest.php
+++ b/exercises/practice/resistor-color/ResistorColorTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class ResistorColorTest extends TestCase


### PR DESCRIPTION
Closes #966

- Removed strict types comment block from test file and example solution
- Added UUIDs and `#[TestDox()]` attributes to all tests
- Added `tests.toml` with all test UUIDs
- Added `resistor-color` to `bin/auto-sync.txt`
- Added myself as contributor in `config.json`

Tests pass locally with the example solution.