### PR TITLE
Sync resistor color trio (issue #993)

### DIFF
--- a/bin/auto-sync.txt
+++ b/bin/auto-sync.txt
@@ -68,6 +68,7 @@ rail-fence-cipher
 raindrops
 resistor-color
 resistor-color-duo
+resistor-color-trio
 reverse-string
 rna-transcription
 robot-name

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "MichaelBunker"
   ],
+  "contributors": [
+    "resu-xuniL"
+  ],
   "files": {
     "solution": [
       "ResistorColorTrio.php"

--- a/exercises/practice/resistor-color-trio/.meta/example.php
+++ b/exercises/practice/resistor-color-trio/.meta/example.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 class ResistorColorTrio

--- a/exercises/practice/resistor-color-trio/.meta/tests.toml
+++ b/exercises/practice/resistor-color-trio/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[d6863355-15b7-40bb-abe0-bfb1a25512ed]
+description = "Orange and orange and black"
+
+[1224a3a9-8c8e-4032-843a-5224e04647d6]
+description = "Blue and grey and brown"
+
+[b8bda7dc-6b95-4539-abb2-2ad51d66a207]
+description = "Red and black and red"
+
+[5b1e74bc-d838-4eda-bbb3-eaba988e733b]
+description = "Green and brown and orange"
+
+[f5d37ef9-1919-4719-a90d-a33c5a6934c9]
+description = "Yellow and violet and yellow"
+
+[5f6404a7-5bb3-4283-877d-3d39bcc33854]
+description = "Blue and violet and blue"
+
+[7d3a6ab8-e40e-46c3-98b1-91639fff2344]
+description = "Minimum possible value"
+
+[ca0aa0ac-3825-42de-9f07-dac68cc580fd]
+description = "Maximum possible value"
+
+[0061a76c-903a-4714-8ce2-f26ce23b0e09]
+description = "First two colors make an invalid octal number"
+
+[30872c92-f567-4b69-a105-8455611c10c4]
+description = "Ignore extra colors"

--- a/exercises/practice/resistor-color-trio/ResistorColorTrioTest.php
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrioTest.php
@@ -1,27 +1,5 @@
 <?php
 
-/*
- * By adding type hints and enabling strict type checking, code can become
- * easier to read, self-documenting and reduce the number of potential bugs.
- * By default, type declarations are non-strict, which means they will attempt
- * to change the original type to match the type specified by the
- * type-declaration.
- *
- * In other words, if you pass a string to a function requiring a float,
- * it will attempt to convert the string value to a float.
- *
- * To enable strict mode, a single declare directive must be placed at the top
- * of the file.
- * This means that the strictness of typing is configured on a per-file basis.
- * This directive not only affects the type declarations of parameters, but also
- * a function's return type.
- *
- * For more info review the Concept on strict type checking in the PHP track
- * <link>.
- *
- * To disable strict typing, comment out the directive below.
- */
-
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;

--- a/exercises/practice/resistor-color-trio/ResistorColorTrioTest.php
+++ b/exercises/practice/resistor-color-trio/ResistorColorTrioTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
 
 class ResistorColorTrioTest extends TestCase
 {
@@ -18,51 +19,91 @@ class ResistorColorTrioTest extends TestCase
         $this->resistor = new ResistorColorTrio();
     }
 
-    public function testOrangeOrangeAndBlack(): void
+    /**
+     * uuid d6863355-15b7-40bb-abe0-bfb1a25512ed
+     */
+    #[TestDox('Orange and orange and black')]
+    public function testOrangeAndOrangeAndBlack(): void
     {
         $this->assertEquals('33 ohms', $this->resistor->label(['orange', 'orange', 'black']));
     }
 
-    public function testBlueGreyAndBrown(): void
+    /**
+     * uuid 1224a3a9-8c8e-4032-843a-5224e04647d6
+     */
+    #[TestDox('Blue and grey and brown')]
+    public function testBlueAndGreyAndBrown(): void
     {
         $this->assertEquals('680 ohms', $this->resistor->label(['blue', 'grey', 'brown']));
     }
 
-    public function testRedBlackAndRed(): void
+    /**
+     * uuid b8bda7dc-6b95-4539-abb2-2ad51d66a207
+     */
+    #[TestDox('Red and black and red')]
+    public function testRedAndBlackAndRed(): void
     {
         $this->assertEquals('2 kiloohms', $this->resistor->label(['red', 'black', 'red']));
     }
 
-    public function testGreenBrownAndOrange(): void
+    /**
+     * uuid 5b1e74bc-d838-4eda-bbb3-eaba988e733b
+     */
+    #[TestDox('Green and brown and orange')]
+    public function testGreenAndBrownAndOrange(): void
     {
         $this->assertEquals('51 kiloohms', $this->resistor->label(['green', 'brown', 'orange']));
     }
 
-    public function testYellowVioletAndYellow(): void
+    /**
+     * uuid f5d37ef9-1919-4719-a90d-a33c5a6934c9
+     */
+    #[TestDox('Yellow and violet and yellow')]
+    public function testYellowAndVioletAndYellow(): void
     {
         $this->assertEquals('470 kiloohms', $this->resistor->label(['yellow', 'violet', 'yellow']));
     }
 
-    public function testBlueVioletAndBlue(): void
+    /**
+     * uuid 5f6404a7-5bb3-4283-877d-3d39bcc33854
+     */
+    #[TestDox('Blue and violet and blue')]
+    public function testBlueAndVioletAndBlue(): void
     {
         $this->assertEquals('67 megaohms', $this->resistor->label(['blue', 'violet', 'blue']));
     }
 
+    /**
+     * uuid 7d3a6ab8-e40e-46c3-98b1-91639fff2344
+     */
+    #[TestDox('Minimum possible value')]
     public function testMinimumPossibleValue(): void
     {
         $this->assertEquals('0 ohms', $this->resistor->label(['black', 'black', 'black']));
     }
 
+    /**
+     * uuid ca0aa0ac-3825-42de-9f07-dac68cc580fd
+     */
+    #[TestDox('Maximum possible value')]
     public function testMaximumPossibleValue(): void
     {
         $this->assertEquals('99 gigaohms', $this->resistor->label(['white', 'white', 'white']));
     }
 
-    public function testFirstTwoNumbersAreInvalidOctal(): void
+    /**
+     * uuid 0061a76c-903a-4714-8ce2-f26ce23b0e09
+     */
+    #[TestDox('First two colors make an invalid octal number')]
+    public function testFirstTwoColorsMakeAnInvalidOctalNumber(): void
     {
         $this->assertEquals('8 ohms', $this->resistor->label(['black', 'grey', 'black']));
     }
 
+    /**
+     * uuid 30872c92-f567-4b69-a105-8455611c10c4
+     */
+    #[TestDox('Ignore extra colors')]
     public function testIgnoreExtraColors(): void
     {
         $this->assertEquals('650 kiloohms', $this->resistor->label(['blue', 'green', 'yellow', 'orange']));


### PR DESCRIPTION
- [x] Synced `Resistor color trio` metadata and docs
- [x] Removed strict types comments from `example.php` and `ResistorColorTrioTest.php`
- [x] Added UUID and TestDox to tests
- [x] Added `resistor-color-trio` to `auto-sync.txt`
- [x] Added GitHub handle to `config.json`

[no important files changed]

Ref: https://github.com/exercism/php/issues/993

Closes #993