### PR TITLE
fix: `use` missing and correct typos

### DIFF
--- a/exercises/concept/lucky-numbers/LuckyNumbersTest.php
+++ b/exercises/concept/lucky-numbers/LuckyNumbersTest.php
@@ -264,7 +264,7 @@ class LuckyNumbersTest extends TestCase
      * @task_id 3
      */
     #[TestDox('Returns an empty string for a valid number input using octal notation')]
-    public function testReturnsAnEmptyStringForAValidNumberInputUsingOcatlNotation(): void
+    public function testReturnsAnEmptyStringForAValidNumberInputUsingOctalNotation(): void
     {
         $luckynumber = new LuckyNumbers();
         $this->assertSame('', $luckynumber->validate('00015-plus'));

--- a/exercises/practice/proverb/ProverbTest.php
+++ b/exercises/practice/proverb/ProverbTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
 
 class ProverbTest extends TestCase
 {

--- a/exercises/practice/twelve-days/TwelveDaysTest.php
+++ b/exercises/practice/twelve-days/TwelveDaysTest.php
@@ -188,7 +188,7 @@ class TwelveDaysTest extends TestCase
      * uuid c095af0d-3137-4653-ad32-bfb899eda24c
      */
     #[TestDox('lyrics -> recites three verses from the middle of the song')]
-    public function testLyricesRecitesThreeVersesFromMiddleOfSong(): void
+    public function testLyricsRecitesThreeVersesFromMiddleOfSong(): void
     {
         $expected =
             "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, " .


### PR DESCRIPTION
Just 2 typos fixing, and 1 missing `PHPUnit\Framework\Attributes\TestDox` _use_

[no important files changed]
