### PR TITLE
Add CI job to ensure practice exercise order

### DIFF
--- a/.github/workflows/order-of-practice-exercises.yml
+++ b/.github/workflows/order-of-practice-exercises.yml
@@ -1,0 +1,16 @@
+name: Ensure practice exercise order
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  call-gha-workflow:
+    name: check
+    uses: exercism/github-actions/.github/workflows/sorted.yml@main
+    with:
+      ordering: ".difficulty, .lowercase_name"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following system dependencies are required:
 - [`bash` shell][gnu-bash].
 - PHP V8.4+ CLI.
 - An active Internet connection for installing required tools / composer packages.
+- [`jq`][jq], if you change the difficulty or add a practice exercise.
 
 Run the following command to get started with this project:
 
@@ -90,6 +91,8 @@ contribution/generator/bin/console app:create-tests '<slug>'
 composer lint:fix
 ```
 
+Run `bin/order-exercises.sh` when you set the exercise difficulty to a sensible value to order the exercises on the website accordingly.
+
 [exercism-configlet]: https://exercism.org/docs/building/configlet
 [exercism-docs]: https://exercism.org/docs
 [exercism-track-home]: https://exercism.org/docs/tracks/php
@@ -98,3 +101,4 @@ composer lint:fix
 [gnu-bash]: https://www.gnu.org/software/bash/
 [local-file-phpcs-config]: phpcs.xml
 [psr-12]: https://www.php-fig.org/psr/psr-12
+[jq]: https://jqlang.org/

--- a/bin/order-exercises.sh
+++ b/bin/order-exercises.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# matches ".difficulty, .lowercase_name" in .github/workflows/order-of-practice-exercises.yml
+
+jq '
+    .exercises.practice |= (
+        map(if .slug == "hello-world" then .difficulty = -1 else . end)
+        | sort_by(.difficulty, (.name|ascii_downcase))
+        | .[0].difficulty = 1
+    )
+' config.json > config.sorted && mv config.sorted config.json

--- a/config.json
+++ b/config.json
@@ -151,246 +151,6 @@
         ]
       },
       {
-        "slug": "reverse-string",
-        "name": "Reverse String",
-        "uuid": "cb533bd3-641d-47ad-a8ca-cebc76075c0b",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "strings"
-        ]
-      },
-      {
-        "slug": "resistor-color",
-        "name": "Resistor Color",
-        "uuid": "141733c5-6d35-4320-a248-54f6a16f1f85",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1
-      },
-      {
-        "slug": "line-up",
-        "name": "Line up",
-        "uuid": "6016009e-9012-447a-87b7-d33ea01492d9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "hamming",
-        "name": "Hamming",
-        "uuid": "48de430b-0d88-4af0-ab48-d00b840312bb",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
-      },
-      {
-        "slug": "resistor-color-duo",
-        "name": "Resistor Color Duo",
-        "uuid": "1e72df07-c456-4501-a274-4b0e2b245167",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1
-      },
-      {
-        "slug": "proverb",
-        "name": "Proverb",
-        "uuid": "75519a64-8237-49e5-927f-c5974816258e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "gigasecond",
-        "name": "Gigasecond",
-        "uuid": "81aa4bc9-4936-46c2-bb2f-433246a86c5d",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "dates"
-        ]
-      },
-      {
-        "slug": "tournament",
-        "name": "Tournament",
-        "uuid": "e0572cf4-5481-4da4-bf9b-0e921cb81627",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "parsing",
-          "strings"
-        ]
-      },
-      {
-        "slug": "simple-cipher",
-        "name": "Simple Cipher",
-        "uuid": "054a332f-f6db-46eb-b86c-2c95829c9ed2",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "randomness",
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
-      },
-      {
-        "slug": "high-scores",
-        "name": "High Scores",
-        "uuid": "723b1abd-24e3-4a0d-a34d-20b7b76c9f59",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "arrays"
-        ]
-      },
-      {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "ae91650f-fe06-466a-a40a-6a24f5926fbe",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "control_flow_if_else_statements",
-          "strings"
-        ]
-      },
-      {
-        "slug": "rna-transcription",
-        "name": "RNA Transcription",
-        "uuid": "81d96250-f2e4-4228-a8e9-254b6b8784ac",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "strings",
-          "transforming"
-        ]
-      },
-      {
-        "slug": "luhn",
-        "name": "Luhn",
-        "uuid": "1b034dc9-be9a-4434-bc78-57742f63107e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4
-      },
-      {
-        "slug": "isogram",
-        "name": "Isogram",
-        "uuid": "435f0ec1-f53c-4fe4-b92b-43a582c2fa82",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
-      },
-      {
-        "slug": "resistor-color-trio",
-        "name": "Resistor Color Trio",
-        "uuid": "eb3ef767-fb22-4f5a-96aa-e1f680644dd9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
-        "slug": "robot-name",
-        "name": "Robot Name",
-        "uuid": "b24d5f98-8d62-4177-b0ae-306bbf0f918b",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "classes",
-          "randomness",
-          "strings"
-        ]
-      },
-      {
-        "slug": "twelve-days",
-        "name": "Twelve Days",
-        "uuid": "c5b122ab-6f8e-476b-8b55-84670edc93b5",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "difference-of-squares",
-        "name": "Difference of Squares",
-        "uuid": "238d86fe-6e29-43b0-9e27-a54caa773618",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "integers",
-          "math"
-        ]
-      },
-      {
-        "slug": "grade-school",
-        "name": "Grade School",
-        "uuid": "2d2974e2-2d5e-41d9-8dc3-951967631b37",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6,
-        "topics": [
-          "arrays"
-        ]
-      },
-      {
-        "slug": "robot-simulator",
-        "name": "Robot Simulator",
-        "uuid": "cc6c3b27-b719-454c-a743-7bc73bd47cf1",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "oop"
-        ]
-      },
-      {
-        "slug": "run-length-encoding",
-        "name": "Run-Length Encoding",
-        "uuid": "0a453685-55c2-47e2-88b2-e26d1d8fbde9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "text_formatting"
-        ]
-      },
-      {
-        "slug": "largest-series-product",
-        "name": "Largest Series Product",
-        "uuid": "4fbeb249-dc1d-4282-8455-d1c06a7cb420",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "integers",
-          "math",
-          "strings",
-          "transforming"
-        ]
-      },
-      {
         "slug": "accumulate",
         "name": "Accumulate",
         "uuid": "87edd481-d099-46b8-9137-22bf8f817e42",
@@ -602,12 +362,12 @@
         "difficulty": 1
       },
       {
-        "slug": "flower-field",
-        "name": "Flower Field",
-        "uuid": "3443aa60-53d4-4483-ad96-07eba9a23b9e",
+        "slug": "micro-blog",
+        "name": "Micro Blog",
+        "uuid": "203ba680-cdbd-494d-a1b6-af426bc84e59",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 6
+        "difficulty": 1
       },
       {
         "slug": "minesweeper",
@@ -669,6 +429,33 @@
           "cryptography",
           "lists",
           "text_formatting"
+        ]
+      },
+      {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "141733c5-6d35-4320-a248-54f6a16f1f85",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "1e72df07-c456-4501-a274-4b0e2b245167",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "cb533bd3-641d-47ad-a8ca-cebc76075c0b",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "topics": [
+          "strings"
         ]
       },
       {
@@ -779,19 +566,6 @@
         ]
       },
       {
-        "slug": "wordy",
-        "name": "Wordy",
-        "uuid": "85408bdd-3c22-4b5a-9c61-044ddfb0c3ac",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "parsing",
-          "strings",
-          "transforming"
-        ]
-      },
-      {
         "slug": "armstrong-numbers",
         "name": "Armstrong Numbers",
         "uuid": "9e7be7f8-ea50-4245-bde3-2207f0bcebdd",
@@ -800,6 +574,31 @@
         "difficulty": 2,
         "topics": [
           "algorithms",
+          "math"
+        ]
+      },
+      {
+        "slug": "darts",
+        "name": "Darts",
+        "uuid": "9875a830-b544-4060-9df1-7b7c1f1576f6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "conditionals",
+          "math",
+          "geometry"
+        ]
+      },
+      {
+        "slug": "difference-of-squares",
+        "name": "Difference of Squares",
+        "uuid": "238d86fe-6e29-43b0-9e27-a54caa773618",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "integers",
           "math"
         ]
       },
@@ -815,6 +614,77 @@
         ]
       },
       {
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "uuid": "81aa4bc9-4936-46c2-bb2f-433246a86c5d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "dates"
+        ]
+      },
+      {
+        "slug": "hamming",
+        "name": "Hamming",
+        "uuid": "48de430b-0d88-4af0-ab48-d00b840312bb",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "filtering",
+          "strings"
+        ]
+      },
+      {
+        "slug": "high-scores",
+        "name": "High Scores",
+        "uuid": "723b1abd-24e3-4a0d-a34d-20b7b76c9f59",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "arrays"
+        ]
+      },
+      {
+        "slug": "isbn-verifier",
+        "name": "ISBN Verifier",
+        "uuid": "f7309216-0ba7-4990-acd7-4a47eca949fb",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "line-up",
+        "name": "Line up",
+        "uuid": "6016009e-9012-447a-87b7-d33ea01492d9",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "ordinal-number",
+        "name": "Ordinal Number",
+        "uuid": "48f2ed50-6169-4dd2-832f-6c41d016be64",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "status": "deprecated",
+        "topics": [
+          "strings",
+          "conditionals"
+        ]
+      },
+      {
+        "slug": "proverb",
+        "name": "Proverb",
+        "uuid": "75519a64-8237-49e5-927f-c5974816258e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "queen-attack",
         "name": "Queen Attack",
         "uuid": "94ceeb58-55c0-48b5-8a7c-d274f60b9010",
@@ -824,14 +694,6 @@
         "topics": [
           "integers"
         ]
-      },
-      {
-        "slug": "protein-translation",
-        "name": "Protein Translation",
-        "uuid": "f5ae2594-7e6d-4722-b6fe-df179a71aada",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
       },
       {
         "slug": "raindrops",
@@ -844,6 +706,14 @@
           "filtering",
           "text_formatting"
         ]
+      },
+      {
+        "slug": "say",
+        "name": "Say",
+        "uuid": "56873c13-5efd-462f-810f-1884d0c776a4",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       },
       {
         "slug": "scrabble-score",
@@ -859,6 +729,22 @@
         ]
       },
       {
+        "slug": "strain",
+        "name": "Strain",
+        "uuid": "8872a713-cb44-4769-a67b-85bbd944a726",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "sublist",
+        "name": "Sublist",
+        "uuid": "a5323160-bb75-4dd7-8800-789a83cd7008",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "sum-of-multiples",
         "name": "Sum of Multiples",
         "uuid": "1b44cb35-28ba-416b-8f45-d168d300f9b4",
@@ -868,6 +754,22 @@
         "topics": [
           "math"
         ]
+      },
+      {
+        "slug": "twelve-days",
+        "name": "Twelve Days",
+        "uuid": "c5b122ab-6f8e-476b-8b55-84670edc93b5",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "yacht",
+        "name": "Yacht",
+        "uuid": "7b51a6cf-e8d1-4942-9e0a-fa65b56a3821",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       },
       {
         "slug": "affine-cipher",
@@ -895,9 +797,25 @@
         ]
       },
       {
+        "slug": "bank-account",
+        "name": "Bank Account",
+        "uuid": "d85c328b-0778-46f6-bd50-d14417fa8347",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "binary-search",
         "name": "Binary Search",
         "uuid": "44867ac1-6aad-439a-a861-9acd3b619f19",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "binary-search-tree",
+        "name": "Binary Search Tree",
+        "uuid": "e13c2b59-75c1-4415-a439-b548721ebdbc",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3
@@ -914,16 +832,20 @@
         ]
       },
       {
-        "slug": "grains",
-        "name": "Grains",
-        "uuid": "3b001897-4052-4dab-84fd-b971a9946e0a",
+        "slug": "house",
+        "name": "House",
+        "uuid": "76a067bc-5bc3-47de-a539-69eb6c80473a",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "floating_point_numbers"
-        ]
+        "difficulty": 3
+      },
+      {
+        "slug": "kindergarten-garden",
+        "name": "Kindergarten Garden",
+        "uuid": "2fd3d924-477d-4113-96a5-c9687776da49",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
       },
       {
         "slug": "markdown",
@@ -934,6 +856,19 @@
         "difficulty": 3,
         "topics": [
           "refactoring"
+        ]
+      },
+      {
+        "slug": "mask-credit-card",
+        "name": "Mask Credit Card",
+        "uuid": "8ea0a659-df50-4575-b6a4-2a0e8d29738a",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "regex",
+          "strings",
+          "conditionals"
         ]
       },
       {
@@ -948,19 +883,6 @@
         ]
       },
       {
-        "slug": "ocr-numbers",
-        "name": "OCR Numbers",
-        "uuid": "a7a269a5-e99c-4fcf-b331-9a130e94f9e4",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "transforming"
-        ]
-      },
-      {
         "slug": "pascals-triangle",
         "name": "Pascal's Triangle",
         "uuid": "a2c918c0-6caa-4c15-a622-e093f3bacba3",
@@ -972,19 +894,6 @@
         ]
       },
       {
-        "slug": "matrix",
-        "name": "Matrix",
-        "uuid": "6d66ec15-b31d-4383-932d-45bc28db0647",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "strings",
-          "matrices",
-          "transforming"
-        ]
-      },
-      {
         "slug": "prime-factors",
         "name": "Prime Factors",
         "uuid": "96de0479-9438-4c74-b57c-67c7073be262",
@@ -993,6 +902,79 @@
         "difficulty": 3,
         "topics": [
           "math"
+        ]
+      },
+      {
+        "slug": "protein-translation",
+        "name": "Protein Translation",
+        "uuid": "f5ae2594-7e6d-4722-b6fe-df179a71aada",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "resistor-color-trio",
+        "name": "Resistor Color Trio",
+        "uuid": "eb3ef767-fb22-4f5a-96aa-e1f680644dd9",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "uuid": "81d96250-f2e4-4228-a8e9-254b6b8784ac",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "strings",
+          "transforming"
+        ]
+      },
+      {
+        "slug": "robot-name",
+        "name": "Robot Name",
+        "uuid": "b24d5f98-8d62-4177-b0ae-306bbf0f918b",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "classes",
+          "randomness",
+          "strings"
+        ]
+      },
+      {
+        "slug": "rotational-cipher",
+        "name": "Rotational Cipher",
+        "uuid": "61add6ab-9eaa-4fbc-b060-8ac44f47fad7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "tournament",
+        "name": "Tournament",
+        "uuid": "e0572cf4-5481-4da4-bf9b-0e921cb81627",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "parsing",
+          "strings"
+        ]
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "ae91650f-fe06-466a-a40a-6a24f5926fbe",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "control_flow_if_else_statements",
+          "strings"
         ]
       },
       {
@@ -1008,6 +990,59 @@
         ]
       },
       {
+        "slug": "food-chain",
+        "name": "Food Chain",
+        "uuid": "9fa82e62-1dd3-45c4-ae33-6c854a7b92b5",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
+        "slug": "grains",
+        "name": "Grains",
+        "uuid": "3b001897-4052-4dab-84fd-b971a9946e0a",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "algorithms",
+          "floating_point_numbers"
+        ]
+      },
+      {
+        "slug": "isogram",
+        "name": "Isogram",
+        "uuid": "435f0ec1-f53c-4fe4-b92b-43a582c2fa82",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "filtering",
+          "strings"
+        ]
+      },
+      {
+        "slug": "luhn",
+        "name": "Luhn",
+        "uuid": "1b034dc9-be9a-4434-bc78-57742f63107e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
+        "slug": "matrix",
+        "name": "Matrix",
+        "uuid": "6d66ec15-b31d-4383-932d-45bc28db0647",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "strings",
+          "matrices",
+          "transforming"
+        ]
+      },
+      {
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "4f15fc17-f68e-43bc-9417-403dd6d03f4f",
@@ -1017,14 +1052,6 @@
         "topics": [
           "strings"
         ]
-      },
-      {
-        "slug": "strain",
-        "name": "Strain",
-        "uuid": "8872a713-cb44-4769-a67b-85bbd944a726",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
       },
       {
         "slug": "pig-latin",
@@ -1051,24 +1078,78 @@
         ]
       },
       {
-        "slug": "sublist",
-        "name": "Sublist",
-        "uuid": "a5323160-bb75-4dd7-8800-789a83cd7008",
+        "slug": "scale-generator",
+        "name": "Scale Generator",
+        "uuid": "8f4545ce-85de-4064-b78c-2177325721b1",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2
+        "difficulty": 4,
+        "status": "deprecated",
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
       },
       {
-        "slug": "poker",
-        "name": "Poker",
-        "uuid": "e8669c8e-bfdd-4207-baf6-23c2e4b12d13",
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "uuid": "c0721b15-5bfb-4a2e-92d3-b2e32c096810",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
+        "slug": "spiral-matrix",
+        "name": "Spiral Matrix",
+        "uuid": "a8d52588-a7af-4543-867b-17f9728df77e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
+        "slug": "alphametics",
+        "name": "Alphametics",
+        "uuid": "49d212c6-6fa3-4e7b-95d9-595613630566",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "eliuds-eggs",
+        "name": "Eliud's Eggs",
+        "uuid": "9a8df843-8805-4287-b863-b8123defc266",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "killer-sudoku-helper",
+        "name": "Killer Sudoku Helper",
+        "uuid": "1ccf740f-9c81-4742-8e00-1ecc5c52d7a3",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "knapsack",
+        "name": "Knapsack",
+        "uuid": "79cdfd22-2c85-46af-ac00-719ac89bd5a9",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "largest-series-product",
+        "name": "Largest Series Product",
+        "uuid": "4fbeb249-dc1d-4282-8455-d1c06a7cb420",
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
         "topics": [
-          "games",
-          "parsing",
-          "sorting"
+          "integers",
+          "math",
+          "strings",
+          "transforming"
         ]
       },
       {
@@ -1084,6 +1165,120 @@
         ]
       },
       {
+        "slug": "ocr-numbers",
+        "name": "OCR Numbers",
+        "uuid": "a7a269a5-e99c-4fcf-b331-9a130e94f9e4",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "strings",
+          "transforming"
+        ]
+      },
+      {
+        "slug": "poker",
+        "name": "Poker",
+        "uuid": "e8669c8e-bfdd-4207-baf6-23c2e4b12d13",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "games",
+          "parsing",
+          "sorting"
+        ]
+      },
+      {
+        "slug": "robot-simulator",
+        "name": "Robot Simulator",
+        "uuid": "cc6c3b27-b719-454c-a743-7bc73bd47cf1",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "oop"
+        ]
+      },
+      {
+        "slug": "run-length-encoding",
+        "name": "Run-Length Encoding",
+        "uuid": "0a453685-55c2-47e2-88b2-e26d1d8fbde9",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "algorithms",
+          "strings",
+          "text_formatting"
+        ]
+      },
+      {
+        "slug": "state-of-tic-tac-toe",
+        "name": "State of Tic-Tac-Toe",
+        "uuid": "64ea517d-88ec-46db-b723-004681255580",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "516250c6-6e1b-4710-b2b9-6bef1716c6d8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "wordy",
+        "name": "Wordy",
+        "uuid": "85408bdd-3c22-4b5a-9c61-044ddfb0c3ac",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5,
+        "topics": [
+          "parsing",
+          "strings",
+          "transforming"
+        ]
+      },
+      {
+        "slug": "circular-buffer",
+        "name": "Circular Buffer",
+        "uuid": "3f077d57-472a-469a-885d-ebc6aaccd3d7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
+      },
+      {
+        "slug": "flower-field",
+        "name": "Flower Field",
+        "uuid": "3443aa60-53d4-4483-ad96-07eba9a23b9e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
+      },
+      {
+        "slug": "grade-school",
+        "name": "Grade School",
+        "uuid": "2d2974e2-2d5e-41d9-8dc3-951967631b37",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "topics": [
+          "arrays"
+        ]
+      },
+      {
+        "slug": "list-ops",
+        "name": "List Ops",
+        "uuid": "56f36086-96a8-4941-8c46-b563f02e5b09",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
+      },
+      {
         "slug": "palindrome-products",
         "name": "Palindrome Products",
         "uuid": "3201ddeb-9046-4801-a31a-28c292686e1e",
@@ -1096,136 +1291,21 @@
         ]
       },
       {
-        "slug": "darts",
-        "name": "Darts",
-        "uuid": "9875a830-b544-4060-9df1-7b7c1f1576f6",
+        "slug": "simple-cipher",
+        "name": "Simple Cipher",
+        "uuid": "054a332f-f6db-46eb-b86c-2c95829c9ed2",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2,
+        "difficulty": 6,
         "topics": [
+          "algorithms",
           "conditionals",
-          "math",
-          "geometry"
-        ]
-      },
-      {
-        "slug": "mask-credit-card",
-        "name": "Mask Credit Card",
-        "uuid": "8ea0a659-df50-4575-b6a4-2a0e8d29738a",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "regex",
+          "loops",
+          "randomness",
           "strings",
-          "conditionals"
+          "text_formatting",
+          "transforming"
         ]
-      },
-      {
-        "slug": "ordinal-number",
-        "name": "Ordinal Number",
-        "uuid": "48f2ed50-6169-4dd2-832f-6c41d016be64",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "deprecated",
-        "topics": [
-          "strings",
-          "conditionals"
-        ]
-      },
-      {
-        "slug": "house",
-        "name": "House",
-        "uuid": "76a067bc-5bc3-47de-a539-69eb6c80473a",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
-        "slug": "scale-generator",
-        "name": "Scale Generator",
-        "uuid": "8f4545ce-85de-4064-b78c-2177325721b1",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "status": "deprecated",
-        "topics": [
-          "conditionals",
-          "strings"
-        ]
-      },
-      {
-        "slug": "bank-account",
-        "name": "Bank Account",
-        "uuid": "d85c328b-0778-46f6-bd50-d14417fa8347",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
-        "slug": "alphametics",
-        "name": "Alphametics",
-        "uuid": "49d212c6-6fa3-4e7b-95d9-595613630566",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
-      },
-      {
-        "slug": "micro-blog",
-        "name": "Micro Blog",
-        "uuid": "203ba680-cdbd-494d-a1b6-af426bc84e59",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1
-      },
-      {
-        "slug": "yacht",
-        "name": "Yacht",
-        "uuid": "7b51a6cf-e8d1-4942-9e0a-fa65b56a3821",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "binary-search-tree",
-        "name": "Binary Search Tree",
-        "uuid": "e13c2b59-75c1-4415-a439-b548721ebdbc",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
-        "slug": "isbn-verifier",
-        "name": "ISBN Verifier",
-        "uuid": "f7309216-0ba7-4990-acd7-4a47eca949fb",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "say",
-        "name": "Say",
-        "uuid": "56873c13-5efd-462f-810f-1884d0c776a4",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "list-ops",
-        "name": "List Ops",
-        "uuid": "56f36086-96a8-4941-8c46-b563f02e5b09",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6
-      },
-      {
-        "slug": "spiral-matrix",
-        "name": "Spiral Matrix",
-        "uuid": "a8d52588-a7af-4543-867b-17f9728df77e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4
       },
       {
         "slug": "zebra-puzzle",
@@ -1234,86 +1314,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7
-      },
-      {
-        "slug": "knapsack",
-        "name": "Knapsack",
-        "uuid": "79cdfd22-2c85-46af-ac00-719ac89bd5a9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
-      },
-      {
-        "slug": "secret-handshake",
-        "name": "Secret Handshake",
-        "uuid": "c0721b15-5bfb-4a2e-92d3-b2e32c096810",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4
-      },
-      {
-        "slug": "killer-sudoku-helper",
-        "name": "Killer Sudoku Helper",
-        "uuid": "1ccf740f-9c81-4742-8e00-1ecc5c52d7a3",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
-      },
-      {
-        "slug": "circular-buffer",
-        "name": "Circular Buffer",
-        "uuid": "3f077d57-472a-469a-885d-ebc6aaccd3d7",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6
-      },
-      {
-        "slug": "state-of-tic-tac-toe",
-        "name": "State of Tic-Tac-Toe",
-        "uuid": "64ea517d-88ec-46db-b723-004681255580",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
-      },
-      {
-        "slug": "food-chain",
-        "name": "Food Chain",
-        "uuid": "9fa82e62-1dd3-45c4-ae33-6c854a7b92b5",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4
-      },
-      {
-        "slug": "kindergarten-garden",
-        "name": "Kindergarten Garden",
-        "uuid": "2fd3d924-477d-4113-96a5-c9687776da49",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
-        "slug": "rotational-cipher",
-        "name": "Rotational Cipher",
-        "uuid": "61add6ab-9eaa-4fbc-b060-8ac44f47fad7",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
-        "slug": "two-bucket",
-        "name": "Two Bucket",
-        "uuid": "516250c6-6e1b-4710-b2b9-6bef1716c6d8",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
-      },
-      {
-        "slug": "eliuds-eggs",
-        "name": "Eliud's Eggs",
-        "uuid": "9a8df843-8805-4287-b863-b8123defc266",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 5
       }
     ],
     "foregone": [


### PR DESCRIPTION
Establish a reproducible ordering of exercises, see [forum thread](https://forum.exercism.org/t/sorting-practice-exercises/56068) for details.

I chose sorting by `difficulty` directly, because that allows to use all 9 levels. And lower cased name did not sound bad to me.

Now someone would need to adjust difficulties to match some real difficulty :smiley: 